### PR TITLE
Correctif d'un bug n'affichait plus certains objets sur la page d'une commune

### DIFF
--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -10,7 +10,7 @@ class Objet < ApplicationRecord
 
   scope :order_by_recensement_priorite,
         lambda {
-          joins(:recensements)
+          left_outer_joins(:recensements)
           .order(Arel.sql(Recensement::SQL_ORDER_PRIORITE))
           .order("recensements.analysed_at DESC")
         }

--- a/spec/factories/objets.rb
+++ b/spec/factories/objets.rb
@@ -21,9 +21,7 @@ FactoryBot.define do
     end
 
     trait :with_recensement do
-      after(:create) do |objet|
-        create(:recensement, objet:)
-      end
+      recensements { [association(:recensement)] }
     end
 
     trait :with_recensement_with_photos_mocked do
@@ -32,19 +30,18 @@ FactoryBot.define do
         recensement_photos_start_number { 1 }
       end
       recensements do
-        after(:create) do |objet|
-          create(:recensement, :with_photos_mocked,
-                 photos_start_number: recensement_photos_start_number,
-                 photos_count: recensement_photos_count,
-                 objet:)
-        end
+        [
+          association(
+            :recensement, :with_photos_mocked,
+            photos_start_number: recensement_photos_start_number,
+            photos_count: recensement_photos_count
+          )
+        ]
       end
     end
 
     trait :with_recensement_without_photo do
-      after(:create) do |objet|
-        create(:recensement, :without_photo, objet:)
-      end
+      recensements { [association(:recensement, :without_photo)] }
     end
 
     trait :with_palissy_photo do
@@ -63,15 +60,11 @@ FactoryBot.define do
     end
 
     trait :en_peril do
-      after(:create) do |objet|
-        create(:recensement, :en_peril, objet:)
-      end
+      recensements { [association(:recensement, :en_peril)] }
     end
 
     trait :disparu do
-      after(:create) do |objet|
-        create(:recensement, :disparu, objet:)
-      end
+      recensements { [association(:recensement, :disparu)] }
     end
   end
 end

--- a/spec/factories/objets.rb
+++ b/spec/factories/objets.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
       end
     end
 
-    trait :en_peril do
+    factory :objet_en_peril do
       recensements { [association(:recensement, :en_peril)] }
     end
 

--- a/spec/factories/objets.rb
+++ b/spec/factories/objets.rb
@@ -21,7 +21,9 @@ FactoryBot.define do
     end
 
     trait :with_recensement do
-      recensements { [association(:recensement)] }
+      after(:create) do |objet|
+        create(:recensement, objet:)
+      end
     end
 
     trait :with_recensement_with_photos_mocked do
@@ -30,18 +32,19 @@ FactoryBot.define do
         recensement_photos_start_number { 1 }
       end
       recensements do
-        [
-          association(
-            :recensement, :with_photos_mocked,
-            photos_start_number: recensement_photos_start_number,
-            photos_count: recensement_photos_count
-          )
-        ]
+        after(:create) do |objet|
+          create(:recensement, :with_photos_mocked,
+                 photos_start_number: recensement_photos_start_number,
+                 photos_count: recensement_photos_count,
+                 objet:)
+        end
       end
     end
 
     trait :with_recensement_without_photo do
-      recensements { [association(:recensement, :without_photo)] }
+      after(:create) do |objet|
+        create(:recensement, :without_photo, objet:)
+      end
     end
 
     trait :with_palissy_photo do
@@ -60,11 +63,15 @@ FactoryBot.define do
     end
 
     trait :en_peril do
-      recensements { [association(:recensement, :en_peril)] }
+      after(:create) do |objet|
+        create(:recensement, :en_peril, objet:)
+      end
     end
 
     trait :disparu do
-      recensements { [association(:recensement, :disparu)] }
+      after(:create) do |objet|
+        create(:recensement, :disparu, objet:)
+      end
     end
   end
 end

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Commune, type: :model do
     let!(:commune) { create(:commune) }
     before do
       create(:objet, :with_recensement, commune:)
-      create(:objet, :en_peril, commune:)
+      create(:objet_en_peril, commune:)
       create_list(:objet, 2, :disparu, commune:)
     end
 

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -92,8 +92,10 @@ RSpec.describe Objet, type: :model do
 
   it ".order_by_recensement_priorite" do
     _objet_non_recensé = create(:objet)
-    _objet_recensé_vert = create(:objet, :with_recensement)
-    objet_recensé_prioritaire = create(:objet, :en_peril)
+    objet_recensé_vert = create(:objet)
+    create(:recensement, objet: objet_recensé_vert)
+    objet_recensé_prioritaire = create(:objet)
+    create(:recensement, :en_peril, objet: objet_recensé_prioritaire)
 
     expect(Objet.order_by_recensement_priorite.count).to eq 3
     expect(Objet.order_by_recensement_priorite.first).to eq(objet_recensé_prioritaire)

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -89,4 +89,13 @@ RSpec.describe Objet, type: :model do
     expect(Objet.inscrits.count).to eq(objets_considérés_comme_inscrits.size)
     expect(Objet.protégés.count).to eq(objets_considérés_comme_classés.size + objets_considérés_comme_inscrits.size)
   end
+
+  it ".order_by_recensement_priorite" do
+    _objet_non_recensé = create(:objet)
+    _objet_recensé_vert = create(:objet, :with_recensement)
+    objet_recensé_prioritaire = create(:objet, :en_peril)
+
+    expect(Objet.order_by_recensement_priorite.count).to eq 3
+    expect(Objet.order_by_recensement_priorite.first).to eq(objet_recensé_prioritaire)
+  end
 end

--- a/spec/policies/communes/recensement_policy_spec.rb
+++ b/spec/policies/communes/recensement_policy_spec.rb
@@ -30,15 +30,6 @@ describe Communes::RecensementPolicy do
       let(:user) { build(:user, commune:) }
       it { should permit(user, recensement) }
     end
-
-    context "objet a deja un recensement + commune started" do
-      let(:commune) { build(:commune, status: :started) }
-      let(:objet) { build(:objet, :with_recensement, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
-      let(:user) { build(:user, commune:) }
-
-      it { should_not permit(user, recensement) }
-    end
   end
 
   permissions :edit?, :update?, :destroy? do


### PR DESCRIPTION
Pour les communes dont le recensement n'était pas terminé, les objets non recensés ne s'affichaient plus sur la page commune côté conservateur.

En bonus, les factories d'objets avec recensement ne fonctionnaient pas bien car elles créaient 2 objets Recensement.