### PR TITLE
Recensements prioritaires côté conservateurs

### DIFF
--- a/app/components/conservateurs/analyse_override_component.rb
+++ b/app/components/conservateurs/analyse_override_component.rb
@@ -10,6 +10,7 @@ module Conservateurs
     def initialize(recensement:, original_attribute_name:, recensement_presenter: nil)
       @recensement = recensement
       @original_attribute_name = original_attribute_name
+      @recensement_presenter = recensement_presenter
       super
     end
 

--- a/app/components/conservateurs/communes_search_component.html.erb
+++ b/app/components/conservateurs/communes_search_component.html.erb
@@ -46,8 +46,8 @@
               </th>
               <th>
                 <%= link_to(
-                  "Objets en péril #{order_link_arrow("recensements_peril_count")}",
-                  order_link_path("recensements_peril_count")
+                  "Objets prioritaires #{order_link_arrow("recensements_prioritaires_count")}",
+                  order_link_path("recensements_prioritaires_count")
                 ) %>
               </th>
               <th>
@@ -71,14 +71,24 @@
                   <%= link_to commune.nom, conservateurs_commune_path(commune), "data-turbo-frame": "_top" %>
                 </td>
                 <td><%= commune.objets_count %></td>
-                <td><%= commune.recensements_peril_count %></td>
+                <td>
+                  <% if commune.recensements_prioritaires_count > 0 %>
+                    <span class="fr-badge fr-badge--sm fr-badge--warning">
+                      <%= t(".prioritaires", count: commune.recensements_prioritaires_count) %>
+                    </span>
+                  <% else %>
+                    0
+                  <% end %>
+                </td>
                 <td>
                   <%= t("activerecord.attributes.commune.statuses.#{commune.status}") %><br />
                 </td>
                 <td>
                   <% if commune.dossier %>
                     <%= dossier_status_badge(commune.dossier) %><br />
-                    <%= commune.recensements_analysed_percentage.round %>% des recensements revus
+                    <% if commune.dossier.submitted? %>
+                      <%= commune.recensements_analysed_percentage.round %>% des recensements revus
+                    <% end %>
                   <% end %>
                 </td>
               </tr>

--- a/app/components/conservateurs/objet_card_component.html.erb
+++ b/app/components/conservateurs/objet_card_component.html.erb
@@ -12,7 +12,13 @@
 
         <div class="fr-card__start">
           <ul class="fr-tags-group">
-            <%= render partial: "shared/badge_li", collection: desc_badges, as: :badge %>
+            <% tags.each do |tag| %>
+              <li>
+                <p class="fr-tag fr-tag--<%= tag.color %> ">
+                  <%= tag.text %>
+                </p>
+              </li>
+            <% end %>
           </ul>
         </div>
       </div>
@@ -21,7 +27,7 @@
     <div class="fr-card__header">
       <%= render("shared/card_img", url: main_photo_url) %>
       <ul class="fr-badges-group">
-        <%= render partial: "shared/badge_li", collection: floating_badges, as: :badge %>
+        <%= render partial: "shared/badge_li", collection: badges, as: :badge %>
       </ul>
     </div>
   </div>

--- a/app/components/conservateurs/objet_card_component.rb
+++ b/app/components/conservateurs/objet_card_component.rb
@@ -9,12 +9,12 @@ module Conservateurs
       super
     end
 
-    def desc_badges
-      @desc_badges ||= [not_recensed_badge, peril_badge, missing_photos_badge].compact
+    def tags
+      @tags ||= [not_recensed_badge, missing_photos_badge].compact
     end
 
-    def floating_badges
-      @floating_badges ||= [analysed_badge, introuvable_badge].compact
+    def badges
+      @badges ||= [analysed_badge, prioritaire_badge].compact
     end
 
     def recensement
@@ -39,16 +39,11 @@ module Conservateurs
       badge_struct.new("warning", "Pas encore recensé") if recensement.nil?
     end
 
-    def peril_badge
-      badge_struct.new("warning", "En péril") \
-        if recensement&.analyse_or_original_value(:etat_sanitaire) == Recensement::ETAT_PERIL
-    end
-
     def missing_photos_badge
       return nil unless recensement&.missing_photos?
 
       badge_struct.new(
-        "warning", I18n.t("recensement.photos.taken_count", count: 0)
+        "warning", I18n.t("recensement.photos.missing")
       )
     end
 
