### PR TITLE
simplification du filtre pour afficher la liste d’édifices

### DIFF
--- a/app/views/edifices/_list.html.haml
+++ b/app/views/edifices/_list.html.haml
@@ -1,4 +1,4 @@
-- unless edifices.count <= 3 && edifices.reduce { |a_moins_de_6_objets, edifice| a_moins_de_6_objets && edifice.objets.count <= 6  }
+- unless edifices.count <= 3 && edifices.all? { _1.objets.count <= 6 }
   %h4 Liste des #{edifices.count} édifices
 
   %ul.fr-mb-8w


### PR DESCRIPTION
je suis tombé sur cette ligne et j’ai mis un moment à la comprendre

`edifices.reduce { |a_moins_de_6_objets, edifice| a_moins_de_6_objets && edifice.objets.count <= 6 }` 

est-ce qu’il y avait une raison d’utiliser `reduce` qui m’échappe ? il me semble que c’est plus lisible avec `all?`. J’ai utilisé un numbered parameter `_1` pour la concision mais on peut aussi laisser `.all?{ |edifice| edifice.objets.count <= 6}`