### PR TITLE
harmonisation des contraintes pessimistes dans le gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,70 +5,70 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
-gem "aasm"
-gem "actioncable"
-gem "active_model_validates_intersection_of"
-gem "activerecord-postgis-adapter"
-gem "active_storage_validations"
-gem "after_commit_everywhere"
-gem "aws-sdk-s3", require: false
-gem "bootsnap", require: false
+gem "aasm", "~> 5.5"
+gem "actioncable", "~> 7.1"
+gem "active_model_validates_intersection_of", "~> 3.0"
+gem "activerecord-postgis-adapter", "~> 9.0"
+gem "active_storage_validations", "~> 1.0"
+gem "after_commit_everywhere", "~> 1.3"
+gem "aws-sdk-s3", "~> 1.132", require: false
+gem "bootsnap", "~> 1.16", require: false
 gem "chartkick", "~> 5.0"
-gem "devise"
-gem "dsfr-view-components"
-gem "factory_bot_rails"
-gem "front_matter_parser"
-gem "haml-rails"
-gem "icalendar"
-gem "image_processing"
-gem "kramdown"
-gem "matrix"
+gem "devise", "~> 4.9"
+gem "dsfr-view-components", "~> 0.4"
+gem "factory_bot_rails", "~> 6.2"
+gem "front_matter_parser", "~> 1.0"
+gem "haml-rails", "~> 2.1"
+gem "icalendar", "~> 2.10"
+gem "image_processing", "~> 1.12"
+gem "kramdown", "~> 2.4"
+gem "matrix", "~> 0.4"
 gem "mjml-rails", "~> 4.9"
 gem "pagy", "~> 6.0"
 gem "pg", "~> 1.5"
 gem "prawn", "~> 2.4"
-gem "prawn-table", "~> 0.2.2"
-gem "progressbar"
+gem "prawn-table", "~> 0.2"
+gem "progressbar", "~> 1.0"
 gem "puma", "~> 6.4"
-gem "pundit"
+gem "pundit", "~> 2.3"
 gem "rails", "~> 7.1"
 gem "ransack", "~> 4.1"
-gem "redis"
-gem "rubyzip"
-gem "sentry-rails"
+gem "redis", "~> 5.0"
+gem "rubyzip", "~> 2.3"
+gem "sentry-rails", "~> 5.15"
 gem "sentry-ruby", "~> 5.15"
-gem "sentry-sidekiq"
-gem "sidekiq"
-gem "turbo-rails"
-gem "typhoeus"
-gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
-gem "view_component"
-gem "vite_rails"
+gem "sentry-sidekiq", "~> 5.15"
+gem "sidekiq", "~> 7.2"
+gem "turbo-rails", "~> 1.4"
+gem "typhoeus", "~> 1.4"
+gem "tzinfo-data", "~> 1.0", platforms: %i[mingw mswin x64_mingw jruby]
+gem "view_component", "~> 2.82"
+gem "vite_rails", "~> 3.0"
 
 group :development, :test do
-  gem "debug", ">= 1.0.0"
-  gem "launchy"
+  gem "debug", ">= 1.0"
+  gem "launchy", "~> 2.5"
   gem "rspec-rails", "~> 6.0"
-  gem "rubocop", require: false
-  gem "rubocop-rails", require: false
+  gem "rubocop", "~> 1.51", require: false
+  gem "rubocop-rails", "~> 2.19", require: false
 end
 
 group :development do
-  gem "aasm-diagram", require: false
-  gem "foreman"
-  gem "html2haml"
-  gem "htmlbeautifier"
-  gem "listen" # for lookbook
-  gem "lookbook", "~> 2.0.5"
-  gem "pry"
-  gem "rails-erd", require: false
-  gem "solargraph"
-  gem "web-console"
+  gem "aasm-diagram", "~> 0.1", require: false
+  gem "foreman", "~> 0.87"
+  gem "html2haml", "~> 2.3"
+  gem "htmlbeautifier", "~> 1.4"
+  gem "listen", "~> 3.8" # for lookbook
+  gem "lookbook", "~> 2.0"
+  gem "pry", "~> 0.14"
+  gem "rails-erd", "~> 1.7", require: false
+  gem "solargraph", "~> 0.49"
+  gem "web-console", "~> 4.2"
 end
 
 group :test do
