### PR TITLE
Évolution de la vue d'un département côté conservateur

### DIFF
--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -19,7 +19,7 @@ module Conservateurs
           .where(departement: @departement)
           .includes(:dossier)
           .include_objets_count
-          .include_objets_recenses_count
+          .include_recensements_prioritaires_count
           .ransack(params[:q])
         @pagy, @communes = pagy @ransack.result, items: 20
         @query_present = params[:q].present?

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -22,7 +22,7 @@ module Conservateurs
           .include_recensements_prioritaires_count
           .include_statut_global
           .ransack(params[:q])
-        @pagy, @communes = pagy @ransack.result.includes(:dossier), items: 20
+        @pagy, @communes = pagy @ransack.result, items: 20
         @query_present = params[:q].present?
       end
     end

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -17,11 +17,10 @@ module Conservateurs
       else
         @ransack = policy_scope(Commune)
           .where(departement: @departement)
-          .includes(:dossier)
           .include_objets_count
           .include_recensements_prioritaires_count
           .ransack(params[:q])
-        @pagy, @communes = pagy @ransack.result, items: 20
+        @pagy, @communes = pagy @ransack.result.includes(:dossier), items: 20
         @query_present = params[:q].present?
       end
     end

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -21,6 +21,7 @@ module Conservateurs
           .include_objets_count
           .include_recensements_prioritaires_count
           .include_statut_global
+          .includes(:dossier)
           .ransack(params[:q])
         @pagy, @communes = pagy @ransack.result, items: 20
         @query_present = params[:q].present?

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -16,6 +16,7 @@ module Conservateurs
         render "show_map"
       else
         @ransack = policy_scope(Commune)
+          .select("nom, code_insee")
           .where(departement: @departement)
           .include_objets_count
           .include_recensements_prioritaires_count

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -16,7 +16,7 @@ module Conservateurs
         render "show_map"
       else
         @ransack = policy_scope(Commune)
-          .where(departement_code: @departement.code)
+          .where(departement: @departement)
           .includes(:dossier)
           .include_objets_count
           .include_objets_recenses_count

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -42,7 +42,7 @@ module Conservateurs
     end
 
     def set_communes
-      fields = %w[code_insee nom status objets_count recensements_prioritaires_count latitude longitude]
+      fields = %w[code_insee nom status objets_count en_peril_count latitude longitude]
       @communes = policy_scope(Commune)
         .where(departement_code: @departement.code)
         .includes(:dossier)

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -16,10 +16,11 @@ module Conservateurs
         render "show_map"
       else
         @ransack = policy_scope(Commune)
-          .select("nom, code_insee")
+          .select("nom")
           .where(departement: @departement)
           .include_objets_count
           .include_recensements_prioritaires_count
+          .include_statut_global
           .ransack(params[:q])
         @pagy, @communes = pagy @ransack.result.includes(:dossier), items: 20
         @query_present = params[:q].present?

--- a/app/frontend/stimulus_controllers_standalone/conservateur_map_controller.js
+++ b/app/frontend/stimulus_controllers_standalone/conservateur_map_controller.js
@@ -112,8 +112,8 @@ export default class extends Controller {
   hydrateStatuses() {
     const communes = JSON.parse(this.wrapperTarget.dataset.communesJson)
     communes.filter(c => c.status == "completed").forEach(commune => {
-      const isPrioritaire = (commune.recensements_prioritaires_count || 0) > 0
-      const status = isPrioritaire ? "prioritaire" : "completed"
+      const prioritaire = (commune.en_peril_count || 0) > 0
+      const status = prioritaire ? "prioritaire" : "completed"
       this.setCommuneState(commune.code_insee, { selectable: true, status })
     })
   }

--- a/app/helpers/commune_helper.rb
+++ b/app/helpers/commune_helper.rb
@@ -30,5 +30,14 @@ module CommuneHelper
      [Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE, Commune::ORDRE_EN_COURS_D_ANALYSE],
      [Commune::STATUT_GLOBAL_ANALYSÉ, Commune::ORDRE_ANALYSÉ]]
   end
+
+  def commune_statut_global_badge(commune, small: false)
+    colors = ["", "", "blue-ecume", "blue-ecume", "success"]
+    content_tag(
+      "p",
+      commune.statut_global_texte,
+      class: "fr-badge fr-badge--#{colors[commune.statut_global]} #{small ? 'fr-badge--sm' : ''}"
+    )
+  end
 end
 # rubocop:enable Rails/OutputSafety

--- a/app/helpers/commune_helper.rb
+++ b/app/helpers/commune_helper.rb
@@ -22,14 +22,13 @@ module CommuneHelper
     text + " de #{commune.nom}"
   end
 
-  def communes_statuses_options_for_select(departement:)
-    counts = Commune.where(departement:).status_value_counts.merge("" => Commune.where(departement:).count)
-    [
-      ["Toutes les communes", ""],
-      ["Communes inactives", "inactive"],
-      ["Recensement démarré", "started"],
-      ["Recensement terminé", "completed"]
-    ].map { |label, key| ["#{label} (#{counts[key]})", key] }
+  def communes_statuses_options_for_select
+    [["Veuillez sélectionner une option", ""],
+     ["Non recensé", "inactive"],
+     ["En cours de recensement", "started"],
+     ["Non analysé", "submitted"],
+     ["En cours d'analyse", "analyse_started"],
+     ["Analysé", "accepted"]]
   end
 end
 # rubocop:enable Rails/OutputSafety

--- a/app/helpers/commune_helper.rb
+++ b/app/helpers/commune_helper.rb
@@ -24,11 +24,11 @@ module CommuneHelper
 
   def communes_statuses_options_for_select
     [["Veuillez sélectionner une option", ""],
-     ["Non recensé", Commune::STATUT_GLOBAL_NON_RECENSÉ],
-     ["En cours de recensement", Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT],
-     ["Non analysé", Commune::STATUT_GLOBAL_NON_ANALYSÉ],
-     ["En cours d'analyse", Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE],
-     ["Analysé", Commune::STATUT_GLOBAL_ANALYSÉ]]
+     [Commune::STATUT_GLOBAL_NON_RECENSÉ, Commune::ORDRE_NON_RECENSÉ],
+     [Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT, Commune::ORDRE_EN_COURS_DE_RECENSEMENT],
+     [Commune::STATUT_GLOBAL_NON_ANALYSÉ, Commune::ORDRE_NON_ANALYSÉ],
+     [Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE, Commune::ORDRE_EN_COURS_D_ANALYSE],
+     [Commune::STATUT_GLOBAL_ANALYSÉ, Commune::ORDRE_ANALYSÉ]]
   end
 end
 # rubocop:enable Rails/OutputSafety

--- a/app/helpers/commune_helper.rb
+++ b/app/helpers/commune_helper.rb
@@ -24,11 +24,11 @@ module CommuneHelper
 
   def communes_statuses_options_for_select
     [["Veuillez sélectionner une option", ""],
-     ["Non recensé", "inactive"],
-     ["En cours de recensement", "started"],
-     ["Non analysé", "submitted"],
-     ["En cours d'analyse", "analyse_started"],
-     ["Analysé", "accepted"]]
+     ["Non recensé", Commune::STATUT_GLOBAL_NON_RECENSÉ],
+     ["En cours de recensement", Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT],
+     ["Non analysé", Commune::STATUT_GLOBAL_NON_ANALYSÉ],
+     ["En cours d'analyse", Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE],
+     ["Analysé", Commune::STATUT_GLOBAL_ANALYSÉ]]
   end
 end
 # rubocop:enable Rails/OutputSafety

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -2,18 +2,19 @@
 
 module DossierHelper
   def dossier_status_badge(dossier, small: false)