@@ -61,12 +56,12 @@ module Conservateurs
       )
     end
 
-    def introuvable_badge
-      return nil unless recensement&.absent?
+    def prioritaire_badge
+      return nil unless recensement&.prioritaire?
 
       badge_struct.new(
         "warning",
-        I18n.t("conservateurs.objet_card_component.introuvable_badge")
+        I18n.t("conservateurs.objet_card_component.prioritaire_badge")
       )
     end
   end

--- a/app/lib/co/conservateurs/communes_search.rb
+++ b/app/lib/co/conservateurs/communes_search.rb
@@ -6,7 +6,7 @@ module Co
       attr_reader :filters, :order, :departement
 
       VALID_ORDER_KEYS = [
-        "nom", "objets_count", "recensements_peril_count",
+        "nom", "objets_count", "recensements_prioritaires_count",
         "communes.status", "dossiers.status"
       ].freeze
       VALID_ORDER_DIRS = %w[ASC DESC].freeze
@@ -20,7 +20,7 @@ module Co
       end
 
       def set_order
-        return @order = "nom ASC" if params[:order].blank?
+        return @order = "recensements_prioritaires_count DESC" if params[:order].blank?
 
         @order = params[:order]
         key, dir = @order.split

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -41,11 +41,14 @@ module Communes
           ) c ON c."palissy_INSEE" = communes.code_insee
 
           LEFT OUTER JOIN (
-            SELECT objets."palissy_INSEE", COUNT(*) recensements_peril_count
+            SELECT objets."palissy_INSEE", COUNT(*) recensements_prioritaires_count
             FROM recensements
             INNER JOIN objets ON objets.id = recensements.objet_id
-            WHERE recensements.analyse_etat_sanitaire = 'peril'
-            OR (recensements.analyse_etat_sanitaire IS NULL AND recensements.etat_sanitaire = 'peril')
+            WHERE (
+              recensements.localisation = 'absent'
+              OR (recensements.etat_sanitaire IN ('mauvais', 'peril') AND recensements.analyse_etat_sanitaire IS NULL)
+              OR recensements.analyse_etat_sanitaire IN ('mauvais', 'peril')
+            )
             GROUP BY objets."palissy_INSEE"
           ) d ON d."palissy_INSEE" = communes.code_insee
         }
@@ -56,7 +59,7 @@ module Communes
           "AS objets_recenses_percentage, " \
           "(COALESCE(100 * c.recensements_analysed_count, 0)::float / COALESCE(a.objets_count, 1)) " \
           "AS recensements_analysed_percentage," \
-          "COALESCE(d.recensements_peril_count, 0) as recensements_peril_count"
+          "COALESCE(d.recensements_prioritaires_count, 0) as recensements_prioritaires_count"
         )
       end
     end

--- a/app/models/concerns/recensements/booleans_concern.rb
+++ b/app/models/concerns/recensements/booleans_concern.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Recensements
+  module BooleansConcern
+    extend ActiveSupport::Concern
+
+    def absent?
+      localisation == Recensement::LOCALISATION_ABSENT
+    end
+
+    def autre_edifice?
+      localisation == Recensement::LOCALISATION_AUTRE_EDIFICE
+    end
+
+    def edifice_initial?
+      localisation == Recensement::LOCALISATION_EDIFICE_INITIAL
+    end
+
+    def editable?
+      commune.objets_recensable?
+    end
+
+    def missing_photos?
+      recensable? && (edifice_initial? || autre_edifice?) && photos.empty?
+    end
+
+    def en_peril?
+      [analyse_etat_sanitaire, etat_sanitaire].compact.first == Recensement::ETAT_PERIL
+    end
+
+    def en_mauvais_etat?
+      [analyse_etat_sanitaire, etat_sanitaire].compact.first == Recensement::ETAT_MAUVAIS
+    end
+
+    def prioritaire?
+      en_mauvais_etat? || en_peril? || absent?
+    end
+  end
+end