-  gem "axe-core-capybara"
-  gem "axe-core-rspec"
-  gem "capybara"
+  gem "axe-core-capybara", "~> 4.7"
+  gem "axe-core-rspec", "~> 4.7"
+  gem "capybara", "~> 3.39"
   gem "selenium-webdriver", "~> 4.16"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,64 +503,64 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  aasm
-  aasm-diagram
-  actioncable
-  active_model_validates_intersection_of
-  active_storage_validations
-  activerecord-postgis-adapter
-  after_commit_everywhere
-  aws-sdk-s3
-  axe-core-capybara
-  axe-core-rspec
-  bootsnap
-  capybara
+  aasm (~> 5.5)
+  aasm-diagram (~> 0.1)
+  actioncable (~> 7.1)
+  active_model_validates_intersection_of (~> 3.0)
+  active_storage_validations (~> 1.0)
+  activerecord-postgis-adapter (~> 9.0)
+  after_commit_everywhere (~> 1.3)
+  aws-sdk-s3 (~> 1.132)
+  axe-core-capybara (~> 4.7)
+  axe-core-rspec (~> 4.7)
+  bootsnap (~> 1.16)
+  capybara (~> 3.39)
   chartkick (~> 5.0)
-  debug (>= 1.0.0)
-  devise
-  dsfr-view-components
-  factory_bot_rails
-  foreman
-  front_matter_parser
-  haml-rails
-  html2haml
-  htmlbeautifier
-  icalendar
-  image_processing
-  kramdown
-  launchy
-  listen
-  lookbook (~> 2.0.5)
-  matrix
+  debug (>= 1.0)
+  devise (~> 4.9)
+  dsfr-view-components (~> 0.4)
+  factory_bot_rails (~> 6.2)
+  foreman (~> 0.87)
+  front_matter_parser (~> 1.0)
+  haml-rails (~> 2.1)
+  html2haml (~> 2.3)
+  htmlbeautifier (~> 1.4)
+  icalendar (~> 2.10)
+  image_processing (~> 1.12)
+  kramdown (~> 2.4)
+  launchy (~> 2.5)
+  listen (~> 3.8)
+  lookbook (~> 2.0)
+  matrix (~> 0.4)
   mjml-rails (~> 4.9)
   pagy (~> 6.0)
   pg (~> 1.5)
   prawn (~> 2.4)
-  prawn-table (~> 0.2.2)
-  progressbar
-  pry
+  prawn-table (~> 0.2)
+  progressbar (~> 1.0)
+  pry (~> 0.14)
   puma (~> 6.4)
-  pundit
+  pundit (~> 2.3)
   rails (~> 7.1)
-  rails-erd
+  rails-erd (~> 1.7)
   ransack (~> 4.1)
-  redis
+  redis (~> 5.0)
   rspec-rails (~> 6.0)
-  rubocop
-  rubocop-rails
-  rubyzip
+  rubocop (~> 1.51)
+  rubocop-rails (~> 2.19)
+  rubyzip (~> 2.3)
   selenium-webdriver (~> 4.16)
-  sentry-rails
+  sentry-rails (~> 5.15)
   sentry-ruby (~> 5.15)
-  sentry-sidekiq
-  sidekiq
-  solargraph
-  turbo-rails
-  typhoeus
-  tzinfo-data
-  view_component
-  vite_rails
-  web-console
+  sentry-sidekiq (~> 5.15)
+  sidekiq (~> 7.2)
+  solargraph (~> 0.49)
+  turbo-rails (~> 1.4)
+  typhoeus (~> 1.4)
+  tzinfo-data (~> 1.0)
+  view_component (~> 2.82)
+  vite_rails (~> 3.0)
+  web-console (~> 4.2)
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
les bonnes pratiques semblent indiquer d’utiliser le pessimistic operator cf https://stackoverflow.com/questions/9265213/should-i-specify-exact-versions-in-my-gemfile

cf https://thoughtbot.com/blog/rubys-pessimistic-operator

> ~> 1.1 means that when you bundle install, you’ll get the highest-released gem version of thin between the range >= 1.1 and < 2.0.

**dans cette PR j’ai mis des contraintes pessimistes qui font que `bundle update` mettra à jour toutes les versions mineures et patch mais jamais majeures.**

je pense que pour la maintenance future c’est aussi plus sécurisant que `bundle update` ne déclenche pas de mises à jour majeures