### PR TITLE
migration du matomo de data.gouv vers beta.gouv

### DIFF
--- a/app/frontend/entrypoints/matomo_tracking.js
+++ b/app/frontend/entrypoints/matomo_tracking.js
@@ -3,10 +3,10 @@ var _paq = window._paq = window._paq || [];
 _paq.push(['disableCookies']);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
-(function() {
-  var u="https://stats.data.gouv.fr/";
-  _paq.push(['setTrackerUrl', u+'piwik.php']);
-  _paq.push(['setSiteId', '237']);
-  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-  g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+(function () {
+  var u = "https://stats.beta.gouv.fr/";
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '71']);
+  var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+  g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
 })();

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
     policy.connect_src \
       :self,
       "https://sentry.incubateur.net",
-      "https://stats.data.gouv.fr",
+      "https://stats.beta.gouv.fr",
       "https://openmaptiles.geo.data.gouv.fr",
       *s3_uris2,
       *(Rails.env.development? ? ["ws://#{ ViteRuby.config.host_with_port }"] : [])


### PR DESCRIPTION
le serveur de data.gouv.fr nous a demandé de migrer vers celui de beta 

cf https://stats.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=71&period=day&date=yesterday#?period=day&date=yesterday&category=Dashboard_Dashboard&subcategory=1&idSite=71