-    color = ""
-    if dossier.nil?
-      libellé = "Non recensé"
-    else
-      libellé = t("dossier.status_badge.#{dossier.status}")
-      if dossier.accepted?
-        color = "success"
-      elsif dossier.submitted?
-        color = "blue-ecume"
-      end
-    end
-    content_tag("p", libellé, class: "fr-badge #{small ? 'fr-badge--sm' : ''} fr-badge--#{color}")
+    status = dossier&.status || "none"
+
+    color = {
+      construction: "",
+      submitted: "blue-ecume",
+      accepted: "success",
+      none: ""
+    }[status.to_sym]
+    content_tag(
+      "p",
+      t("dossier.status_badge.#{status}"),
+      class: "fr-badge fr-badge--#{color} #{small ? 'fr-badge--sm' : ''}"
+    )
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -2,16 +2,18 @@
 
 module DossierHelper
   def dossier_status_badge(dossier, small: false)
-    color = {
-      construction: "new",
-      submitted: "info",
-      accepted: "success"
-    }[dossier.status.to_sym]
-    content_tag(
-      "p",
-      t("dossier.status_badge.#{dossier.status}"),
-      class: "fr-badge fr-badge--#{color} #{small ? 'fr-badge--sm' : ''}"
-    )
+    color = ""
+    if dossier.nil?
+      libellé = "Non recensé"
+    else
+      libellé = t("dossier.status_badge.#{dossier.status}")
+      if dossier.accepted?
+        color = "success"
+      elsif dossier.submitted?
+        color = "blue-ecume"
+      end
+    end
+    content_tag("p", libellé, class: "fr-badge #{small ? 'fr-badge--sm' : ''} fr-badge--#{color}")
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -31,4 +31,8 @@ module DossierHelper
     titre = "Déplacement #{dossier.visit == 'prioritaire' ? 'prioritaire' : 'souhaitable'}"
     dsfr_tag(title: titre)
   end
+
+  def dossier_states
+    Dossier.aasm.states_for_select.prepend(["Sélectionnez une option", ""])
+  end
 end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -60,19 +60,11 @@ class Commune < ApplicationRecord
 
   accepts_nested_attributes_for :dossier, :users
 
-  STATUT_GLOBAL_NON_RECENSÉ = 0
-  STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = 1
-  STATUT_GLOBAL_NON_ANALYSÉ = 2
-  STATUT_GLOBAL_EN_COURS_D_ANALYSE = 3
-  STATUT_GLOBAL_ANALYSÉ = 4
-
-  STATUT_GLOBAL_SQL = %(CASE
-    WHEN communes.status = 'inactive' THEN #{STATUT_GLOBAL_NON_RECENSÉ}
-    WHEN communes.status = 'started' THEN #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}
-    WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN #{STATUT_GLOBAL_NON_ANALYSÉ}
-    WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN #{STATUT_GLOBAL_EN_COURS_D_ANALYSE}
-    WHEN dossiers.status = 'accepted' THEN #{STATUT_GLOBAL_ANALYSÉ}
-  END).squish
+  STATUT_GLOBAL_NON_RECENSÉ = "Non recensé"
+  STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = "En cours de rencensement"
+  STATUT_GLOBAL_NON_ANALYSÉ = "Non analysé"
+  STATUT_GLOBAL_EN_COURS_D_ANALYSE = "En cours d'analyse"
+  STATUT_GLOBAL_ANALYSÉ = "Analysé"
 
   validate do |commune|
     next if commune.nom.blank? || commune.nom == commune.nom.strip

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -66,6 +66,27 @@ class Commune < ApplicationRecord
   STATUT_GLOBAL_EN_COURS_D_ANALYSE = "En cours d'analyse"
   STATUT_GLOBAL_ANALYSÉ = "Analysé"
 
+  scope :sort_by_statut_global_asc,
+        lambda {
+          %(CASE
+            WHEN statut_global = #{STATUT_GLOBAL_NON_RECENSÉ} THEN 1
+            WHEN statut_global = #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT} THEN 2
+            WHEN statut_global = #{STATUT_GLOBAL_NON_ANALYSÉ} THEN 3
+            WHEN statut_global = #{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])} THEN 4
+            WHEN statut_global = #{STATUT_GLOBAL_ANALYSÉ} THEN 5
+          END)
+        }
+  scope :sort_by_statut_global_desc,
+        lambda {
+          %(CASE
+            WHEN statut_global = #{STATUT_GLOBAL_NON_RECENSÉ} THEN 5
+            WHEN statut_global = #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT} THEN 4
+            WHEN statut_global = #{STATUT_GLOBAL_NON_ANALYSÉ} THEN 3
+            WHEN statut_global = #{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])} THEN 2
+            WHEN statut_global = #{STATUT_GLOBAL_ANALYSÉ} THEN 1
+          END)
+        }
+
   validate do |commune|
     next if commune.nom.blank? || commune.nom == commune.nom.strip
 

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -129,7 +129,7 @@ class Commune < ApplicationRecord
   # -------
 
   def self.ransackable_attributes(_ = nil)
-    %w[nom code_insee departement_code status objets_count en_peril_count disparus_count]
+    %w[nom code_insee departement_code status objets_count en_peril_count disparus_count statut_global]
   end
 
   def self.ransackable_scopes(_ = nil) = [:recensements_photos_presence_in]

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -61,15 +61,27 @@ class Commune < ApplicationRecord
   accepts_nested_attributes_for :dossier, :users
 
   STATUT_GLOBAL_NON_RECENSÉ = "Non recensé"
-  ORDRE_NON_RECENSÉ = 1
+  ORDRE_NON_RECENSÉ = 0
   STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = "En cours de rencensement"
-  ORDRE_EN_COURS_DE_RECENSEMENT = 2
+  ORDRE_EN_COURS_DE_RECENSEMENT = 1
   STATUT_GLOBAL_NON_ANALYSÉ = "Non analysé"
-  ORDRE_NON_ANALYSÉ = 3
+  ORDRE_NON_ANALYSÉ = 2
   STATUT_GLOBAL_EN_COURS_D_ANALYSE = "En cours d'analyse"
-  ORDRE_EN_COURS_D_ANALYSE = 4
+  ORDRE_EN_COURS_D_ANALYSE = 3
   STATUT_GLOBAL_ANALYSÉ = "Analysé"
-  ORDRE_ANALYSÉ = 5
+  ORDRE_ANALYSÉ = 4
+
+  STATUT_GLOBAUX = [
+    STATUT_GLOBAL_NON_RECENSÉ,
+    STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT,
+    STATUT_GLOBAL_NON_ANALYSÉ,
+    STATUT_GLOBAL_EN_COURS_D_ANALYSE,
+    STATUT_GLOBAL_ANALYSÉ
+  ].freeze
+
+  def statut_global_texte
+    STATUT_GLOBAUX[statut_global]
+  end
 
   validate do |commune|
     next if commune.nom.blank? || commune.nom == commune.nom.strip

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -60,6 +60,14 @@ class Commune < ApplicationRecord
 
   accepts_nested_attributes_for :dossier, :users
 
