### PR TITLE
ajout d’un sanity check pour valider la cohérence des dates de campagnes et leurs statuts

### DIFF
--- a/app/jobs/sanity_checks_job.rb
+++ b/app/jobs/sanity_checks_job.rb
@@ -34,7 +34,9 @@ class SanityChecksJob
   end
 
   def check_campaign_statuses_and_dates
-    Campaign.ongoing.where("date_fin < ?", Time.zone.today).each do |campaign|
+    Campaign.ongoing.where("date_fin < ?", Time.zone.today - 1.day).each do |campaign|
+      # this will warn for campaigns that should have ended the day before yesterday
+      # because the cron job that closes them runs later in the day than this job
       text = "La campagne #{campaign} est en en cours mais sa date de fin est " \
              "#{campaign.date_fin} au lieu d'être dans le futur"
       logger.info text


### PR DESCRIPTION
en local le cron job censé modifier les statuts des campagnes ne tourne pas. On se retrouve avec des campagnes dans des états incohérents.
J’ai eu peur que ça se produise en prod, alors j’ai écrit ce sanity check qui nous avertira si ça se produit un jour (par exemple si le cron job ne tourne plus). J’ai vérifié et il n’y a aucune occurence en prod pour l’instant 😅 