### PR TITLE
fix gallery problem

### DIFF
--- a/app/components/gallery_component.rb
+++ b/app/components/gallery_component.rb
@@ -9,7 +9,7 @@ class GalleryComponent < ViewComponent::Base
   delegate :count, to: :photos_structs
 
   def self.from_attachments(attachments, **kwargs)
-    new(attachments.map { PHOTO_STRUCT.new(_1.url, _1.variant(:medium).url) }, **kwargs)
+    new(attachments.map { PHOTO_STRUCT.new(_1, _1.variant(:medium)) }, **kwargs)
   end
 
   def self.from_urls(original_urls, **kwargs)


### PR DESCRIPTION
cf https://sentry.incubateur.net/organizations/betagouv/issues/4728/

you cannot call .url when it's not been processed yet. you have to call image_tag with the attachment itself so that it delays the actual processing of the variant