+  STATUT_GLOBAL_SQL = %(CASE
+    WHEN communes.status = 'inactive' THEN 'inactive'
+    WHEN communes.status = 'started' THEN 'started'
+    WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN 'submitted'
+    WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN 'analyse_started'
+    WHEN dossiers.status = 'accepted' then 'accepted'
+  END).squish
+
   validate do |commune|
     next if commune.nom.blank? || commune.nom == commune.nom.strip
 

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -61,31 +61,15 @@ class Commune < ApplicationRecord
   accepts_nested_attributes_for :dossier, :users
 
   STATUT_GLOBAL_NON_RECENSÉ = "Non recensé"
+  ORDRE_NON_RECENSÉ = 1
   STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = "En cours de rencensement"
+  ORDRE_EN_COURS_DE_RECENSEMENT = 2
   STATUT_GLOBAL_NON_ANALYSÉ = "Non analysé"
+  ORDRE_NON_ANALYSÉ = 3
   STATUT_GLOBAL_EN_COURS_D_ANALYSE = "En cours d'analyse"
+  ORDRE_EN_COURS_D_ANALYSE = 4
   STATUT_GLOBAL_ANALYSÉ = "Analysé"
-
-  scope :sort_by_statut_global_asc,
-        lambda {
-          order(Arel.sql(%(CASE
-            WHEN statut_global = '#{STATUT_GLOBAL_NON_RECENSÉ}' THEN 1
-            WHEN statut_global = '#{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}' THEN 2
-            WHEN statut_global = '#{STATUT_GLOBAL_NON_ANALYSÉ}' THEN 3
-            WHEN statut_global = '#{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])}' THEN 4
-            WHEN statut_global = '#{STATUT_GLOBAL_ANALYSÉ}' THEN 5
-          END).squish))
-        }
-  scope :sort_by_statut_global_desc,
-        lambda {
-          order(Arel.sql(%(CASE
-            WHEN statut_global = '#{STATUT_GLOBAL_NON_RECENSÉ}' THEN 5
-            WHEN statut_global = '#{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}' THEN 4
-            WHEN statut_global = '#{STATUT_GLOBAL_NON_ANALYSÉ}' THEN 3
-            WHEN statut_global = '#{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])}' THEN 2
-            WHEN statut_global = '#{STATUT_GLOBAL_ANALYSÉ}' THEN 1
-          END).squish))
-        }
+  ORDRE_ANALYSÉ = 5
 
   validate do |commune|
     next if commune.nom.blank? || commune.nom == commune.nom.strip

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -129,8 +129,7 @@ class Commune < ApplicationRecord
   # -------
 
   def self.ransackable_attributes(_ = nil)
-    %w[nom code_insee departement_code status objets_count recensements_prioritaires_count
-       types_recensements_prioritaires]
+    %w[nom code_insee departement_code status objets_count en_peril_count disparus_count]
   end
 
   def self.ransackable_scopes(_ = nil) = [:recensements_photos_presence_in]

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -133,7 +133,7 @@ class Commune < ApplicationRecord
   end
 
   def self.ransackable_scopes(_ = nil) = [:recensements_photos_presence_in]
-  def self.ransackable_associations(_ = nil) = %i[dossier dossiers objets]
+  def self.ransackable_associations(_ = nil) = %w[dossier dossiers objets]
 
   ransacker(:nom, type: :string) { Arel.sql("unaccent(nom)") }
 end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -68,23 +68,23 @@ class Commune < ApplicationRecord
 
   scope :sort_by_statut_global_asc,
         lambda {
-          %(CASE
-            WHEN statut_global = #{STATUT_GLOBAL_NON_RECENSÉ} THEN 1
-            WHEN statut_global = #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT} THEN 2
-            WHEN statut_global = #{STATUT_GLOBAL_NON_ANALYSÉ} THEN 3
-            WHEN statut_global = #{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])} THEN 4
-            WHEN statut_global = #{STATUT_GLOBAL_ANALYSÉ} THEN 5
-          END)
+          order(Arel.sql(%(CASE
+            WHEN statut_global = '#{STATUT_GLOBAL_NON_RECENSÉ}' THEN 1
+            WHEN statut_global = '#{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}' THEN 2
+            WHEN statut_global = '#{STATUT_GLOBAL_NON_ANALYSÉ}' THEN 3
+            WHEN statut_global = '#{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])}' THEN 4
+            WHEN statut_global = '#{STATUT_GLOBAL_ANALYSÉ}' THEN 5
+          END).squish))
         }
   scope :sort_by_statut_global_desc,
         lambda {
-          %(CASE
-            WHEN statut_global = #{STATUT_GLOBAL_NON_RECENSÉ} THEN 5
-            WHEN statut_global = #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT} THEN 4
-            WHEN statut_global = #{STATUT_GLOBAL_NON_ANALYSÉ} THEN 3
-            WHEN statut_global = #{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])} THEN 2
-            WHEN statut_global = #{STATUT_GLOBAL_ANALYSÉ} THEN 1
-          END)
+          order(Arel.sql(%(CASE
+            WHEN statut_global = '#{STATUT_GLOBAL_NON_RECENSÉ}' THEN 5
+            WHEN statut_global = '#{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}' THEN 4
+            WHEN statut_global = '#{STATUT_GLOBAL_NON_ANALYSÉ}' THEN 3
+            WHEN statut_global = '#{sanitize_sql(['%s', STATUT_GLOBAL_EN_COURS_D_ANALYSE])}' THEN 2
+            WHEN statut_global = '#{STATUT_GLOBAL_ANALYSÉ}' THEN 1
+          END).squish))
         }
 
   validate do |commune|

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -60,12 +60,18 @@ class Commune < ApplicationRecord
 
   accepts_nested_attributes_for :dossier, :users
 
+  STATUT_GLOBAL_NON_RECENSÉ = 0
+  STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = 1
+  STATUT_GLOBAL_NON_ANALYSÉ = 2
+  STATUT_GLOBAL_EN_COURS_D_ANALYSE = 3
+  STATUT_GLOBAL_ANALYSÉ = 4
+
   STATUT_GLOBAL_SQL = %(CASE
-    WHEN communes.status = 'inactive' THEN 'inactive'
-    WHEN communes.status = 'started' THEN 'started'
-    WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN 'submitted'
-    WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN 'analyse_started'
-    WHEN dossiers.status = 'accepted' then 'accepted'
+    WHEN communes.status = 'inactive' THEN #{STATUT_GLOBAL_NON_RECENSÉ}
+    WHEN communes.status = 'started' THEN #{STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}
+    WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN #{STATUT_GLOBAL_NON_ANALYSÉ}
+    WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN #{STATUT_GLOBAL_EN_COURS_D_ANALYSE}
+    WHEN dossiers.status = 'accepted' THEN #{STATUT_GLOBAL_ANALYSÉ}
   END).squish
 
   validate do |commune|

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -129,7 +129,8 @@ class Commune < ApplicationRecord
   # -------
 
   def self.ransackable_attributes(_ = nil)
-    %w[nom code_insee departement_code status objets_count recensements_prioritaires_count]
+    %w[nom code_insee departement_code status objets_count recensements_prioritaires_count
+       types_recensements_prioritaires]
   end
 
   def self.ransackable_scopes(_ = nil) = [:recensements_photos_presence_in]

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -82,18 +82,6 @@ module Communes
       end
 
       ransacker(:recensements_prioritaires_count) { Arel.sql("recensements_prioritaires_count") }
