### PR TITLE
conservateurs: améliorations de l’UI de la vue d’un departement

### DIFF
--- a/app/frontend/stylesheets/utilities.css
+++ b/app/frontend/stylesheets/utilities.css
@@ -18,7 +18,7 @@
 
 @media (max-width: 576px) {
   .co-hide--sm { display: none !important; }
-  .co-display--sm.hide { display: block !important; }
+  .co-display--sm { display: block !important; }
 }
 
 /* OVERFLOWS */

--- a/app/frontend/stylesheets/utilities.css
+++ b/app/frontend/stylesheets/utilities.css
@@ -18,6 +18,7 @@
 
 @media (max-width: 576px) {
   .co-hide--sm { display: none !important; }
+  .co-display--sm.hide { display: block !important; }
 }
 
 /* OVERFLOWS */

--- a/app/views/conservateurs/departements/_campaigns.html.haml
+++ b/app/views/conservateurs/departements/_campaigns.html.haml
@@ -1,7 +1,7 @@
 - if departement.current_campaign
-  = render CalloutWithCtaComponent.new do |c|
-    - c.with_text { "Une campagne est en cours dans ce département" }
-    - c.with_cta { link_to "Voir la campagne", conservateurs_campaign_path(departement.current_campaign), class: "fr-btn" }
+  %p
+    Une campagne est en cours dans ce département ·
+    = link_to "Voir la campagne", conservateurs_campaign_path(departement.current_campaign), class: "fr-link"
 - elsif departement.campaigns.planned.any?
   - campaign = departement.campaigns.planned.first
   %p

--- a/app/views/conservateurs/departements/_stats.html.haml
+++ b/app/views/conservateurs/departements/_stats.html.haml
@@ -1,8 +1,39 @@
-.fr-accordion.fr-mb-2w
+-# version desktop
+.fr-mb-4w.fr-background-alt--blue-france.fr-p-2w.co-hide--sm
+  %h2.fr-text--lg Statistiques du département
+  .fr-grid-row.fr-grid-row--gutters
+    .fr-col-md-3.fr-col-12
+      .fr-card
+        .fr-card__body
+          .fr-card__content
+            %h2.fr-card__title.fr-text-title--blue-france #{stats.communes_completed_percentage}%
+            %p.fr-card__desc de communes recenseuses, soit #{stats.communes_completed_count} communes sur #{stats.communes_count}
+
+    .fr-col-md-3.fr-col-12
+      .fr-card
+        .fr-card__body
+          .fr-card__content
+            %h2.fr-card__title.fr-text-title--blue-france #{stats.objets_recenses_percentage}%
+            %p.fr-card__desc d'objets recensés, soit #{stats.objets_recenses_count} objets sur #{stats.objets_count}
+
+    .fr-col-md-6
+      .fr-card
+        .fr-card__body
+          .fr-card__content
+            %h2.fr-card__title.fr-text-title--blue-france État sanitaire des objets recensés
+            .fr-card__desc
+              = bar_chart [{name: "En péril", color: "rgba(179, 64, 1, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_PERIL]]] },
+                          {name: "Mauvais état", color: "rgba(133, 133, 247, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_MAUVAIS]]]  },
+                          {name: "État moyen", color: "rgba(174, 173, 249, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_MOYEN]]]  },
+                          {name: "Bon état", color: "rgba(205, 206, 252, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_BON]]] }],
+                stacked: true, height: 200, xtitle: "nombre d’objets"
+
+-# version mobile
+.fr-mb-4w.fr-accordion.fr-background-alt--blue-france.hide.co-display--sm
   %h3.fr-accordion__title
     %button.fr-accordion__btn{"aria-expanded" => "false", "aria-controls" => "accordion-stats"} Voir les statistiques du département
   .fr-collapse{id: "accordion-stats"}
-    .fr-grid-row.fr-grid-row--gutters.fr-mb-4w.fr-background-alt--blue-france
+    .fr-grid-row.fr-grid-row--gutters.fr-mb-2w.fr-background-alt--blue-france
       .fr-col-md-3.fr-col-12
         .fr-card
           .fr-card__body
@@ -16,15 +47,3 @@
             .fr-card__content
               %h2.fr-card__title.fr-text-title--blue-france #{stats.objets_recenses_percentage}%
               %p.fr-card__desc d'objets recensés, soit #{stats.objets_recenses_count} objets sur #{stats.objets_count}
-
-      .fr-col-md-6.co-hide--sm
-        .fr-card
-          .fr-card__body
-            .fr-card__content
-              %h2.fr-card__title.fr-text-title--blue-france État sanitaire des objets recensés
-              .fr-card__desc
-                = bar_chart [{name: "En péril", color: "rgba(179, 64, 1, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_PERIL]]] },
-                            {name: "Mauvais état", color: "rgba(133, 133, 247, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_MAUVAIS]]]  },
-                            {name: "État moyen", color: "rgba(174, 173, 249, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_MOYEN]]]  },
-                            {name: "Bon état", color: "rgba(205, 206, 252, 1)", data: [["", stats.etats_sanitaires_value_counts[Recensement::ETAT_BON]]] }],
-                  stacked: true, height: 200, xtitle: "nombre d’objets"


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/3c1b452d1f5048719a4b879ec9208845?v=95aca3f8728a4ddd8ee25be0c6b07def&p=4d68f37a6af24364b165895015a76f8a&pm=s

## le callout vers la campagne en cours devient un simple paragraphe

![campagne](https://github.com/betagouv/collectif-objets/assets/883348/5696cbd9-2174-4fde-ae57-634722b94246)

## simplification du bandeau de stats sur desktop

![stats-desktop](https://github.com/betagouv/collectif-objets/assets/883348/719a1118-cfa3-4d61-9bd5-956a687ef57c)

sur mobile rien ne change, c’est toujours un accordéon

j’ai dupliqué le code pour faire simple, c’est dans un unique fichier donc ca me parait ok