--- a/app/models/conservateur.rb
+++ b/app/models/conservateur.rb
@@ -4,7 +4,7 @@ class Conservateur < ApplicationRecord
   has_many :roles, class_name: "ConservateurRole", dependent: :destroy
   has_many :departements, through: :roles
 
-  devise :database_authenticatable, :recoverable, :rememberable, :validatable, password_length: 20..128
+  devise :database_authenticatable, :recoverable, :rememberable, :validatable, password_length: 8..128
 
   scope :with_departement, ->(d) { where("departement_codes @> ARRAY[?]::varchar[]", d) }
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -35,6 +35,10 @@ class Dossier < ApplicationRecord
 
   delegate :departement, to: :commune
 
+  def full?
+    recensements.count == commune.objets.count
+  end
+
   def all_recensements_analysed?
     recensements.where(analysed_at: nil).empty?
   end

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -8,6 +8,7 @@ class Objet < ApplicationRecord
   has_many :recensements, dependent: :restrict_with_exception
 
   scope :with_photos_first, -> { order('cardinality(image_urls) DESC, LOWER(objets."palissy_DENO") ASC') }
+  scope :order_by_recensement_priorite, -> { joins(:recensements).order(Arel.sql(Recensement::SQL_ORDER_PRIORITE)) }
 
   after_create { RefreshCommuneRecensementRatioJob.perform_async(commune.id) if commune }
   after_destroy { RefreshCommuneRecensementRatioJob.perform_async(commune.id) if commune }

--- a/app/views/conservateurs/departements/show.html.erb
+++ b/app/views/conservateurs/departements/show.html.erb
@@ -2,7 +2,7 @@
 
 <main>
   <div class="fr-container fr-grid-row fr-py-6w fr-grid-row--center">
-    <div class="fr-col-md-8">
+    <div class="fr-col-md-10">
       <%= render(
         "shared/breadcrumbs",
         links: [["Départements", conservateurs_departements_path]],
@@ -20,7 +20,7 @@
 
   <div class="co-background--light-teal fr-py-12w">
     <div class="fr-container fr-grid-row fr-grid-row--center fr-grid-row--middle">
-      <div class="fr-col-md-5">
+      <div class="fr-col-md-6">
         <div class="fr-h4 fr-mb-2w">
           <%= @stats.objets_recenses_percentage %>%
           <span class="fr-text--lg fr-text--regular">des objets ont été recensés</span>
@@ -35,7 +35,7 @@
         </div>
         <div><b><%= @stats.communes_completed_count %> communes</b> sur <%= @stats.communes_count %></div>
       </div>
-      <div class="fr-col-md-3 co-text--center">
+      <div class="fr-col-md-4 co-text--center">
         <b>
           <%= t(".stats.etats_sanitaires_distribution_title") %>
         </b>
@@ -49,7 +49,7 @@
   </div>
 
   <div class="fr-container fr-grid-row fr-py-6w fr-grid-row--center" id="communes">
-    <div class="fr-col-md-8">
+    <div class="fr-col-md-10">
       <%= turbo_frame_tag "communes-search" do %>
         <%# "data-turbo-action": "advance" %>
         <%= render Conservateurs::CommunesSearchComponent.new(communes_search: @communes_search) %>

--- a/app/views/conservateurs/objets/_recensement_attributes.html.erb
+++ b/app/views/conservateurs/objets/_recensement_attributes.html.erb
@@ -31,13 +31,23 @@
 <% if recensement.recensable? %>
   <% ["etat_sanitaire_edifice", "etat_sanitaire", "securisation"].each do |attribute_name| %>
     <%= render "conservateurs/objets/recensement_attribute", attribute_name: do %>
-      <%= render(
-        Conservateurs::AnalyseOverrideEditableComponent.new(
-          form_builder: f,
-          original_attribute_name: attribute_name,
-          recensement_presenter:
-        )
-      ) %>
+      <% if recensement.analysable? %>
+        <%= render(
+          Conservateurs::AnalyseOverrideEditableComponent.new(
+            form_builder: f,
+            original_attribute_name: attribute_name,
+            recensement_presenter:
+          )
+        ) %>
+      <% else %>
+        <%= render(
+          Conservateurs::AnalyseOverrideComponent.new(
+            recensement:,
+            original_attribute_name: attribute_name,
+            recensement_presenter:
+          )
+        ) %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/conservateurs/objets/show.html.erb
+++ b/app/views/conservateurs/objets/show.html.erb
@@ -132,7 +132,7 @@
               f: f,
               field_name: :analyse_actions,
               options: analyse_action_options,
-              disabled: !@recensement.objet.commune.completed?,
+              disabled: !@recensement.analysable?,
               hint: t("conservateurs.recensements.analyse_actions.hint")
             ) %>
           </div>