-      ransacker(:types_recensements_prioritaires) do
-        Arel.sql(%(
-          CASE
-            WHEN recensements_prioritaires.en_peril_count > 0 AND recensements_prioritaires.disparus_count > 0
-              THEN 'peril_disparu'
-            WHEN recensements_prioritaires.en_peril_count > 0 AND recensements_prioritaires.disparus_count = 0
-              THEN 'peril'
-            WHEN recensements_prioritaires.en_peril_count = 0 AND recensements_prioritaires.disparus_count > 0
-              THEN 'disparu'
-            ELSE NULL
-          END).squish)
-      end
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -65,7 +65,6 @@ module Communes
           %{
             LEFT OUTER JOIN (
               #{Recensement.select(%{objets."palissy_INSEE",
-                COUNT(*),
                 SUM(CASE WHEN #{Recensement::RECENSEMENT_ABSENT_SQL} THEN 1 ELSE 0 END) AS disparus_count,
                 SUM(CASE WHEN #{Recensement::RECENSEMENT_EN_PERIL_SQL} THEN 1 ELSE 0 END) AS en_peril_count
                  })
@@ -75,13 +74,14 @@ module Communes
             ) AS recensements_prioritaires
             ON recensements_prioritaires."palissy_INSEE" = communes.code_insee
           }.squish
-        ).select(%(COALESCE(recensements_prioritaires.count, 0) AS recensements_prioritaires_count,
-              COALESCE(disparus_count, 0) AS disparus_count,
-              COALESCE(en_peril_count, 0) AS en_peril_count
+        ).select(%(
+          COALESCE(recensements_prioritaires.disparus_count, 0) AS disparus_count,
+          COALESCE(recensements_prioritaires.en_peril_count, 0) AS en_peril_count
         ).squish)
       end
 
-      ransacker(:recensements_prioritaires_count) { Arel.sql("recensements_prioritaires_count") }
+      ransacker(:en_peril_count) { Arel.sql("en_peril_count") }
+      ransacker(:disparus_count) { Arel.sql("disparus_count") }
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -87,13 +87,11 @@ module Communes
         joins(%{
           LEFT OUTER JOIN (
             SELECT communes.code_insee, (CASE
-                WHEN communes.status = 'inactive' THEN '#{Commune::STATUT_GLOBAL_NON_RECENSÉ}'
-                WHEN communes.status = 'started' THEN '#{Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}'
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN
-                  '#{Commune::STATUT_GLOBAL_NON_ANALYSÉ}'
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN
-                  '#{sanitize_sql(['%s', Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE])}'
-                WHEN dossiers.status = 'accepted' then '#{Commune::STATUT_GLOBAL_ANALYSÉ}'
+                WHEN communes.status = 'inactive' THEN #{Commune::ORDRE_NON_RECENSÉ}
+                WHEN communes.status = 'started' THEN #{Commune::ORDRE_EN_COURS_DE_RECENSEMENT}
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN #{Commune::ORDRE_NON_ANALYSÉ}
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN #{Commune::ORDRE_EN_COURS_D_ANALYSE}
+                WHEN dossiers.status = 'accepted' then #{Commune::ORDRE_ANALYSÉ}
               END) AS statut_global
             FROM communes
             LEFT OUTER JOIN dossiers

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -16,7 +16,7 @@ module Communes
             FROM objets
             GROUP BY "palissy_INSEE"
           ) a ON a."palissy_INSEE" = communes.code_insee
-        }
+          }.squish
         ).select("communes.*, COALESCE(a.objets_count, 0) AS objets_count")
       end
 
@@ -71,7 +71,7 @@ module Communes
               WHERE (#{Recensement::RECENSEMENT_PRIORITAIRE_SQL})
               GROUP BY "palissy_INSEE"
             ) d ON d."palissy_INSEE" = communes.code_insee
-          }
+          }.squish
         ).select("communes.*, COALESCE(d.recensements_prioritaires_count, 0) AS recensements_prioritaires_count")
       end
 

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -85,15 +85,6 @@ module Communes
 
       def self.include_statut_global
         joins(%{
-          LEFT OUTER JOIN (
-            SELECT communes.code_insee, (CASE
-                WHEN communes.status = 'inactive' THEN 'inactive'
-                WHEN communes.status = 'started' THEN 'started'
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN 'submitted'
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN 'analyse_started'
-                WHEN dossiers.status = 'accepted' then 'accepted'
-              END) AS statut_global
-            FROM communes
             LEFT OUTER JOIN dossiers
             ON communes.dossier_id = dossiers.id
             LEFT OUTER JOIN (
@@ -105,13 +96,11 @@ module Communes
               GROUP BY dossiers.id
             ) AS nb_recensements_par_dossiers
             ON dossiers.id = nb_recensements_par_dossiers.id
-          ) AS communes_statut_global
-          ON communes.code_insee = communes_statut_global.code_insee
         }.squish)
-        .select("statut_global")
+        .select("#{Commune::STATUT_GLOBAL_SQL} AS statut_global")
       end
 
-      ransacker(:statut_global) { Arel.sql("statut_global") }
+      ransacker(:statut_global) { Arel.sql(Commune::STATUT_GLOBAL_SQL) }
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -82,6 +82,34 @@ module Communes
 
       ransacker(:en_peril_count) { Arel.sql("en_peril_count") }
       ransacker(:disparus_count) { Arel.sql("disparus_count") }
+
+      def self.include_statut_global
+        joins(%{
+          LEFT OUTER JOIN (
+            SELECT communes.code_insee, (CASE
+                WHEN communes.status = 'inactive' THEN 'inactive'
+                WHEN communes.status = 'started' THEN 'started'
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN 'submitted'
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN 'analyse_started'
+                WHEN dossiers.status = 'accepted' then 'accepted'
+              END) AS statut_global
+            FROM communes
+            LEFT OUTER JOIN dossiers
+            ON communes.dossier_id = dossiers.id
+            LEFT OUTER JOIN (
+              SELECT dossiers.id,
+                SUM(CASE WHEN recensements.analysed_at IS NOT NULL THEN 1 ELSE 0 END) AS recensements_analysed_count
+              FROM dossiers
+              LEFT OUTER JOIN recensements
+              ON dossiers.id = recensements.dossier_id
+              GROUP BY dossiers.id
+            ) AS nb_recensements_par_dossiers
+            ON dossiers.id = nb_recensements_par_dossiers.id
+          ) AS communes_statut_global
+          ON communes.code_insee = communes_statut_global.code_insee
+        }.squish)
+        .select("statut_global")
+      end
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -84,8 +84,20 @@ module Communes
       ransacker(:disparus_count) { Arel.sql("disparus_count") }
 
       def self.include_statut_global
-        left_outer_joins(:dossier)
-        .joins(%{
+        joins(%{
+          LEFT OUTER JOIN (
+            SELECT communes.code_insee, (CASE
+                WHEN communes.status = 'inactive' THEN '#{Commune::STATUT_GLOBAL_NON_RECENSÉ}'
+                WHEN communes.status = 'started' THEN '#{Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT}'
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN
+                  '#{Commune::STATUT_GLOBAL_NON_ANALYSÉ}'
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN
+                  '#{sanitize_sql(['%s', Commune::STATUT_GLOBAL_EN_COURS_D_ANALYSE])}'
+                WHEN dossiers.status = 'accepted' then '#{Commune::STATUT_GLOBAL_ANALYSÉ}'
+              END) AS statut_global
+            FROM communes
+            LEFT OUTER JOIN dossiers
+            ON communes.dossier_id = dossiers.id
             LEFT OUTER JOIN (
               SELECT dossiers.id,
                 SUM(CASE WHEN recensements.analysed_at IS NOT NULL THEN 1 ELSE 0 END) AS recensements_analysed_count
@@ -95,11 +107,13 @@ module Communes
               GROUP BY dossiers.id
             ) AS nb_recensements_par_dossiers
             ON dossiers.id = nb_recensements_par_dossiers.id
+          ) AS communes_statut_global
+          ON communes.code_insee = communes_statut_global.code_insee
         }.squish)
-        .select("#{Commune::STATUT_GLOBAL_SQL} AS statut_global")
+        .select("statut_global")
       end
 
-      ransacker(:statut_global) { Arel.sql(Commune::STATUT_GLOBAL_SQL) }
+      ransacker(:statut_global) { Arel.sql("statut_global") }
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -110,6 +110,8 @@ module Communes
         }.squish)
         .select("statut_global")
       end
