### PR TITLE
erreur 404 pour les urls d’articles de presse inexistants

### DIFF
--- a/app/controllers/presse_controller.rb
+++ b/app/controllers/presse_controller.rb
@@ -6,7 +6,7 @@ class PresseController < ApplicationController
   end
 
   def show
-    raise ArgumentError if ArticlePresse.all_ids.exclude? params[:id]
+    raise ActionController::RoutingError, "Article inexistant" if ArticlePresse.all_ids.exclude? params[:id]
 
     @article = ArticlePresse.load_from_id(params[:id])
   end


### PR DESCRIPTION
devrait corriger https://sentry.incubateur.net/organizations/betagouv/issues/31294 des attaqueurs essaient de XSS a partir de cette URL