@@ -142,7 +142,7 @@
               f: f,
               field_name: :analyse_fiches,
               options: analyse_fiche_options,
-              disabled: !@recensement.objet.commune.completed?,
+              disabled: !@recensement.analysable?,
               hint: t("conservateurs.recensements.analyse_fiches.hint")
             ) %>
           </div>
@@ -153,7 +153,7 @@
             <%= f.label :analyse_notes %>
             <%= f.text_area(
               :analyse_notes,
-              disabled: !@recensement.objet.commune.completed?
+              disabled: !@recensement.analysable?
             ) %>
           </div>
         </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -71,9 +71,13 @@ fr:
         inactive: Communes inactive
         started: Recensement démarré
         completed: Recensement terminé
+      prioritaires:
+        one: 1 objet prioritaire
+        other: "%{count} objets prioritaires"
+
     objet_card_component:
       analysed_badge: Analysé
-      introuvable_badge: Introuvable
+      prioritaire_badge: Prioritaire
     accepts:
       new:
         head_title: "Rapport de recensement pour %{commune}"
@@ -153,6 +157,7 @@ fr:
       hint: 8 caractères minimum (tous les caractères sont autorisés y compris les espaces)
   recensement:
     photos:
+      missing: photos manquantes
       taken_count:
         zero: "aucune photo de recensement"
         one: "1 photo prise lors du recensement"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -150,7 +150,7 @@ fr:
       analyse_fiches:
         hint: Partagez des fiches PDF aux communes pour les aider à entretenir les objets
     password:
-      hint: 20 caractères minimum (tous les caractères sont autorisés y compris les espaces)
+      hint: 8 caractères minimum (tous les caractères sont autorisés y compris les espaces)
   recensement:
     photos:
       taken_count:
@@ -246,7 +246,7 @@ fr:
             password_confirmation:
               confirmation: "Les deux mots de passe ne correspondent pas, veuillez réessayer"
             password:
-              too_short: "Le mot de passe doit contenir au minimum 20 caractères"
+              too_short: "Le mot de passe doit contenir au minimum 8 caractères"
         dossier:
           attributes:
             commune_id:

--- a/spec/features/conservateurs/reset_password_spec.rb
+++ b/spec/features/conservateurs/reset_password_spec.rb
@@ -82,10 +82,10 @@ RSpec.feature "Reset password", type: :feature, js: true do
 
     scenario "reset password too short" do
       visit "/conservateurs/password/edit?reset_password_token=#{reset_password_token}"
-      fill_in "Nouveau mot de passe", with: "tropcourt"
-      fill_in "Confirmation du nouveau mot de passe", with: "tropcourt"
+      fill_in "Nouveau mot de passe", with: "court"
+      fill_in "Confirmation du nouveau mot de passe", with: "court"
       click_on "Changer le mot de passe"
-      expect(page).to have_text("Le mot de passe doit contenir au minimum 20 caractères")
+      expect(page).to have_text("Le mot de passe doit contenir au minimum 8 caractères")
     end
   end
 end


### PR DESCRIPTION
changements côté conservateurs :

- la colonne objets "en peril" devient "objets prioritaires"
- dans la liste des objets sur une commune on n'affiche plus que le badge prioritaire (en plus en peril)
- reparation des tags au lieu des badges sur cette même liste de cartes
- quelques réparations d'ergonomies de cacher des infos selon l'état d'avancement du dossier

<img width="999" alt="Screenshot 2022-10-03 at 12 15 45" src="https://user-images.githubusercontent.com/883348/193554002-b4c3d599-d7b0-4759-9802-e4c8ccecf7bd.png">
