### PR TITLE
Ajout d'une marge sur les message d'alerte

### DIFF
--- a/app/views/shared/_flashes.html.haml
+++ b/app/views/shared/_flashes.html.haml
@@ -1,10 +1,5 @@
-- if notice
+- if notice || alert
   .fr-container.fr-pt-1w{role: "alert"}
-    .fr-alert.fr-alert--info
+    .fr-alert{class: [("fr-alert--info" if notice), ("fr-alert--error" if alert)] }
       .fr-alert__content
-        = notice
-- if alert
-  .fr-container.fr-pt-1w{role: "alert"}
-    .fr-alert.fr-alert--error
-      .fr-alert__content
-        = alert
+        = notice ? notice : alert

--- a/app/views/shared/_flashes.html.haml
+++ b/app/views/shared/_flashes.html.haml
@@ -1,5 +1,5 @@
 - if notice || alert
-  .fr-container.fr-pt-1w{role: "alert"}
+  .fr-container.fr-mt-1w{role: "alert"}
     .fr-alert{class: [("fr-alert--info" if notice), ("fr-alert--error" if alert)] }
       .fr-alert__content
         = notice ? notice : alert

--- a/app/views/shared/_flashes.html.haml
+++ b/app/views/shared/_flashes.html.haml
@@ -1,10 +1,10 @@
 - if notice
-  .fr-container{role: "alert"}
+  .fr-container.fr-pt-1w{role: "alert"}
     .fr-alert.fr-alert--info
       .fr-alert__content
         = notice
 - if alert
-  .fr-container{role: "alert"}
+  .fr-container.fr-pt-1w{role: "alert"}
     .fr-alert.fr-alert--error
       .fr-alert__content
         = alert


### PR DESCRIPTION
En me baladant sur les différents parcours utilisateur, j'ai remarqué que les messages d'alerte étaient collés au header, comme on peut le voir sur cette capture d'écran :
![message alerte collé - Collectif Objets](https://user-images.githubusercontent.com/1522772/230373194-1b3765be-b43e-4fba-9165-af563af4437d.png)

Voilà ce que ça donne avec une marge en plus : 
![message alerte avec marge - Collectif Objets](https://user-images.githubusercontent.com/1522772/230373554-81045062-2e71-42fe-ba87-bbffdc0fb511.png)


J'en ai profité pour faire un léger refactoring de flashes.html