+
+      ransacker(:statut_global) { Arel.sql("statut_global") }
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -89,8 +89,10 @@ module Communes
             SELECT communes.code_insee, (CASE
                 WHEN communes.status = 'inactive' THEN #{Commune::ORDRE_NON_RECENSÉ}
                 WHEN communes.status = 'started' THEN #{Commune::ORDRE_EN_COURS_DE_RECENSEMENT}
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0 THEN #{Commune::ORDRE_NON_ANALYSÉ}
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0 THEN #{Commune::ORDRE_EN_COURS_D_ANALYSE}
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0
+                  THEN #{Commune::ORDRE_NON_ANALYSÉ}
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0
+                  THEN #{Commune::ORDRE_EN_COURS_D_ANALYSE}
                 WHEN dossiers.status = 'accepted' then #{Commune::ORDRE_ANALYSÉ}
               END) AS statut_global
             FROM communes

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -84,11 +84,18 @@ module Communes
           COALESCE(recensements_en_peril.count, 0) AS recensements_en_peril_count,
           COALESCE(recensements_disparus.count, 0) AS recensements_disparus_count,
           COALESCE(recensements_en_peril.count, 0) + COALESCE(recensements_disparus.count, 0)
-            AS recensements_prioritaires_count
-          })
+            AS recensements_prioritaires_count,
+            CASE
+              WHEN recensements_en_peril.count > 0 AND recensements_disparus.count > 0 THEN 'peril_disparu'
+              WHEN recensements_en_peril.count > 0 AND recensements_disparus.count IS NULL THEN 'peril'
+              WHEN recensements_en_peril.count IS NULL AND recensements_disparus.count > 0 THEN 'disparu'
+              ELSE NULL
+            END AS types_recensements_prioritaires
+        }.squish)
       end
 
       ransacker(:recensements_prioritaires_count) { Arel.sql("recensements_prioritaires_count") }
+      ransacker(:types_recensements_prioritaires) { Arel.sql("types_recensements_prioritaires") }
     end
   end
 end

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -84,9 +84,8 @@ module Communes
       ransacker(:disparus_count) { Arel.sql("disparus_count") }
 
       def self.include_statut_global
-        joins(%{
-            LEFT OUTER JOIN dossiers
-            ON communes.dossier_id = dossiers.id
+        left_outer_joins(:dossier)
+        .joins(%{
             LEFT OUTER JOIN (
               SELECT dossiers.id,
                 SUM(CASE WHEN recensements.analysed_at IS NOT NULL THEN 1 ELSE 0 END) AS recensements_analysed_count

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -89,9 +89,9 @@ module Communes
           CASE
             WHEN recensements_prioritaires.en_peril_count > 0 AND recensements_prioritaires.disparus_count > 0
               THEN 'peril_disparu'
-            WHEN recensements_prioritaires.en_peril_count > 0 AND recensements_prioritaires.disparus_count IS NULL
+            WHEN recensements_prioritaires.en_peril_count > 0 AND recensements_prioritaires.disparus_count = 0
               THEN 'peril'
-            WHEN recensements_prioritaires.en_peril_count IS NULL AND recensements_prioritaires.disparus_count > 0
+            WHEN recensements_prioritaires.en_peril_count = 0 AND recensements_prioritaires.disparus_count > 0
               THEN 'disparu'
             ELSE NULL
           END).squish)

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -13,9 +13,7 @@ module Communes
         joins(
           %{
           LEFT OUTER JOIN (
-            SELECT "palissy_INSEE", COUNT(*) objets_count
-            FROM objets
-            GROUP BY "palissy_INSEE"
+            #{Objet.select(:palissy_INSEE, 'COUNT(*) AS objets_count').group(:palissy_INSEE).to_sql}
           ) a ON a."palissy_INSEE" = communes.code_insee
           }.squish
         ).select("communes.*, COALESCE(a.objets_count, 0) AS objets_count")

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -84,18 +84,19 @@ module Communes
           COALESCE(recensements_en_peril.count, 0) AS recensements_en_peril_count,
           COALESCE(recensements_disparus.count, 0) AS recensements_disparus_count,
           COALESCE(recensements_en_peril.count, 0) + COALESCE(recensements_disparus.count, 0)
-            AS recensements_prioritaires_count,
-            CASE
-              WHEN recensements_en_peril.count > 0 AND recensements_disparus.count > 0 THEN 'peril_disparu'
-              WHEN recensements_en_peril.count > 0 AND recensements_disparus.count IS NULL THEN 'peril'
-              WHEN recensements_en_peril.count IS NULL AND recensements_disparus.count > 0 THEN 'disparu'
-              ELSE NULL
-            END AS types_recensements_prioritaires
-        }.squish)
+            AS recensements_prioritaires_count }.squish)
       end
 
       ransacker(:recensements_prioritaires_count) { Arel.sql("recensements_prioritaires_count") }
-      ransacker(:types_recensements_prioritaires) { Arel.sql("types_recensements_prioritaires") }
+      ransacker(:types_recensements_prioritaires) do
+        Arel.sql(%(
+          CASE
+            WHEN recensements_en_peril.count > 0 AND recensements_disparus.count > 0 THEN 'peril_disparu'
+            WHEN recensements_en_peril.count > 0 AND recensements_disparus.count IS NULL THEN 'peril'
+            WHEN recensements_en_peril.count IS NULL AND recensements_disparus.count > 0 THEN 'disparu'
+            ELSE NULL
+          END).squish)
+      end
     end
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -10,9 +10,9 @@ class Dossier < ApplicationRecord
 
   include AASM
   aasm column: :status, timestamps: true, whiny_persistence: true do
-    state :construction, initial: true, display: "En construction"
-    state :submitted, display: "En attente d'analyse"
-    state :accepted, display: "Accepté"
+    state :construction, initial: true, display: I18n.t("dossier.status_badge.construction")
+    state :submitted, display: I18n.t("dossier.status_badge.submitted")
+    state :accepted, display: I18n.t("dossier.status_badge.accepted")
 
     event :submit, after: :aasm_after_submit do
       transitions from: :construction, to: :submitted

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -85,5 +85,5 @@ class Dossier < ApplicationRecord
     commune.return_to_started! unless commune.started?
   end
 
-  def self.ransackable_attributes(_ = nil) = %w[status]
+  def self.ransackable_attributes(_ = nil) = %w[status submitted_at]
 end

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -28,6 +28,7 @@
               %th= sort_link ransack, :en_peril_count, "Objets en péril", data: { turbo_action: "replace" }
               %th= sort_link ransack, :disparus_count, "Objets disparus", data: { turbo_action: "replace" }
               %th= sort_link ransack, :statut_global, "Analyse", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :dossier_submitted_at, "Date du recensement", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|
               %tr
@@ -37,6 +38,7 @@
                 %td= commune.en_peril_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" } : 0
                 %td= commune.disparus_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU#{commune.disparus_count > 1 ? "S" : ""}" } : 0          
                 %td= commune_statut_global_badge(commune)
