### PR TITLE
corrections CSS print pour le rapport - bug tabs

### DIFF
--- a/app/frontend/stylesheets/print.css
+++ b/app/frontend/stylesheets/print.css
@@ -7,9 +7,12 @@
   .co-print-invisible { visibility: hidden; }
   .fr-grid-row .fr-card { height: 300px; }
   .hide.co-print-display { display: block !important; }
-  .fr-p-4w.co-print-no-padding { padding: 0 !important; }
+  .co-print-no-padding { padding: 0 !important; }
   .co-print-no-border { border: none; }
-  .fr-tabs { display: block; }
+  .fr-tabs {
+    display: block;
+    height: auto;
+  }
   .fr-tabs__panel {
     padding: 0;
     margin: 0;
@@ -19,4 +22,6 @@
 
 .co-break-after-page { break-after: page; }
 .co-break-after-avoid { break-after: avoid; }
+.co-break-after-auto--last-child:last-child { break-after: auto; }
+
 .co-break-inside-avoid { break-inside: avoid; }

--- a/app/presenters/rapport_presenter.rb
+++ b/app/presenters/rapport_presenter.rb
@@ -18,14 +18,18 @@ class RapportPresenter
   end
 
   def each_fiche_item
-    ordered_recensements.map(&:analyse_fiches).flatten.uniq.sort.each_with_index do |fiche_id, index|
-      yield fiche: Fiche.load_from_id(fiche_id),
-            recensements: ordered_recensements.select { _1.analyse_fiches.include?(fiche_id) },
+    fiches.each_with_index do |fiche, index|
+      yield fiche:,
+            recensements: ordered_recensements.select { _1.analyse_fiches.include?(fiche.id) },
             index: index + 1
     end
   end
 
   attr_reader :dossier
+
+  def fiches
+    @fiches ||= fiche_ids.map { Fiche.load_from_id(_1) }
+  end
 
   private
 
@@ -34,5 +38,9 @@ class RapportPresenter
       .recensements
       .includes(:objet)
       .order('objets."palissy_EDIF" ASC, objets."palissy_REF"')
+  end
+
+  def fiche_ids
+    @fiche_ids ||= ordered_recensements.map(&:analyse_fiches).flatten.uniq.sort
   end
 end

--- a/app/views/shared/_dossier_rapport.html.haml
+++ b/app/views/shared/_dossier_rapport.html.haml
@@ -51,45 +51,46 @@
       %h3.fr-text--md.fr-mb-0 Commentaires du conservateur
       = rapport.notes_conservateur.presence || "Aucun commentaire"
 
-  %h4.fr-mt-4w#fiches Vue des objets regroupés par fiche conseil
-  .co-break-after-page
-    - rapport.each_fiche_item do |fiche:, recensements:, index:|
-      %div.co-break-inside-avoid{id: "fiche-#{fiche.id}"}
-        %h5 Fiche #{index} · #{fiche.title}
-        .fr-mb-2w
-          Le conservateur vous a recommandé la lecture de la fiche conseil suivante pour
-          - if recensements.count == 1
-            cet objet
-          - else
-            ces #{recensements.count} objets
-        .co-print-hide.fr-mb-2w
-          = link_to "Voir la fiche conseil \"#{fiche.title}\"",
-            fiche_path(fiche.id),
-            data: { turbo_frame: "_top" },
-            class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line"
+  - if rapport.fiches.any?
+    %h4.fr-mt-4w#fiches Vue des objets regroupés par fiche conseil
+    .co-break-after-page.co-break-after-auto--last-child
+      - rapport.each_fiche_item do |fiche:, recensements:, index:|
+        %div.co-break-inside-avoid{id: "fiche-#{fiche.id}"}
+          %h5 Fiche #{index} · #{fiche.title}
+          .fr-mb-2w
+            Le conservateur vous a recommandé la lecture de la fiche conseil suivante pour
+            - if recensements.count == 1
+              cet objet
+            - else
+              ces #{recensements.count} objets
+          .co-print-hide.fr-mb-2w
+            = link_to "Voir la fiche conseil \"#{fiche.title}\"",
+              fiche_path(fiche.id),
+              data: { turbo_frame: "_top" },
+              class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-arrow-right-line"
 
-        .co-print-hide
-          .fr-mb-4w.fr-grid-row.fr-grid-row--gutters
-            - recensements.each do |recensement|
-              - { objet: recensement.objet, commune: recensement.commune } => { objet:, commune: }
-              .fr-col-md-3
-                = render ::ObjetCardComponent.new objet,
-                  commune: commune,
-                  path: current_user ? commune_objet_path(commune, objet) : objet_path(objet),
-                  main_photo_origin: :recensement,
-                  link_html_attributes: { data: { turbo_frame: "_top" } }
-
-        .hide.co-print-display.fr-mb-4w
-          - recensements.each_slice(4) do |recensements|
-            .fr-grid-row.fr-grid-row--gutters.co-flex--align-items-center
+          .co-print-hide
+            .fr-mb-4w.fr-grid-row.fr-grid-row--gutters
               - recensements.each do |recensement|
                 - { objet: recensement.objet, commune: recensement.commune } => { objet:, commune: }
-                .fr-col-sm-4
-                  .co-rapport-photo
-                    - if recensement.photos.any?
-                      = vite_or_raw_image_tag recensement.photos.first.variant(:medium), alt: "© Licence ouverte"
-                  #{objet.nom} (#{objet.palissy_EDIF}) ·
-                  %span.fr-text--sm #{objet.palissy_REF}
+                .fr-col-md-3
+                  = render ::ObjetCardComponent.new objet,
+                    commune: commune,
+                    path: current_user ? commune_objet_path(commune, objet) : objet_path(objet),
+                    main_photo_origin: :recensement,
+                    link_html_attributes: { data: { turbo_frame: "_top" } }
+
+          .hide.co-print-display.fr-mb-4w
+            - recensements.each_slice(4) do |recensements|
+              .fr-grid-row.fr-grid-row--gutters.co-flex--align-items-center
+                - recensements.each do |recensement|
+                  - { objet: recensement.objet, commune: recensement.commune } => { objet:, commune: }
+                  .fr-col-sm-4
+                    .co-rapport-photo
+                      - if recensement.photos.any?
+                        = vite_or_raw_image_tag recensement.photos.first.variant(:medium), alt: "© Licence ouverte"
+                    #{objet.nom} (#{objet.palissy_EDIF}) ·
+                    %span.fr-text--sm #{objet.palissy_REF}
 
   %h4.fr-mt-8w#objets.co-break-after-avoid Vue détaillée objet par objet
   - rapport.each_recensement_item do |**recensement_item|

--- a/app/views/shared/rapport/_recensement.html.haml
+++ b/app/views/shared/rapport/_recensement.html.haml
@@ -1,11 +1,11 @@
 -# local_assigns: (:objet, :recensement, :presenter, :commune, :index)
 
-.fr-pb-6w.co-border--bottom.co-border--none-for-last.co-print-no-border.co-break-after-page{id: "#{objet.palissy_REF}", class: ("fr-mt-6w" if index > 1)}
+.fr-pb-6w.co-border--bottom.co-border--none-for-last.co-print-no-border.co-break-after-page.co-break-after-auto--last-child{id: "#{objet.palissy_REF}", class: ("fr-mt-6w" if index > 1)}
   %h5.fr-mt-0.fr-mb-1w Objet #{index} · #{objet.nom}
 
   .fr-mb-2w
     - path = current_user ? commune_objet_path(commune, objet) : objet_path(objet)
-    = link_to "voir lʼobjet", path , data: { turbo_frame: "_top" }
+    .co-print-hide= link_to "voir lʼobjet", path , data: { turbo_frame: "_top" }
     %span.fr-text--sm · Référence POP Palissy : #{objet.palissy_REF}
 
   .fr-mb-1w.co-break-inside-avoid
@@ -23,7 +23,7 @@
             class: "co-cursor--zoom-in" do
             = vite_or_raw_image_tag photo.variant(:medium), alt: "© Licence ouverte"
 
-  .fr-grid-row
+  .fr-grid-row.fr-grid-row--gutters.fr-mt-1w
     .fr-col-md-6
       .co-break-inside-avoid
         .co-text--bold.fr-mt-2w Où se trouve l’objet ?
@@ -44,11 +44,11 @@
           = render Conservateurs::AnalyseOverrideComponent.new recensement:, recensement_presenter: presenter, original_attribute_name: :securisation
 
     .fr-col-md-6
-      .co-background--light-teal.fr-p-4w.fr-mb-4w.co-print-no-padding
-        .co-break-inside-avoid
+      .co-background--light-teal.fr-px-4w.fr-pb-4w.fr-pt-2w.fr-mb-4w.co-print-no-padding
+        .fr-mt-2w.co-break-inside-avoid
           .co-text--bold Commentaires de la commune
           = recensement.notes.presence || "Aucun commentaire"
-        .fr-mt-4w.co-break-inside-avoid
+        .fr-mt-2w.co-break-inside-avoid
           .co-text--bold Commentaires du conservateur
           = recensement.analyse_notes.presence || "Aucun commentaire"
 


### PR DESCRIPTION
le bug principal de pages tronquées provenait de la `height` settée en JS par le DSFR sur les tabs. je l’ai corrigée en forçant `height: auto` en version print.

Le reste des changements sont des petites améliorations du layout : 

- ne pas afficher "Vue groupée par fiches quand il n’y a aucune fiche"
- corrections de marges en vue print
- pas de retour a la page apres le dernier objet pour eviter une page blanche