### PR TITLE
corrections mineures d’affichage des dossiers en fonction des états

### DIFF
--- a/app/components/communes/objet_card_component.rb
+++ b/app/components/communes/objet_card_component.rb
@@ -36,6 +36,8 @@ module Communes
 
     def recensement_badge
       color, text = objet_recensement_badge_color_and_text(objet)
+      return nil unless color && text
+
       badge_struct.new(color, text)
     end
 

--- a/app/controllers/admin/dossiers_controller.rb
+++ b/app/controllers/admin/dossiers_controller.rb
@@ -7,7 +7,8 @@ module Admin
       raise if params[:status] != "construction"
 
       @dossier.return_to_construction!
-      redirect_to admin_commune_path(@dossier.commune), notice: "Dossier repassé en construction"
+      redirect_to admin_commune_path(@dossier.commune),
+                  notice: "Commune repassée en recensement & dossier repassé en construction"
     end
 
     private

--- a/app/helpers/objet_helper.rb
+++ b/app/helpers/objet_helper.rb
@@ -39,6 +39,8 @@ module ObjetHelper
 
   def objet_recensement_badge(objet)
     color, text = objet_recensement_badge_color_and_text(objet)
+    return nil unless color && text
+
     content_tag(:span, class: "fr-badge fr-badge--md fr-badge--#{color}") { text }
   end
 

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -11,9 +11,11 @@
 
   .fr-grid-row
     .fr-col-md-8
-      %p= commune_status_badge(@commune)
+      %p
+        = commune_status_badge(@commune)
+        = dossier_status_badge(@commune.dossier, small: true)
 
-      - if @commune.recensement_ratio.present?
+      - if @commune.started? && @commune.recensement_ratio.present?
         %p
           Objets recensés à #{@commune.recensement_ratio}%
           - if @commune.recensements.any? && @commune.recensements.missing_photos.any?
@@ -25,7 +27,8 @@
           - if @commune.completed_at.present?
             %br
             et terminé le #{l(@commune.completed_at, format: :long_with_weekday)}
-      %div.co-flex
+
+      %div.co-flex.fr-mt-8w
         %h4
           = icon_span("account-circle")
           #{@commune.users.count} Usager(s)
@@ -125,8 +128,8 @@
     %p #{dossier.recensements.count} recensements
 
     - if dossier.can_return_to_construction?
-      %a.fr-btn.fr-btn--secondary{href: admin_dossier_path(dossier, status: "construction"), "data-turbo-method": "PUT"}
-        Repasser en recensement démarré
+      = link_to admin_dossier_path(dossier, status: "construction"), class: "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-go-back-line", data: {"turbo-method": "PUT"} do
+        Repasser la commune en recensement et le dossier en construction
   = render UnfoldComponent.new(max_height_px: 800, button_text: "Voir tous les recensements") do
     .fr-table
       %table
@@ -154,7 +157,6 @@
                 %td
                   = render Conservateurs::AnalyseOverrideComponent.new(original_attribute_name: :securisation, recensement:, recensement_presenter:)
               - else
-                %td
                 %td
                 %td
               %td

--- a/app/views/communes/objets/show.html.haml
+++ b/app/views/communes/objets/show.html.haml
@@ -7,6 +7,11 @@
     %h1.fr-mb-0= @objet.nom
     = objet_recensement_badge(@objet)
 
+  - if @commune.dossier.accepted? && @objet.current_recensement.analyse_notes.present?
+    .fr-mb-8w.co-break-inside-avoid
+      .co-text--bold Commentaires du conservateur
+      .co-blockquote= @objet.current_recensement.analyse_notes
+
   = render ObjetPageComponent.new(objet: @objet) do |c|
     - if @objet.current_recensement&.draft?
       - c.with_cta do

--- a/app/views/communes/objets/show.html.haml
+++ b/app/views/communes/objets/show.html.haml
@@ -7,7 +7,7 @@
     %h1.fr-mb-0= @objet.nom
     = objet_recensement_badge(@objet)
 
-  - if @commune.dossier.accepted? && @objet.current_recensement.analyse_notes.present?
+  - if @commune.dossier&.accepted? && @objet.current_recensement.analyse_notes.present?
     .fr-mb-8w.co-break-inside-avoid
       .co-text--bold Commentaires du conservateur
       .co-blockquote= @objet.current_recensement.analyse_notes


### PR DESCRIPTION
admin
- affichage de l’état du dossier pour les communes ayant recensé tout en haut de la page `admin/communes#show`
- suppression d’une colonne en trop dans le tableau de recensements
- amélioration des wordings de "retour en construction"


interface communes
- apres analyse, un badge vide s’affichait dans la liste des objets et en haut de la page objet
- apres analyse, il peut y avoir un badge "commentaires" si le conservateur a laissé un commentaire, mais ce commentaire n’apparaissait pas sur la page objet, ce qui était perturbant. je l’affiche maitnenant un peu n’importe comment mais au moins c’est plus cohérent