+                %td= commune.dossier&.submitted_at&.strftime("%d/%m/%y")
 
     - if pagy.pages > 1
       .fr-mt-8w.co-pagination-wrapper

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -8,6 +8,9 @@
         = f.text_field :nom_unaccented_cont, data: { controller: "input-autosubmit", action: "change->input-autosubmit#submit" }
       %div
         %button.fr-btn.fr-btn--tertiary.fr-icon-search-line
+      .fr-pl-3w
+        = f.label :dossier_status_eq, "Statut de l'analyse"
+        = f.select :dossier_status_eq, Dossier.aasm.states_for_select.prepend(["Sélectionnez une option", ""]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       - if query_present
         .fr-pl-3w
           = link_to "réinitialiser les filtres", conservateurs_departement_path(departement), class: "fr-link"

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -11,9 +11,6 @@
       .fr-pl-3w
         = f.label :dossier_status_eq, "Statut de l'analyse"
         = f.select :dossier_status_eq, dossier_states, {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
-      .fr-pl-3w
-        = f.label :types_recensements_prioritaires_cont, "Objets prioritaires"
-        = f.select :types_recensements_prioritaires_cont, options_for_select([["Sélectionnez une option", ""], ["DISPARU", "disparu"], ["PERIL", "peril"]]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       - if query_present
         .fr-pl-3w
           = link_to "réinitialiser les filtres", conservateurs_departement_path(departement), class: "fr-link"

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -37,12 +37,10 @@
                 %td= commune.objets_count
                 %td
                   - if commune.recensements_prioritaires_count.positive?
-                    - recensements_en_peril_count = commune.recensements_en_peril_count
-                    - if recensements_en_peril_count.positive?
-                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{recensements_en_peril_count} PERIL" }
-                    - recensements_disparus_count = commune.recensements_disparus_count
-                    - if recensements_disparus_count.positive? 
-                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{recensements_disparus_count} DISPARU" }
+                    - if commune.en_peril_count.positive?
+                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" }
+                    - if commune.disparus_count.positive? 
+                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU" }
                   - else
                     0              
                 %td= dossier_status_badge(commune.dossier, small: true)

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -8,9 +8,6 @@
         = f.text_field :nom_unaccented_cont, data: { controller: "input-autosubmit", action: "change->input-autosubmit#submit" }
       %div
         %button.fr-btn.fr-btn--tertiary.fr-icon-search-line
-      .fr-pl-3w
-        = f.label :status_eq, "État du recensement"
-        = f.select :status_eq, communes_statuses_options_for_select(departement:), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       - if query_present
         .fr-pl-3w
           = link_to "réinitialiser les filtres", conservateurs_departement_path(departement), class: "fr-link"
@@ -25,7 +22,6 @@
               %th= sort_link ransack, :nom, "Commune", data: { turbo_action: "replace" }
               %th= sort_link ransack, :objets_count, "Objets", data: { turbo_action: "replace" }
               %th= sort_link ransack, :recensements_prioritaires_count, "Objets prioritaires", data: { turbo_action: "replace" }
-              %th= sort_link ransack, "status", "Recensement", data: { turbo_action: "replace" }
               %th= sort_link ransack, "dossier_status", "Analyse", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|
@@ -43,7 +39,6 @@
                       = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.recensements.absent.count} DISPARU" }
                   - else
                     0              
-                %td= t("activerecord.attributes.commune.statuses.#{commune.status}")
                 %td
                   - if commune.dossier
                     %div= dossier_status_badge(commune.dossier, small: true)

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -39,11 +39,8 @@
                       = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.recensements.absent.count} DISPARU" }
                   - else
                     0              
-                %td
-                  - if commune.dossier
-                    %div= dossier_status_badge(commune.dossier, small: true)
-                    -# - if commune.dossier.submitted?
-                    -#   \#{commune.recensements_analysed_percentage.round}% des recensements revus
+                %td= dossier_status_badge(commune.dossier, small: true)
+
     - if pagy.pages > 1
       .fr-mt-8w.co-pagination-wrapper
         != render partial: 'shared/pagy_nav', locals: {pagy:}

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -12,7 +12,7 @@
         = f.label :dossier_status_eq, "Statut de l'analyse"
         = f.select :dossier_status_eq, Dossier.aasm.states_for_select.prepend(["Sélectionnez une option", ""]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       .fr-pl-3w
-        = f.label :types_recensements_prioritaires_cont, "Statut de l'analyse"
+        = f.label :types_recensements_prioritaires_cont, "Objets prioritaires"
         = f.select :types_recensements_prioritaires_cont, options_for_select([["Sélectionnez une option", ""], ["DISPARU", "disparu"], ["PERIL", "peril"]]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       - if query_present
         .fr-pl-3w

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -9,8 +9,9 @@
       %div
         %button.fr-btn.fr-btn--tertiary.fr-icon-search-line
       .fr-pl-3w
-        = f.label :dossier_status_eq, "Statut de l'analyse"
-        = f.select :dossier_status_eq, dossier_states, {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
+        = f.label :statut_global_eq, "Statut de l'analyse"
+        = f.select :statut_global_eq, communes_statuses_options_for_select, {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
+
       - if query_present
         .fr-pl-3w
           = link_to "réinitialiser les filtres", conservateurs_departement_path(departement), class: "fr-link"
@@ -26,7 +27,7 @@
               %th= sort_link ransack, :objets_count, "Objets", data: { turbo_action: "replace" }
               %th= sort_link ransack, :en_peril_count, "En péril", data: { turbo_action: "replace" }
               %th= sort_link ransack, :disparus_count, "Disparus", data: { turbo_action: "replace" }
-              %th= sort_link ransack, "dossier_status", "Analyse", data: { turbo_action: "replace" }
+              %th= sort_link ransack, "statut_global", "Analyse", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|
               %tr
@@ -35,7 +36,7 @@
                 %td= commune.objets_count
                 %td= commune.en_peril_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" } : 0
                 %td= commune.disparus_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU#{commune.disparus_count > 1 ? "S" : ""}" } : 0          
-                %td= dossier_status_badge(commune.dossier, small: true)
+                %td= commune.statut_global
 
     - if pagy.pages > 1
       .fr-mt-8w.co-pagination-wrapper

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -24,7 +24,8 @@
             %tr
               %th= sort_link ransack, :nom, "Commune", data: { turbo_action: "replace" }
               %th= sort_link ransack, :objets_count, "Objets", data: { turbo_action: "replace" }
-              %th= sort_link ransack, :recensements_prioritaires_count, "Objets prioritaires", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :en_peril_count, "En péril", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :disparus_count, "Disparus", data: { turbo_action: "replace" }
               %th= sort_link ransack, "dossier_status", "Analyse", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|
@@ -32,14 +33,8 @@
                 %td
                   = link_to commune.nom, conservateurs_commune_path(commune), "data-turbo-frame": "_top"
                 %td= commune.objets_count
-                %td
-                  - if commune.recensements_prioritaires_count.positive?
-                    - if commune.en_peril_count.positive?
-                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" }
-                    - if commune.disparus_count.positive? 
-                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU" }
-                  - else
-                    0              
+                %td= commune.en_peril_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" } : 0
+                %td= commune.disparus_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU#{commune.disparus_count > 1 ? "S" : ""}" } : 0          
                 %td= dossier_status_badge(commune.dossier, small: true)
 
     - if pagy.pages > 1

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -10,7 +10,7 @@
         %button.fr-btn.fr-btn--tertiary.fr-icon-search-line
       .fr-pl-3w
         = f.label :dossier_status_eq, "Statut de l'analyse"
-        = f.select :dossier_status_eq, Dossier.aasm.states_for_select.prepend(["Sélectionnez une option", ""]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
+        = f.select :dossier_status_eq, dossier_states, {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       .fr-pl-3w
         = f.label :types_recensements_prioritaires_cont, "Objets prioritaires"
         = f.select :types_recensements_prioritaires_cont, options_for_select([["Sélectionnez une option", ""], ["DISPARU", "disparu"], ["PERIL", "peril"]]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -27,7 +27,7 @@
               %th= sort_link ransack, :objets_count, "Objets", data: { turbo_action: "replace" }
               %th= sort_link ransack, :en_peril_count, "En péril", data: { turbo_action: "replace" }
               %th= sort_link ransack, :disparus_count, "Disparus", data: { turbo_action: "replace" }
-              %th= sort_link ransack, "statut_global", "Analyse", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :statut_global, "Analyse", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|
               %tr

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -36,7 +36,7 @@
                 %td= commune.objets_count
                 %td= commune.en_peril_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.en_peril_count} PERIL" } : 0
                 %td= commune.disparus_count.positive? ? dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.disparus_count} DISPARU#{commune.disparus_count > 1 ? "S" : ""}" } : 0          
-                %td= commune.statut_global
+                %td= commune_statut_global_badge(commune)
 
     - if pagy.pages > 1
       .fr-mt-8w.co-pagination-wrapper

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -24,9 +24,9 @@
           %thead
             %tr
               %th= sort_link ransack, :nom, "Commune", data: { turbo_action: "replace" }
-              %th= sort_link ransack, :objets_count, "Objets", data: { turbo_action: "replace" }
-              %th= sort_link ransack, :en_peril_count, "En péril", data: { turbo_action: "replace" }
-              %th= sort_link ransack, :disparus_count, "Disparus", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :objets_count, "Nombre d'objets", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :en_peril_count, "Objets en péril", data: { turbo_action: "replace" }
+              %th= sort_link ransack, :disparus_count, "Objets disparus", data: { turbo_action: "replace" }
               %th= sort_link ransack, :statut_global, "Analyse", data: { turbo_action: "replace" }
           %tbody
             - communes.each do |commune|

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -35,19 +35,20 @@
                 %td= commune.objets_count
                 %td
                   - if commune.recensements_prioritaires_count.positive?
-                    %span.fr-badge.fr-badge--sm.fr-badge--warning
-                      - if commune.recensements_prioritaires_count == 1
-                        1 objet prioritaire
-                      - else
-                        \#{commune.recensements_prioritaires_count} objets prioritaires
+                    - recensements_en_peril_count = commune.recensements.en_peril.count
+                    - if recensements_en_peril_count.positive?
+                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{recensements_en_peril_count} PERIL" }
+                    - recensements_absent_count = commune.recensements.absent.count
+                    - if recensements_absent_count.positive? 
+                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.recensements.absent.count} DISPARU" }
                   - else
-                    0
+                    0              
                 %td= t("activerecord.attributes.commune.statuses.#{commune.status}")
                 %td
                   - if commune.dossier
                     %div= dossier_status_badge(commune.dossier, small: true)
-                    - if commune.dossier.submitted?
-                      \#{commune.recensements_analysed_percentage.round}% des recensements revus
+                    -# - if commune.dossier.submitted?
+                    -#   \#{commune.recensements_analysed_percentage.round}% des recensements revus
     - if pagy.pages > 1
       .fr-mt-8w.co-pagination-wrapper
         != render partial: 'shared/pagy_nav', locals: {pagy:}

--- a/app/views/conservateurs/departements/_communes_search.html.haml
+++ b/app/views/conservateurs/departements/_communes_search.html.haml
@@ -11,6 +11,9 @@
       .fr-pl-3w
         = f.label :dossier_status_eq, "Statut de l'analyse"
         = f.select :dossier_status_eq, Dossier.aasm.states_for_select.prepend(["Sélectionnez une option", ""]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
+      .fr-pl-3w
+        = f.label :types_recensements_prioritaires_cont, "Statut de l'analyse"
+        = f.select :types_recensements_prioritaires_cont, options_for_select([["Sélectionnez une option", ""], ["DISPARU", "disparu"], ["PERIL", "peril"]]), {}, data: { controller: "input-autosubmit", action: "input-autosubmit#submit" }
       - if query_present
         .fr-pl-3w
           = link_to "réinitialiser les filtres", conservateurs_departement_path(departement), class: "fr-link"
@@ -34,12 +37,12 @@
                 %td= commune.objets_count
                 %td
                   - if commune.recensements_prioritaires_count.positive?
-                    - recensements_en_peril_count = commune.recensements.en_peril.count
+                    - recensements_en_peril_count = commune.recensements_en_peril_count
                     - if recensements_en_peril_count.positive?
                       = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{recensements_en_peril_count} PERIL" }
-                    - recensements_absent_count = commune.recensements.absent.count
-                    - if recensements_absent_count.positive? 
-                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{commune.recensements.absent.count} DISPARU" }
+                    - recensements_disparus_count = commune.recensements_disparus_count
+                    - if recensements_disparus_count.positive? 
+                      = dsfr_badge(status: :warning, classes: ["fr-badge--sm"]) { "#{recensements_disparus_count} DISPARU" }
                   - else
                     0              
                 %td= dossier_status_badge(commune.dossier, small: true)

--- a/app/views/conservateurs/departements/_map.html.haml
+++ b/app/views/conservateurs/departements/_map.html.haml
@@ -5,8 +5,8 @@
       Commune ayant soumis un dossier de recensement
     .fr-pb-2w
       .map-legend-icon.commune-prioritaire
-      Commune ayant soumis un dossier de recensement avec des objets prioritaires
-.co-position-relative{"data-communes-json" => "#{communes.map { _1.slice(%w[code_insee status objets_count recensements_prioritaires_count]) }.to_json}",
+      Commune ayant soumis un dossier de recensement avec des objets en péril
+.co-position-relative{"data-communes-json" => "#{communes.map { _1.slice(%w[code_insee status objets_count en_peril_count]) }.to_json}",
   "data-conservateur-map-target" => "wrapper",
   "data-controller" => "conservateur-map",
   "data-departement-json" => "#{@departement_json}"}

--- a/app/views/conservateurs/departements/_map_sidebar_commune_template.html.haml
+++ b/app/views/conservateurs/departements/_map_sidebar_commune_template.html.haml
@@ -4,9 +4,9 @@
       %h5= commune.nom
       %div= dossier_status_badge(commune.dossier, small: true)
     .fr-mb-6w
-      - if commune.recensements_prioritaires_count
+      - if commune.en_peril_count
         .co-text--bold
-          = t(".prioritaires_count", count: commune.recensements_prioritaires_count)
+          = t(".en_peril_count", count: commune.en_peril_count)
         %div sur #{t(".recensed_count", count: commune.objets_count)}
       - else
         = t(".recensed_count", count: commune.objets_count)

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -98,8 +98,8 @@ fr:
   dossier:
     status_badge:
       construction: Partiellement recensé
-      submitted: En cours d'analyse
-      accepted: Accepté
+      submitted: Non analysé
+      accepted: Analysé
     rapport:
       recensement:
         notes: Commentaires de la commune

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -97,9 +97,9 @@ fr:
       en_danger: Facile à voler
   dossier:
     status_badge:
-      construction: Recensement en cours
-      submitted: À analyser
-      accepted: Rapport envoyé à la commune
+      construction: Partiellement recensé
+      submitted: En cours d'analyse
+      accepted: Accepté
     rapport:
       recensement:
         notes: Commentaires de la commune

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -100,6 +100,7 @@ fr:
       construction: Partiellement recensé
       submitted: Non analysé
       accepted: Analysé
+      none: Non recensé
     rapport:
       recensement:
         notes: Commentaires de la commune

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,7 +117,7 @@ fr:
       intro:
         title: Le recensement
         content1: Mener un recensement, c’est aller vérifier la présence d’un objet au sein de son édifice et constater son état en répondant à un questionnaire simplifié. C’est une opération rapide à mener (5 à 10 min par objet) et qui ne demande aucune expertise ou formation particulière. Les données collectées permettent aux conservateurs en charge de votre territoire de mieux connaître votre patrimoine, de vous aider à le valoriser et d’intervenir à temps pour le protéger.
-        content2: Vous êtes élu·e ou agent municipal ? Vous êtes en charge du patrimoine de votre commune ? Sur Collectif Objets vous pouvez retrouver la liste des objets classés Monuments Historiques abrités par votre commune à la page “les objets de ma commune” afin de les recenser.
+        content2: Vous êtes élu·e ou agent municipal ? Vous êtes en charge du patrimoine de votre commune ? Sur Collectif Objets vous pouvez retrouver la liste des objets protégés Monuments Historiques abrités par votre commune à la page “les objets de ma commune” afin de les recenser.
       etape1:
         title: Étape 1 - Je me rends sur place
         content1: Pour évaluer au mieux les conditions de vos objets Monuments Historiques au moment de leur recensement, celui-ci doit être effectué sur place et être accompagné de photos actuelles.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -52,9 +52,9 @@ fr:
       title:
         campaign: Campagne de recensement du %{date_lancement} au %{date_fin}
       map_sidebar_commune_template:
-        prioritaires_count:
-          one: 1 objet prioritaire
-          other: "%{count} objets prioritaires"
+        en_peril_count:
+          one: 1 objet en péril
+          other: "%{count} objets en péril"
         recensed_count:
           one: 1 objet recensé
           other: "%{count} objets recensés"

--- a/contenus/content_blobs/documentation_conservateur.md
+++ b/contenus/content_blobs/documentation_conservateur.md
@@ -254,6 +254,6 @@ La [Licence Ouverte Etalab](https://www.etalab.gouv.fr/licence-ouverte-open-lice
 
 ## Qu’est-ce qu’un « objet prioritaire » dans Collectif Objets ?
 
-Il s’agit d’un objet qui a été désigné par la commune qui l’abrite (ou qui devrait l’abriter) comme : disparu, en mauvais état de conservation ou en péril.
+Il s’agit d’un objet qui a été désigné par la commune qui l’abrite (ou qui devrait l’abriter) comme : disparu ou en péril.
 
 Les objets prioritaires sont donc les objets qui semblent mériter une attention particulière dans un délai restreint.

--- a/spec/factories/objets.rb
+++ b/spec/factories/objets.rb
@@ -58,5 +58,13 @@ FactoryBot.define do
         ]
       end
     end
+
+    trait :en_peril do
+      recensements { [association(:recensement, :en_peril)] }
+    end
+
+    trait :disparu do
+      recensements { [association(:recensement, :disparu)] }
+    end
   end
 end

--- a/spec/factories/recensement.rb
+++ b/spec/factories/recensement.rb
@@ -55,5 +55,16 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :disparu do
+      recensable { false }
+      localisation { Recensement::LOCALISATION_ABSENT }
+      etat_sanitaire { nil }
+      securisation { nil }
+    end
+
+    trait :en_peril do
+      etat_sanitaire { Recensement::ETAT_PERIL }
+    end
   end
 end

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -105,4 +105,29 @@ RSpec.describe Commune, type: :model do
       expect(Commune.include_objets_count.first.objets_count).to eq 2
     end
   end
+
+  describe ".include_recensements_prioritaires_count" do
+    before do
+      commune = create(:commune)
+      create(:objet, :with_recensement, commune:)
+      objet_en_peril = create(:objet, commune:)
+      create(:recensement, :en_peril, objet: objet_en_peril)
+      2.times do
+        objet_disparu = create(:objet, commune:)
+        create(:recensement, :disparu, objet: objet_disparu)
+      end
+    end
+
+    it "fournit un compteur d'objets prioritaires" do
+      expect(Commune.include_recensements_prioritaires_count.first.recensements_prioritaires_count).to eq 3
+    end
+
+    it "fournit un compteur d'objets disparus" do
+      expect(Commune.include_recensements_prioritaires_count.first.disparus_count).to eq 2
+    end
+
+    it "fournit un compteur d'objets en péril" do
+      expect(Commune.include_recensements_prioritaires_count.first.en_peril_count).to eq 1
+    end
+  end
 end

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -114,10 +114,6 @@ RSpec.describe Commune, type: :model do
       create_list(:objet, 2, :disparu, commune:)
     end
 
-    it "fournit un compteur d'objets prioritaires" do
-      expect(Commune.include_recensements_prioritaires_count.first.recensements_prioritaires_count).to eq 3
-    end
-
     it "fournit un compteur d'objets disparus" do
       expect(Commune.include_recensements_prioritaires_count.first.disparus_count).to eq 2
     end

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -90,4 +90,19 @@ RSpec.describe Commune, type: :model do
       expect(dossier.reload.status.to_sym).to eq :submitted
     end
   end
+
+  describe ".include_objets_count" do
+    before do
+      commune = create(:commune)
+      create_list(:objet, 2, commune:)
+    end
+
+    it "a un compteur d'objets" do
+      expect(Commune.include_objets_count.first.has_attribute?(:objets_count)).to be true
+    end
+
+    it "fournit un compteur avec 2 objets" do
+      expect(Commune.include_objets_count.first.objets_count).to eq 2
+    end
+  end
 end

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -110,12 +110,8 @@ RSpec.describe Commune, type: :model do
     before do
       commune = create(:commune)
       create(:objet, :with_recensement, commune:)
-      objet_en_peril = create(:objet, commune:)
-      create(:recensement, :en_peril, objet: objet_en_peril)
-      2.times do
-        objet_disparu = create(:objet, commune:)
-        create(:recensement, :disparu, objet: objet_disparu)
-      end
+      create(:objet, :en_peril, commune:)
+      create_list(:objet, 2, :disparu, commune:)
     end
 
     it "fournit un compteur d'objets prioritaires" do


### PR DESCRIPTION
L'objectif est de faire évoluer la page de visualisation d'un département côté conservateur (/conservateurs/departements/ID_DU_DEPARTEMENT), et plus précisément le tableau des communes, qui ressemble actuellement à ça :

![Vue_Departement avant](https://github.com/betagouv/collectif-objets/assets/1522772/5dbbbfd8-0360-4cad-8b8d-0bb73a3b65b7)

Voici la maquette vers laquelle je dois aller :
![Vue_Departement objectif](https://github.com/betagouv/collectif-objets/assets/1522772/4edf12f8-5009-4253-b463-661304840dfe)

Dans la colonne Objets prioritaires, il y a désormais une distinction entre les objets "disparus" et les objets "en péril" (en très mauvais état). Un objet est dit "prioritaire" s'il est disparu ou en péril.

Le tri de la colonne Objets prioritaires se fait en fonction du nombre total d'objets prioritaires.
Le filtre d'objets prioritaires (via la select box en haut du tableau) permet de ne remonter que les communes ayant au moins un objet prioritaire du critère choisi (disparu ou en péril).
