### PR TITLE
réparation de la modale de recensement sans photos

### DIFF
--- a/app/views/communes/recensements/_step3.html.haml
+++ b/app/views/communes/recensements/_step3.html.haml
@@ -8,9 +8,12 @@
 
   - if @modal == "confirmation-no-photos"
     = dsfr_modal(title: "Êtes-vous sûr de ne pas pouvoir prendre de photos ?",
+          opened: true,
           html_attributes: { id: "modal-confirmation-no-photos",
             "data-controller": "modal-auto-open",
             "data-modal-auto-open-target": "modal"}) do |m|
+      - m.with_header do
+        = link_to "Fermer", wizard.confirmation_modal_close_path, class: "fr-link--close fr-link"
       %p Attention : votre recensement risque de ne pas être exploitable par le conservateur sans photos.
 
       %p

--- a/spec/features/communes/recensement_spec.rb
+++ b/spec/features/communes/recensement_spec.rb
@@ -163,6 +163,8 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
     find("label", text: "Je ne trouve pas l’objet").click
     click_on "Passer à l’étape suivante"
     expect(page).to have_text("Je confirme ne pas trouver l’objet")
+    sleep 1 # sleep and check modal is still present to make sure it does not autoclose
+    expect(page).to have_text("Je confirme ne pas trouver l’objet")
     click_on "Annuler"
     expect(page).to have_text("Avez-vous trouvé l’objet ?")
     find("label", text: "Je ne trouve pas l’objet").click
@@ -218,6 +220,8 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
     find("label", text: "L’objet se trouve dans l’édifice indiqué initialement").click
     find("label", text: "L’objet n’est pas recensable").click
     click_on "Passer à l’étape suivante"
+    expect(page).to have_text("Je confirme que l’objet n’est pas recensable")
+    sleep 1 # sleep and check modal is still present to make sure it does not autoclose
     expect(page).to have_text("Je confirme que l’objet n’est pas recensable")
     click_on "Annuler"
     find("label", text: "L’objet n’est pas recensable").click
@@ -282,6 +286,8 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
     click_on "Passer à l’étape suivante"
     expect(page).to have_text("Étape 3 sur 6")
     click_on "Passer à l’étape suivante"
+    expect(page).to have_text("Êtes-vous sûr de ne pas pouvoir prendre de photos ?")
+    sleep 1 # sleep and check modal is still present to make sure it does not autoclose
     expect(page).to have_text("Êtes-vous sûr de ne pas pouvoir prendre de photos ?")
     click_on "Annuler" # same here
     click_on "Passer à l’étape suivante"


### PR DESCRIPTION
je ne sais pas vraiment ce qui se passait, ceci est un fix un peu rapide où j’ai juste fait en sorte que le markup html soit exactement identique sur la step 3 photos que sur les 1 et 2 ou les modales marchaient

j’ai modifié les tests pour qu’on soit prévenus si ça se reproduit

il faudra néanmoins un jour se pencher sur cette ouverture de modale via Turbo un peu sauvage, le controller stimulus auto open modal est vraiment un hack