### PR TITLE
ajout des actions dans la galerie photos de recensement côté conservateur (rotation, suppression, ajout)

### DIFF
--- a/app/components/galerie/action_groups/base.rb
+++ b/app/components/galerie/action_groups/base.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Galerie
-  module Actions
-    class Basic
+  module ActionGroups
+    class Base
       include Rails.application.routes.url_helpers
 
       delegate :current_photo, to: :@galerie

--- a/app/components/galerie/action_groups/base.rb
+++ b/app/components/galerie/action_groups/base.rb
@@ -12,18 +12,28 @@ module Galerie
       end
 
       def buttons(responsive_variant: :desktop)
-        [download_button(responsive_variant:)]
+        all(responsive_variant:).map(&:button_component)
       end
 
-      def confirmations = []
-      def upload_confirmation = nil
-      def upload_button = nil
+      def confirmations(responsive_variant: :desktop)
+        all(responsive_variant:).map(&:confirmation_component).compact
+      end
 
-      def download_button(responsive_variant: :desktop)
-        Galerie::Actions::Download::ButtonComponent.new(
+      def download(responsive_variant:)
+        Galerie::Actions::Download.new(
           url: current_photo.download_url,
           responsive_variant:
         )
+      end
+
+      def upload = nil
+      def rotate = nil
+      def destroy = nil
+
+      private
+
+      def all(responsive_variant: :desktop)
+        [download(responsive_variant:)]
       end
     end
   end

--- a/app/components/galerie/action_groups/conservateur_recensement.rb
+++ b/app/components/galerie/action_groups/conservateur_recensement.rb
@@ -3,68 +3,56 @@
 module Galerie
   module ActionGroups
     class ConservateurRecensement < Base
-      delegate :close_path, :next_photo, to: :@galerie
+      delegate :close_path, :previous_photo, :next_photo, to: :@galerie
 
       def initialize(galerie:, recensement:)
         super(galerie:)
         @recensement = recensement
       end
 
-      def buttons(responsive_variant: :desktop)
-        [
-          download_button(responsive_variant:),
-          rotate_button(responsive_variant:),
-          destroy_button(responsive_variant:),
-          upload_button(responsive_variant:)
-        ].compact
-      end
-
-      def confirmations
-        [destroy_confirmation, upload_confirmation].compact
-      end
-
-      def rotate_button(responsive_variant: :desktop)
+      def rotate(responsive_variant: :desktop)
         return nil if current_photo.nil?
 
-        Galerie::Actions::Rotate::ButtonComponent.new(
+        Galerie::Actions::Rotate.new(
           attachment_path: conservateurs_attachment_path(current_photo.id),
           redirect_path: current_photo.lightbox_path,
           responsive_variant:
         )
       end
 
-      def destroy_button(responsive_variant: :desktop)
+      def destroy(responsive_variant: :desktop)
         return nil if current_photo.nil?
 
-        Galerie::Actions::Destroy::ButtonComponent.new(responsive_variant:)
-      end
-
-      def destroy_confirmation
-        return nil if current_photo.nil?
-
-        Galerie::Actions::Destroy::ConfirmationComponent.new(
+        Galerie::Actions::Destroy.new(
           attachment_path: conservateurs_attachment_path(current_photo.id),
-          redirect_path: next_photo&.lightbox_path || previous_photo&.lightbox_path || close_path
+          redirect_path: next_photo&.lightbox_path || previous_photo&.lightbox_path || close_path,
+          responsive_variant:
         )
       end
 
-      def upload_button(responsive_variant: :desktop)
+      def upload(responsive_variant: :desktop)
         return nil unless @recensement.recensable?
 
-        Galerie::Actions::Upload::ButtonComponent.new(responsive_variant:)
-      end
-
-      def upload_confirmation
-        return nil unless @recensement.recensable?
-
-        Galerie::Actions::Upload::ConfirmationComponent.new(
+        Galerie::Actions::Upload.new(
           attachments_path: conservateurs_attachments_path,
           recensement_id: @recensement.id,
           message:
             "Vous pouvez ajouter des photos récentes liées à ce recensement. " \
             "Merci de ne pas ajouter de photos d’archives.",
-          redirect_path: close_path
+          redirect_path: close_path,
+          responsive_variant:
         )
+      end
+
+      private
+
+      def all(responsive_variant: :desktop)
+        [
+          download(responsive_variant:),
+          rotate(responsive_variant:),
+          destroy(responsive_variant:),
+          upload(responsive_variant:)
+        ].compact
       end
     end
   end

--- a/app/components/galerie/action_groups/conservateur_recensement.rb
+++ b/app/components/galerie/action_groups/conservateur_recensement.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 module Galerie
-  module Actions
-    class ConservateurRecensement
-      include Rails.application.routes.url_helpers
-
-      delegate :close_path, :current_photo, :next_photo, :previous_photo, to: :@galerie
+  module ActionGroups
+    class ConservateurRecensement < Base
+      delegate :close_path, :next_photo, to: :@galerie
 
       def initialize(galerie:, recensement:)
-        @galerie = galerie
+        super(galerie:)
         @recensement = recensement
       end
 
@@ -23,13 +21,6 @@ module Galerie
 
       def confirmations
         [destroy_confirmation, upload_confirmation].compact
-      end
-
-      def download_button(responsive_variant: :desktop)
-        Galerie::Actions::Download::ButtonComponent.new(
-          url: current_photo.download_url,
-          responsive_variant:
-        )
       end
 
       def rotate_button(responsive_variant: :desktop)

--- a/app/components/galerie/actions/base_concern.rb
+++ b/app/components/galerie/actions/base_concern.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module BaseConcern
+      extend ActiveSupport::Concern
+
+      included do
+        attr_reader :responsive_variant
+      end
+
+      def button_component
+        # all actions should have a button
+        raise NotImplementedError
+      end
+
+      def confirmation_component
+        # not all actions have a confirmation modal
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/basic.rb
+++ b/app/components/galerie/actions/basic.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class Basic
+      include Rails.application.routes.url_helpers
+
+      delegate :current_photo, to: :@galerie
+
+      def initialize(galerie:)
+        @galerie = galerie
+      end
+
+      def buttons(with_text: true)
+        [download_button(with_text:)]
+      end
+
+      def confirmations = []
+      def upload_confirmation = nil
+      def upload_button = nil
+
+      def download_button(with_text: true)
+        Galerie::Actions::Download::ButtonComponent.new(
+          url: current_photo.download_url,
+          with_text:
+        )
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/basic.rb
+++ b/app/components/galerie/actions/basic.rb
@@ -11,18 +11,18 @@ module Galerie
         @galerie = galerie
       end
 
-      def buttons(with_text: true)
-        [download_button(with_text:)]
+      def buttons(responsive_variant: :desktop)
+        [download_button(responsive_variant:)]
       end
 
       def confirmations = []
       def upload_confirmation = nil
       def upload_button = nil
 
-      def download_button(with_text: true)
+      def download_button(responsive_variant: :desktop)
         Galerie::Actions::Download::ButtonComponent.new(
           url: current_photo.download_url,
-          with_text:
+          responsive_variant:
         )
       end
     end

--- a/app/components/galerie/actions/button_concern.rb
+++ b/app/components/galerie/actions/button_concern.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module ButtonConcern
+      extend ActiveSupport::Concern
+
+      included do
+        attr_reader :with_text
+      end
+
+      def button_icon_class
+        classes = %w[action fr-btn]
+        classes +=
+          if with_text
+            %w[fr-btn--sm fr-btn--icon-right fr-btn--secondary]
+          else
+            %w[fr-btn--lg fr-btn--icon fr-btn--tertiary-no-outline]
+          end
+        classes.join(" ")
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/button_concern.rb
+++ b/app/components/galerie/actions/button_concern.rb
@@ -6,15 +6,15 @@ module Galerie
       extend ActiveSupport::Concern
 
       included do
-        attr_reader :with_text
+        attr_reader :responsive_variant
       end
 
       def button_icon_class
         classes = %w[action fr-btn]
         classes +=
-          if with_text
+          if responsive_variant == :desktop
             %w[fr-btn--sm fr-btn--icon-right fr-btn--secondary]
-          else
+          elsif responsive_variant == :mobile
             %w[fr-btn--lg fr-btn--icon fr-btn--tertiary-no-outline]
           end
         classes.join(" ")

--- a/app/components/galerie/actions/conservateur_recensement.rb
+++ b/app/components/galerie/actions/conservateur_recensement.rb
@@ -58,10 +58,14 @@ module Galerie
       end
 
       def upload_button(with_text: true)
+        return nil unless @recensement.recensable?
+
         Galerie::Actions::Upload::ButtonComponent.new(with_text:)
       end
 
       def upload_confirmation
+        return nil unless @recensement.recensable?
+
         Galerie::Actions::Upload::ConfirmationComponent.new(
           attachments_path: conservateurs_attachments_path,
           create_params: { recensement_id: @recensement.id },

--- a/app/components/galerie/actions/conservateur_recensement.rb
+++ b/app/components/galerie/actions/conservateur_recensement.rb
@@ -68,7 +68,7 @@ module Galerie
 
         Galerie::Actions::Upload::ConfirmationComponent.new(
           attachments_path: conservateurs_attachments_path,
-          create_params: { recensement_id: @recensement.id },
+          recensement_id: @recensement.id,
           message:
             "Vous pouvez ajouter des photos récentes liées à ce recensement. " \
             "Merci de ne pas ajouter de photos d’archives.",

--- a/app/components/galerie/actions/conservateur_recensement.rb
+++ b/app/components/galerie/actions/conservateur_recensement.rb
@@ -12,12 +12,12 @@ module Galerie
         @recensement = recensement
       end
 
-      def buttons(with_text: true)
+      def buttons(responsive_variant: :desktop)
         [
-          download_button(with_text:),
-          rotate_button(with_text:),
-          destroy_button(with_text:),
-          upload_button(with_text:)
+          download_button(responsive_variant:),
+          rotate_button(responsive_variant:),
+          destroy_button(responsive_variant:),
+          upload_button(responsive_variant:)
         ].compact
       end
 
@@ -25,27 +25,27 @@ module Galerie
         [destroy_confirmation, upload_confirmation].compact
       end
 
-      def download_button(with_text: true)
+      def download_button(responsive_variant: :desktop)
         Galerie::Actions::Download::ButtonComponent.new(
           url: current_photo.download_url,
-          with_text:
+          responsive_variant:
         )
       end
 
-      def rotate_button(with_text: true)
+      def rotate_button(responsive_variant: :desktop)
         return nil if current_photo.nil?
 
         Galerie::Actions::Rotate::ButtonComponent.new(
           attachment_path: conservateurs_attachment_path(current_photo.id),
           redirect_path: current_photo.lightbox_path,
-          with_text:
+          responsive_variant:
         )
       end
 
-      def destroy_button(with_text: true)
+      def destroy_button(responsive_variant: :desktop)
         return nil if current_photo.nil?
 
-        Galerie::Actions::Destroy::ButtonComponent.new(with_text:)
+        Galerie::Actions::Destroy::ButtonComponent.new(responsive_variant:)
       end
 
       def destroy_confirmation
@@ -57,10 +57,10 @@ module Galerie
         )
       end
 
-      def upload_button(with_text: true)
+      def upload_button(responsive_variant: :desktop)
         return nil unless @recensement.recensable?
 
-        Galerie::Actions::Upload::ButtonComponent.new(with_text:)
+        Galerie::Actions::Upload::ButtonComponent.new(responsive_variant:)
       end
 
       def upload_confirmation

--- a/app/components/galerie/actions/conservateur_recensement.rb
+++ b/app/components/galerie/actions/conservateur_recensement.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class ConservateurRecensement
+      include Rails.application.routes.url_helpers
+
+      delegate :close_path, :current_photo, :next_photo, :previous_photo, to: :@galerie
+
+      def initialize(galerie:, recensement:)
+        @galerie = galerie
+        @recensement = recensement
+      end
+
+      def buttons(with_text: true)
+        [
+          download_button(with_text:),
+          rotate_button(with_text:),
+          destroy_button(with_text:),
+          upload_button(with_text:)
+        ].compact
+      end
+
+      def confirmations
+        [destroy_confirmation, upload_confirmation].compact
+      end
+
+      def download_button(with_text: true)
+        Galerie::Actions::Download::ButtonComponent.new(
+          url: current_photo.download_url,
+          with_text:
+        )
+      end
+
+      def rotate_button(with_text: true)
+        return nil if current_photo.nil?
+
+        Galerie::Actions::Rotate::ButtonComponent.new(
+          attachment_path: conservateurs_attachment_path(current_photo.id),
+          redirect_path: current_photo.lightbox_path,
+          with_text:
+        )
+      end
+
+      def destroy_button(with_text: true)
+        return nil if current_photo.nil?
+
+        Galerie::Actions::Destroy::ButtonComponent.new(with_text:)
+      end
+
+      def destroy_confirmation
+        return nil if current_photo.nil?
+
+        Galerie::Actions::Destroy::ConfirmationComponent.new(
+          attachment_path: conservateurs_attachment_path(current_photo.id),
+          redirect_path: next_photo&.lightbox_path || previous_photo&.lightbox_path || close_path
+        )
+      end
+
+      def upload_button(with_text: true)
+        Galerie::Actions::Upload::ButtonComponent.new(with_text:)
+      end
+
+      def upload_confirmation
+        Galerie::Actions::Upload::ConfirmationComponent.new(
+          attachments_path: conservateurs_attachments_path,
+          create_params: { recensement_id: @recensement.id },
+          message:
+            "Vous pouvez ajouter des photos récentes liées à ce recensement. " \
+            "Merci de ne pas ajouter de photos d’archives.",
+          redirect_path: close_path
+        )
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/destroy.rb
+++ b/app/components/galerie/actions/destroy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class Destroy
+      include BaseConcern
+
+      attr_reader :url, :attachment_path, :redirect_path
+
+      def initialize(attachment_path:, redirect_path:, responsive_variant: :desktop)
+        @responsive_variant = responsive_variant
+        @attachment_path = attachment_path
+        @redirect_path = redirect_path
+      end
+
+      def button_component
+        ButtonComponent.new(responsive_variant:)
+      end
+
+      def confirmation_component
+        ConfirmationComponent.new(attachment_path:, redirect_path:)
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/destroy/button_component.html.haml
+++ b/app/components/galerie/actions/destroy/button_component.html.haml
@@ -1,4 +1,4 @@
-= button_tag(with_text ? "Supprimer" : "",
+= button_tag(responsive_variant == :desktop ? "Supprimer" : "",
   type: "button",
   class: "#{button_icon_class} fr-icon-delete-line action",
   data: { fr_opened: false },

--- a/app/components/galerie/actions/destroy/button_component.html.haml
+++ b/app/components/galerie/actions/destroy/button_component.html.haml
@@ -1,0 +1,5 @@
+= button_tag(with_text ? "Supprimer" : "",
+  type: "button",
+  class: "#{button_icon_class} fr-icon-delete-line action",
+  data: { fr_opened: false },
+  "aria-controls": "confirmation-suppression")

--- a/app/components/galerie/actions/destroy/button_component.rb
+++ b/app/components/galerie/actions/destroy/button_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Destroy
+      class ButtonComponent < ViewComponent::Base
+        include ButtonConcern
+
+        def initialize(with_text: true)
+          super
+          @with_text = with_text
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/destroy/button_component.rb
+++ b/app/components/galerie/actions/destroy/button_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Destroy
+    class Destroy
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 

--- a/app/components/galerie/actions/destroy/button_component.rb
+++ b/app/components/galerie/actions/destroy/button_component.rb
@@ -6,9 +6,9 @@ module Galerie
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 
-        def initialize(with_text: true)
+        def initialize(responsive_variant: :desktop)
           super
-          @with_text = with_text
+          @responsive_variant = responsive_variant
         end
       end
     end

--- a/app/components/galerie/actions/destroy/confirmation_component.html.haml
+++ b/app/components/galerie/actions/destroy/confirmation_component.html.haml
@@ -1,0 +1,16 @@
+= dsfr_modal(title: "Êtes-vous sûr de vouloir supprimer cette photo ?", html_attributes: { id: "confirmation-suppression" }) do |component|
+  - component.with_button do
+    = button_to("Supprimer",
+        attachment_path,
+        method: :delete,
+        params: { redirect_path: redirect_path },
+        type: "button",
+        class: "fr-btn fr-btn--sm fr-btn",
+        "aria-controls": "confirmation-suppression")
+  - component.with_button do
+    = button_tag("Annuler",
+      type: "button",
+      class: "fr-btn fr-btn--sm fr-btn--secondary",
+      "aria-controls": "confirmation-suppression")
+  %p
+    Attention: cette action est définitive, vous ne pourrez pas la récupérer.

--- a/app/components/galerie/actions/destroy/confirmation_component.html.haml
+++ b/app/components/galerie/actions/destroy/confirmation_component.html.haml
@@ -1,12 +1,14 @@
+-# un-nest the destroy form so that the buttons group looks good
+= form_tag attachment_path, method: :delete, id: "destroy-attachment" do
+  = hidden_field_tag :redirect_path, redirect_path
+
 = dsfr_modal(title: "Êtes-vous sûr de vouloir supprimer cette photo ?", html_attributes: { id: "confirmation-suppression" }) do |component|
   - component.with_button do
-    = button_to("Supprimer",
-        attachment_path,
-        method: :delete,
-        params: { redirect_path: redirect_path },
-        type: "button",
-        class: "fr-btn fr-btn--sm fr-btn",
-        "aria-controls": "confirmation-suppression")
+    = button_tag("Supprimer",
+      type:"submit",
+      form: "destroy-attachment",
+      class: "fr-btn fr-btn--sm",
+      "aria-controls": "confirmation-suppression")
   - component.with_button do
     = button_tag("Annuler",
       type: "button",

--- a/app/components/galerie/actions/destroy/confirmation_component.rb
+++ b/app/components/galerie/actions/destroy/confirmation_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Destroy
+    class Destroy
       class ConfirmationComponent < ViewComponent::Base
         attr_reader :attachment_path, :redirect_path
 

--- a/app/components/galerie/actions/destroy/confirmation_component.rb
+++ b/app/components/galerie/actions/destroy/confirmation_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Destroy
+      class ConfirmationComponent < ViewComponent::Base
+        attr_reader :attachment_path, :redirect_path
+
+        def initialize(attachment_path:, redirect_path:)
+          super
+          @attachment_path = attachment_path
+          @redirect_path = redirect_path
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/download.rb
+++ b/app/components/galerie/actions/download.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class Download
+      include BaseConcern
+      attr_reader :url
+
+      def initialize(url:, responsive_variant: :desktop)
+        @responsive_variant = responsive_variant
+        @url = url
+      end
+
+      def button_component
+        ButtonComponent.new(responsive_variant:, url:)
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/download/button_component.html.haml
+++ b/app/components/galerie/actions/download/button_component.html.haml
@@ -1,3 +1,3 @@
-= link_to(with_text ? "Télécharger" : "",
+= link_to(responsive_variant == :desktop ? "Télécharger" : "",
   url,
   class: "#{button_icon_class} fr-icon-download-line action")

--- a/app/components/galerie/actions/download/button_component.html.haml
+++ b/app/components/galerie/actions/download/button_component.html.haml
@@ -1,0 +1,3 @@
+= link_to(with_text ? "Télécharger" : "",
+  url,
+  class: "#{button_icon_class} fr-icon-download-line action")

--- a/app/components/galerie/actions/download/button_component.rb
+++ b/app/components/galerie/actions/download/button_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Download
+      class ButtonComponent < ViewComponent::Base
+        include ButtonConcern
+
+        attr_reader :url
+
+        def initialize(url:, with_text: true)
+          super
+          @with_text = with_text
+          @url = url
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/download/button_component.rb
+++ b/app/components/galerie/actions/download/button_component.rb
@@ -8,9 +8,9 @@ module Galerie
 
         attr_reader :url
 
-        def initialize(url:, with_text: true)
+        def initialize(url:, responsive_variant: :desktop)
           super
-          @with_text = with_text
+          @responsive_variant = responsive_variant
           @url = url
         end
       end

--- a/app/components/galerie/actions/download/button_component.rb
+++ b/app/components/galerie/actions/download/button_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Download
+    class Download
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 

--- a/app/components/galerie/actions/rotate.rb
+++ b/app/components/galerie/actions/rotate.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class Rotate
+      include BaseConcern
+      attr_reader :attachment_path, :redirect_path
+
+      def initialize(attachment_path:, redirect_path:, responsive_variant: :desktop)
+        @responsive_variant = responsive_variant
+        @attachment_path = attachment_path
+        @redirect_path = redirect_path
+      end
+
+      def button_component
+        ButtonComponent.new(attachment_path:, redirect_path:, responsive_variant:)
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/rotate/button_component.html.haml
+++ b/app/components/galerie/actions/rotate/button_component.html.haml
@@ -1,0 +1,5 @@
+= button_to(with_text ? "Pivoter" : "",
+  attachment_path,
+  method: :patch,
+  params: { operation: "rotate", degrees: "90", redirect_path: },
+  class: "#{button_icon_class} fr-icon-arrow-go-forward-line")

--- a/app/components/galerie/actions/rotate/button_component.html.haml
+++ b/app/components/galerie/actions/rotate/button_component.html.haml
@@ -1,4 +1,4 @@
-= button_to(with_text ? "Pivoter" : "",
+= button_to(responsive_variant == :desktop ? "Pivoter" : "",
   attachment_path,
   method: :patch,
   params: { operation: "rotate", degrees: "90", redirect_path: },

--- a/app/components/galerie/actions/rotate/button_component.rb
+++ b/app/components/galerie/actions/rotate/button_component.rb
@@ -8,9 +8,9 @@ module Galerie
 
         attr_reader :attachment_path, :redirect_path
 
-        def initialize(attachment_path:, redirect_path:, with_text: true)
+        def initialize(attachment_path:, redirect_path:, responsive_variant: :desktop)
           super
-          @with_text = with_text
+          @responsive_variant = responsive_variant
           @attachment_path = attachment_path
           @redirect_path = redirect_path
         end

--- a/app/components/galerie/actions/rotate/button_component.rb
+++ b/app/components/galerie/actions/rotate/button_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Rotate
+    class Rotate
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 

--- a/app/components/galerie/actions/rotate/button_component.rb
+++ b/app/components/galerie/actions/rotate/button_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Rotate
+      class ButtonComponent < ViewComponent::Base
+        include ButtonConcern
+
+        attr_reader :attachment_path, :redirect_path
+
+        def initialize(attachment_path:, redirect_path:, with_text: true)
+          super
+          @with_text = with_text
+          @attachment_path = attachment_path
+          @redirect_path = redirect_path
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/upload.rb
+++ b/app/components/galerie/actions/upload.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    class Upload
+      include BaseConcern
+
+      attr_reader :attachments_path, :recensement_id, :redirect_path, :message
+
+      def initialize(attachments_path:, recensement_id:, redirect_path:, message:, responsive_variant: :desktop)
+        @responsive_variant = responsive_variant
+        @attachments_path = attachments_path
+        @recensement_id = recensement_id
+        @redirect_path = redirect_path
+        @message = message
+      end
+
+      def button_component
+        ButtonComponent.new(responsive_variant:)
+      end
+
+      def confirmation_component
+        ConfirmationComponent.new(attachments_path:, recensement_id:, redirect_path:, message:)
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/upload/button_component.html.haml
+++ b/app/components/galerie/actions/upload/button_component.html.haml
@@ -1,0 +1,5 @@
+= button_tag(with_text ? "Ajouter" : "",
+  type: "button",
+  class: "#{button_icon_class} fr-icon-add-circle-line action",
+  data: { fr_opened: false },
+  "aria-controls": "galerie--actions--upload--modal-confirmation-ajout")

--- a/app/components/galerie/actions/upload/button_component.html.haml
+++ b/app/components/galerie/actions/upload/button_component.html.haml
@@ -1,4 +1,4 @@
-= button_tag(with_text ? "Ajouter" : "",
+= button_tag(responsive_variant == :desktop ? "Ajouter" : "",
   type: "button",
   class: "#{button_icon_class} fr-icon-add-circle-line action",
   data: { fr_opened: false },

--- a/app/components/galerie/actions/upload/button_component.rb
+++ b/app/components/galerie/actions/upload/button_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Upload
+    class Upload
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 

--- a/app/components/galerie/actions/upload/button_component.rb
+++ b/app/components/galerie/actions/upload/button_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Upload
+      class ButtonComponent < ViewComponent::Base
+        include ButtonConcern
+
+        def initialize(with_text: true)
+          super
+          @with_text = with_text
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/upload/button_component.rb
+++ b/app/components/galerie/actions/upload/button_component.rb
@@ -6,9 +6,9 @@ module Galerie
       class ButtonComponent < ViewComponent::Base
         include ButtonConcern
 
-        def initialize(with_text: true)
+        def initialize(responsive_variant: :desktop)
           super
-          @with_text = with_text
+          @responsive_variant = responsive_variant
         end
       end
     end

--- a/app/components/galerie/actions/upload/confirmation_component.rb
+++ b/app/components/galerie/actions/upload/confirmation_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Galerie
+  module Actions
+    module Upload
+      class ConfirmationComponent < ViewComponent::Base
+        attr_reader :attachments_path, :create_params, :redirect_path, :message
+
+        def initialize(attachments_path:, create_params:, redirect_path:, message:)
+          super
+          @attachments_path = attachments_path
+          @create_params = create_params
+          @redirect_path = redirect_path
+          @message = message
+        end
+      end
+    end
+  end
+end

--- a/app/components/galerie/actions/upload/confirmation_component.rb
+++ b/app/components/galerie/actions/upload/confirmation_component.rb
@@ -2,7 +2,7 @@
 
 module Galerie
   module Actions
-    module Upload
+    class Upload
       class ConfirmationComponent < ViewComponent::Base
         attr_reader :attachments_path, :recensement_id, :redirect_path, :message
 

--- a/app/components/galerie/actions/upload/confirmation_component.rb
+++ b/app/components/galerie/actions/upload/confirmation_component.rb
@@ -4,12 +4,12 @@ module Galerie
   module Actions
     module Upload
       class ConfirmationComponent < ViewComponent::Base
-        attr_reader :attachments_path, :create_params, :redirect_path, :message
+        attr_reader :attachments_path, :recensement_id, :redirect_path, :message
 
-        def initialize(attachments_path:, create_params:, redirect_path:, message:)
+        def initialize(attachments_path:, recensement_id:, redirect_path:, message:)
           super
           @attachments_path = attachments_path
-          @create_params = create_params
+          @recensement_id = recensement_id
           @redirect_path = redirect_path
           @message = message
         end

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
@@ -10,7 +10,7 @@
       autocomplete: "off",
       direct_upload: true,
       data: { galerie__actions__upload__confirmation_component_target: "uploadFileInput",
-        action: "change->galerie--actions--upload--confirmation-component#triggerUpload" })
+        action: "change->galerie--actions--upload--confirmation-component#triggerSubmit" })
 
   = dsfr_modal(title: "Ajouter une photo du recensement", html_attributes: { id: "galerie--actions--upload--modal-confirmation-ajout" }) do |component|
     - component.with_button do

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
@@ -3,8 +3,7 @@
   -# invisible upload form and field triggered via JS
   = form_with(url: attachments_path,
     data: { galerie__actions__upload__confirmation_component_target: "uploadForm" }) do |f|
-    - create_params.each do |key, value|
-      = f.hidden_field key, value: value
+    = f.hidden_field :recensement_id, value: recensement_id
     = f.hidden_field :redirect_path, value: redirect_path
     = f.file_field(:new_blob_id,
       class: "fr-file-input hide",

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
@@ -1,0 +1,29 @@
+%div{ data: { controller: "galerie--actions--upload--confirmation-component" } }
+
+  -# invisible upload form and field triggered via JS
+  = form_with(url: attachments_path,
+    data: { galerie__actions__upload__confirmation_component_target: "uploadForm" }) do |f|
+    - create_params.each do |key, value|
+      = f.hidden_field key, value: value
+    = f.hidden_field :redirect_path, value: redirect_path
+    = f.file_field(:new_blob_id,
+      class: "fr-file-input hide",
+      autocomplete: "off",
+      direct_upload: true,
+      data: { galerie__actions__upload__confirmation_component_target: "uploadFileInput",
+        action: "change->galerie--actions--upload--confirmation-component#triggerUpload" })
+
+  = dsfr_modal(title: "Ajouter une photo du recensement", html_attributes: { id: "galerie--actions--upload--modal-confirmation-ajout" }) do |component|
+    - component.with_button do
+      = button_tag("Ajouter une photo",
+              type: "button",
+              class: "fr-btn fr-btn--sm fr-btn",
+              data: { action: "click->galerie--actions--upload--confirmation-component#triggerSelectFile",
+                galerie__actions__upload__confirmation_component_target: "uploadButton" },
+              "aria-controls": "galerie--actions--upload--modal-confirmation-ajout")
+    - component.with_button do
+      = button_tag("Annuler",
+        type: "button",
+        class: "fr-btn fr-btn--sm fr-btn--secondary",
+        "aria-controls": "galerie--actions--upload--modal-confirmation-ajout")
+    %p= message

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component.html.haml
@@ -16,11 +16,11 @@
   = dsfr_modal(title: "Ajouter une photo du recensement", html_attributes: { id: "galerie--actions--upload--modal-confirmation-ajout" }) do |component|
     - component.with_button do
       = button_tag("Ajouter une photo",
-              type: "button",
-              class: "fr-btn fr-btn--sm fr-btn",
-              data: { action: "click->galerie--actions--upload--confirmation-component#triggerSelectFile",
-                galerie__actions__upload__confirmation_component_target: "uploadButton" },
-              "aria-controls": "galerie--actions--upload--modal-confirmation-ajout")
+        type: "button",
+        class: "fr-btn fr-btn--sm fr-btn",
+        data: { action: "click->galerie--actions--upload--confirmation-component#triggerSelectFile",
+          galerie__actions__upload__confirmation_component_target: "uploadButton" },
+        "aria-controls": "galerie--actions--upload--modal-confirmation-ajout")
     - component.with_button do
       = button_tag("Annuler",
         type: "button",

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component_controller.js
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     this.uploadFileInputTarget.click()
   }
 
-  triggerUpload(_event) {
+  triggerSubmit(_event) {
     this.uploadButtonTarget.disabled = true
     this.uploadFormTarget.requestSubmit()
   }

--- a/app/components/galerie/actions/upload/confirmation_component/confirmation_component_controller.js
+++ b/app/components/galerie/actions/upload/confirmation_component/confirmation_component_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["uploadForm", "uploadFileInput", "uploadButton"]
+
+  triggerSelectFile(event) {
+    event.preventDefault()
+    this.uploadFileInputTarget.click()
+  }
+
+  triggerUpload(_event) {
+    this.uploadButtonTarget.disabled = true
+    this.uploadFormTarget.requestSubmit()
+  }
+}

--- a/app/components/galerie/frame_component.rb
+++ b/app/components/galerie/frame_component.rb
@@ -9,19 +9,19 @@ module Galerie
       :title,
       :turbo_frame,
       :current_photo_id,
-      :path_without_query,
-      :display_actions
+      :path_without_query
     )
 
     delegate :count, to: :photos
+
+    attr_accessor :actions
 
     def initialize(
       photos:,
       title:,
       turbo_frame:,
       current_photo_id:,
-      path_without_query:,
-      display_actions: false
+      path_without_query:
     )
       super
       @photos = photos
@@ -29,7 +29,6 @@ module Galerie
       @turbo_frame = turbo_frame
       @current_photo_id = current_photo_id
       @path_without_query = path_without_query
-      @display_actions = display_actions
       @photos.each { augment_photo_presenter(_1) }
     end
 

--- a/app/components/galerie/frame_component.rb
+++ b/app/components/galerie/frame_component.rb
@@ -46,7 +46,11 @@ module Galerie
       photos.find_index { _1.id == current_photo_id.to_i }
     end
 
-    def current_photo = current_index.present? && photos[current_index]
+    def current_photo
+      return nil if current_index.blank?
+
+      photos[current_index]
+    end
 
     def previous_photo
       return nil if current_photo.nil? || current_index.zero?

--- a/app/components/galerie/frame_component.rb
+++ b/app/components/galerie/frame_component.rb
@@ -61,7 +61,7 @@ module Galerie
     end
 
     def call
-      turbo_frame_tag turbo_frame do
+      turbo_frame_tag(turbo_frame, class: "co-galerie-turbo-frame") do
         if current_photo_id
           render Galerie::LightboxComponent.new(self)
         else

--- a/app/components/galerie/lightbox_component.rb
+++ b/app/components/galerie/lightbox_component.rb
@@ -7,11 +7,11 @@ module Galerie
     delegate(
       :photos,
       :current_photo_id,
-      :display_actions,
       :close_path,
       :turbo_frame,
       :count,
       :path_without_query,
+      :actions,
       :current_photo,
       :previous_photo,
       :next_photo,

--- a/app/components/galerie/lightbox_component/lightbox_component.css
+++ b/app/components/galerie/lightbox_component/lightbox_component.css
@@ -73,6 +73,20 @@
   margin: 0 auto;
 }
 
+.spinner {
+  display: none;
+}
+.co-galerie-turbo-frame[busy] .spinner {
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1000;
+  padding: 1rem;
+  border-radius: 50%;
+  opacity: 0.6;
+}
+
 @media only screen and (min-width: 768px) {
   .co-galerie .footer {
     display: none;

--- a/app/components/galerie/lightbox_component/lightbox_component.css
+++ b/app/components/galerie/lightbox_component/lightbox_component.css
@@ -7,7 +7,7 @@
   width: 100vw;
   display: flex;
   flex-direction: column;
-  z-index: 600;
+  z-index: 800;
 }
 
 .co-galerie > .header,

--- a/app/components/galerie/lightbox_component/lightbox_component.css
+++ b/app/components/galerie/lightbox_component/lightbox_component.css
@@ -10,10 +10,12 @@
   z-index: 600;
 }
 
-.co-galerie > .header {
+.co-galerie > .header,
+.co-galerie > .footer {
   padding: 1rem 1rem;
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 
 .co-galerie > .header .left {
@@ -65,4 +67,23 @@
   color: #ccc;
   padding: 1rem .5rem;
   text-align: center;
+}
+
+@media only screen and (min-width: 768px) {
+  .co-galerie .footer {
+    display: none;
+  }
+  .co-galerie .close-button {
+    /* copied from .fr-btn--sm because there are no responsive classes like .fr-btn--sm@md */
+    font-size: .875rem;
+    line-height: 1.5rem;
+    min-height: 2rem;
+    padding: .25rem .75rem;
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .co-galerie .header .action {
+    display: none;
+  }
 }

--- a/app/components/galerie/lightbox_component/lightbox_component.css
+++ b/app/components/galerie/lightbox_component/lightbox_component.css
@@ -69,6 +69,10 @@
   text-align: center;
 }
 
+.co-galerie > .footer .action:only-child {
+  margin: 0 auto;
+}
+
 @media only screen and (min-width: 768px) {
   .co-galerie .footer {
     display: none;

--- a/app/components/galerie/lightbox_component/lightbox_component.html.haml
+++ b/app/components/galerie/lightbox_component/lightbox_component.html.haml
@@ -2,8 +2,10 @@
   close_path:,
   next_photo_path: next_photo&.lightbox_path,
   previous_photo_path: previous_photo&.lightbox_path,
-  turbo_frame: turbo_frame,
   action: "keydown.esc@document->galerie--lightbox-component#close keydown.left@document->galerie--lightbox-component#previous keydown.right@document->galerie--lightbox-component#next" } }
+
+  .spinner.fr-background-default--grey
+    %span.fr-icon-refresh-line.co-rotating{"aria-hidden": "true"}
 
   - actions&.confirmations&.each do |component|
     = render component

--- a/app/components/galerie/lightbox_component/lightbox_component.html.haml
+++ b/app/components/galerie/lightbox_component/lightbox_component.html.haml
@@ -4,18 +4,20 @@
   previous_photo_path: previous_photo&.lightbox_path,
   turbo_frame: turbo_frame,
   action: "keydown.esc@document->galerie--lightbox-component#close keydown.left@document->galerie--lightbox-component#previous keydown.right@document->galerie--lightbox-component#next" } }
+
+  - actions&.confirmations&.each do |component|
+    = render component
+
   .header.fr-background-default--grey
     .left
       Photo #{current_index + 1} / #{count}
     .right
-      = link_to("Télécharger",
-        current_photo.download_url,
-        class: "fr-btn fr-btn--sm fr-btn--secondary action fr-btn--icon-left fr-icon-download-line")
-      - if display_actions
-        -# TODO
-      = link_to("Fermer",
+      - actions&.buttons&.each do |component|
+        = render component
+      = button_to("Fermer",
         close_path,
-        class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-right fr-icon-close-line")
+        method: :get,
+        class: "fr-btn fr-btn--tertiary fr-btn--icon-right fr-icon-close-line close-button")
 
   .content
     .arrow-link
@@ -41,3 +43,7 @@
       - if current_photo.description
         = "·"
         = current_photo.description
+
+  .footer.fr-background-default--grey
+    - actions&.buttons(with_text: false)&.each do |component|
+      = render component

--- a/app/components/galerie/lightbox_component/lightbox_component.html.haml
+++ b/app/components/galerie/lightbox_component/lightbox_component.html.haml
@@ -47,5 +47,5 @@
         = current_photo.description
 
   .footer.fr-background-default--grey
-    - actions&.buttons(with_text: false)&.each do |component|
+    - actions&.buttons(responsive_variant: :mobile)&.each do |component|
       = render component

--- a/app/components/galerie/lightbox_component/lightbox_component_controller.js
+++ b/app/components/galerie/lightbox_component/lightbox_component_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
   close(_event) {
     // this should prevent closing the lightbox when a dialog is open but it doesn't work
     // because the dialog is closed first
-    if (document.querySelector("dialog[open]")) return;
+    // if (document.querySelector("dialog[open]")) return;
 
     Turbo.visit(this.element.dataset.closePath, { frame: this.element.dataset.turboFrame })
   }

--- a/app/components/galerie/lightbox_component/lightbox_component_controller.js
+++ b/app/components/galerie/lightbox_component/lightbox_component_controller.js
@@ -14,6 +14,10 @@ export default class extends Controller {
   }
 
   close(_event) {
+    // this should prevent closing the lightbox when a dialog is open but it doesn't work
+    // because the dialog is closed first
+    if (document.querySelector("dialog[open]")) return;
+
     Turbo.visit(this.element.dataset.closePath, { frame: this.element.dataset.turboFrame })
   }
 

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -31,10 +31,10 @@
   - elsif count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
-        - if actions&.rotate
-          = t("galerie.miniatures.open", count:)
-        - else
+        - if actions&.is_a?(Galerie::ActionGroups::ConservateurRecensement)
           = t("galerie.miniatures.open_with_actions", count:)
+        - else
+          = t("galerie.miniatures.open", count:)
 
   - if credits.any?
     .co-text--muted.fr-mt-1w.fr-text--sm

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -31,7 +31,10 @@
   - elsif count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
-        = t("galerie.miniatures.open", count:)
+        - if actions&.is_a?(Galerie::Actions::Basic)
+          = t("galerie.miniatures.open", count:)
+        - else
+          = t("galerie.miniatures.open_with_actions", count:)
 
   - if credits.any?
     .co-text--muted.fr-mt-1w.fr-text--sm

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -31,7 +31,7 @@
   - elsif count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
-        - if actions&.is_a?(Galerie::Actions::Basic)
+        - if actions&.is_a?(Galerie::ActionGroups::Base)
           = t("galerie.miniatures.open", count:)
         - else
           = t("galerie.miniatures.open_with_actions", count:)

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -24,7 +24,11 @@
           %span.co-flex--grow
             = t("galerie.miniatures.last_thumb", count: hidden_photos_count)
 
-  - if count >= 1
+  - if count == 0 && actions&.upload_confirmation && actions&.upload_button
+    = render actions.upload_confirmation
+    = render actions.upload_button
+
+  - elsif count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
         = t("galerie.miniatures.open", count:)

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -24,14 +24,14 @@
           %span.co-flex--grow
             = t("galerie.miniatures.last_thumb", count: hidden_photos_count)
 
-  - if count == 0 && actions&.upload_confirmation && actions&.upload_button
-    = render actions.upload_confirmation
-    = render actions.upload_button
+  - if count == 0 && actions&.upload
+    = render actions.upload.confirmation_component
+    = render actions.upload.button_component
 
   - elsif count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
-        - if actions&.is_a?(Galerie::ActionGroups::Base)
+        - if actions&.rotate
           = t("galerie.miniatures.open", count:)
         - else
           = t("galerie.miniatures.open_with_actions", count:)

--- a/app/controllers/conservateurs/attachments_controller.rb
+++ b/app/controllers/conservateurs/attachments_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Conservateurs
+  class AttachmentsController < BaseController
+    before_action :set_attachment, :validate_redirect_path, only: %i[update destroy]
+    before_action :validate_redirect_path
+
+    def create
+      @recensement = Recensement.find(params[:recensement_id])
+      authorize(::ActiveStorage::Attachment.new(record: @recensement))
+      @recensement.photos.attach(params[:new_blob_id])
+      query = { "galerie_recensement_#{@recensement.id}_photo_id" => @recensement.photos.last.id }
+      redirect_to "#{params[:redirect_path]}?#{query.to_query}"
+    end
+
+    def update
+      raise ArgumentError, "invalid operation (should be 'rotate')" unless params[:operation] == "rotate"
+
+      raise ArgumentError, "invalid degrees param - only 90 an -90 accepted" \
+        unless %w[90 -90].include?(params[:degrees])
+
+      @attachment.rotate!(degrees: params[:degrees].to_i)
+      redirect_to(params[:redirect_path])
+    end
+
+    def destroy
+      @attachment.purge
+      redirect_to(params[:redirect_path])
+    end
+
+    private
+
+    def set_attachment
+      @attachment = ::ActiveStorage::Attachment.find(params[:id])
+      authorize(@attachment)
+    end
+
+    def validate_redirect_path
+      raise ArgumentError, "missing redirect_path" if params[:redirect_path].blank?
+    end
+  end
+end

--- a/app/helpers/galerie_helper.rb
+++ b/app/helpers/galerie_helper.rb
@@ -10,7 +10,7 @@ module GalerieHelper
       current_photo_id: params["#{turbo_frame}_photo_id"],
       path_without_query: request.path
     )
-    galerie.actions = Galerie::Actions::Basic.new(galerie:)
+    galerie.actions = Galerie::ActionGroups::Base.new(galerie:)
     galerie
   end
 
@@ -26,9 +26,9 @@ module GalerieHelper
     )
     galerie.actions =
       if actions_routes_scope == :conservateurs
-        Galerie::Actions::ConservateurRecensement.new(recensement:, galerie:)
+        Galerie::ActionGroups::ConservateurRecensement.new(recensement:, galerie:)
       else
-        Galerie::Actions::Basic.new(galerie:)
+        Galerie::ActionGroups::Base.new(galerie:)
       end
     galerie
   end

--- a/app/helpers/galerie_helper.rb
+++ b/app/helpers/galerie_helper.rb
@@ -3,13 +3,15 @@
 module GalerieHelper
   def galerie_objet(objet)
     turbo_frame = "galerie_objet_#{objet.id}"
-    Galerie::FrameComponent.new(
+    galerie = Galerie::FrameComponent.new(
       photos: objet.palissy_photos_presenters,
       title: t("objets.photos_count", count: objet.palissy_photos_presenters.count),
       turbo_frame:,
       current_photo_id: params["#{turbo_frame}_photo_id"],
       path_without_query: request.path
     )
+    galerie.actions = Galerie::Actions::Basic.new(galerie:)
+    galerie
   end
 
   def galerie_recensement(recensement, actions_routes_scope: nil)
@@ -22,9 +24,12 @@ module GalerieHelper
       path_without_query: request.path,
       turbo_frame:
     )
-    if actions_routes_scope == :conservateurs
-      galerie.actions = Galerie::Actions::ConservateurRecensement.new(recensement:, galerie:)
-    end
+    galerie.actions =
+      if actions_routes_scope == :conservateurs
+        Galerie::Actions::ConservateurRecensement.new(recensement:, galerie:)
+      else
+        Galerie::Actions::Basic.new(galerie:)
+      end
     galerie
   end
 end

--- a/app/helpers/galerie_helper.rb
+++ b/app/helpers/galerie_helper.rb
@@ -7,21 +7,24 @@ module GalerieHelper
       photos: objet.palissy_photos_presenters,
       title: t("objets.photos_count", count: objet.palissy_photos_presenters.count),
       turbo_frame:,
-      display_actions: false,
       current_photo_id: params["#{turbo_frame}_photo_id"],
       path_without_query: request.path
     )
   end
 
-  def galerie_recensement(recensement, display_actions: false)
+  def galerie_recensement(recensement, actions_routes_scope: nil)
     turbo_frame = "galerie_recensement_#{recensement.id}"
-    Galerie::FrameComponent.new(
+    current_photo_id = params["#{turbo_frame}_photo_id"]
+    galerie = Galerie::FrameComponent.new(
       photos: recensement.photos_presenters,
       title: t("recensement.photos.taken_count", count: recensement.photos_presenters.count),
-      turbo_frame:,
-      current_photo_id: params["#{turbo_frame}_photo_id"],
+      current_photo_id:,
       path_without_query: request.path,
-      display_actions:
+      turbo_frame:
     )
+    if actions_routes_scope == :conservateurs
+      galerie.actions = Galerie::Actions::ConservateurRecensement.new(recensement:, galerie:)
+    end
+    galerie
   end
 end

--- a/app/policies/conservateurs/active_storage/attachment_policy.rb
+++ b/app/policies/conservateurs/active_storage/attachment_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Conservateurs
+  module ActiveStorage
+    class AttachmentPolicy < BasePolicy
+      alias attachment record
+
+      def update?
+        attachment.record.is_a?(Recensement) &&
+          conservateur.departements.include?(recensement.departement) &&
+          recensement.commune.completed? &&
+          recensement.dossier.submitted? &&
+          !impersonating?
+      end
+
+      alias destroy? update?
+      alias create? update?
+
+      private
+
+      def recensement = attachment.record
+    end
+  end
+end

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -164,7 +164,7 @@
                     Photos manquantes
                 - else
                   .co-galerie-miniatures--minimal
-                    = render galerie_recensement(recensement, display_actions: false)
+                    = render galerie_recensement(recensement)
 
               %td
                 - if recensement.notes.present?

--- a/app/views/conservateurs/analyses/edit.html.haml
+++ b/app/views/conservateurs/analyses/edit.html.haml
@@ -55,7 +55,7 @@
             - else
               %p.co-text--italic Aucune commentaire laissé par la commune pour cet objet
         .fr-col-md-4.co-flex-md-reverse-order
-          = render galerie_recensement(@recensement, display_actions: false)
+          = render galerie_recensement(@recensement, actions_routes_scope: :conservateurs)
 
   .fr-grid-row
     .fr-col-md-12

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -416,8 +416,8 @@ fr:
         one: "1 autre photo …"
         other: "%{count} autres photos …"
       open:
-        one: Agrandir
-        other: Voir la galerie
+        one: Voir ou modifier cette photo
+        other: Voir ou modifier les %{count} photos
   pdf_embed_component:
     download: Télécharger le fichier PDF
   campaign_v1_mailer:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -416,6 +416,9 @@ fr:
         one: "1 autre photo …"
         other: "%{count} autres photos …"
       open:
+        one: Voir cette photo
+        other: Voir les %{count} photos
+      open_with_actions:
         one: Voir ou modifier cette photo
         other: Voir ou modifier les %{count} photos
   pdf_embed_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,6 +123,7 @@ Rails.application.routes.draw do
     resource :conservateur, only: [:update]
     resources :visits, only: [:index]
     resources :fiches, only: :index
+    resources :attachments, only: %i[create update destroy]
   end
 
   ## -----

--- a/spec/features/galerie_objet_spec.rb
+++ b/spec/features/galerie_objet_spec.rb
@@ -11,7 +11,7 @@ feature "Galerie objet photos palissy", type: :feature, js: true do
       expect(page).to have_text("3 photos connues")
       expect(page).to have_selector("img[src*='objet1.jpg']")
       expect(find("h1", text: /La Sainte-Famille/)).to be_visible
-      click_on "Voir la galerie"
+      click_on "Voir ou modifier les 3 photos"
       expect(page).to have_selector(".co-galerie")
       expect(page).to have_selector('button[disabled][title="photo précédente"]')
       click_on "photo suivante"

--- a/spec/features/galerie_objet_spec.rb
+++ b/spec/features/galerie_objet_spec.rb
@@ -11,7 +11,7 @@ feature "Galerie objet photos palissy", type: :feature, js: true do
       expect(page).to have_text("3 photos connues")
       expect(page).to have_selector("img[src*='objet1.jpg']")
       expect(find("h1", text: /La Sainte-Famille/)).to be_visible
-      click_on "Voir ou modifier les 3 photos"
+      click_on "Voir les 3 photos"
       expect(page).to have_selector(".co-galerie")
       expect(page).to have_selector('button[disabled][title="photo précédente"]')
       click_on "photo suivante"

--- a/spec/policies/conservateurs/active_storage/attachment_policy_spec.rb
+++ b/spec/policies/conservateurs/active_storage/attachment_policy_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Conservateurs::ActiveStorage::AttachmentPolicy do
+  subject { described_class }
+
+  permissions :update?, :destroy? do
+    context "photo d'une commune completed dossier submitted d'un departement du conservateur" do
+      let(:commune) { build(:commune, status: :completed) }
+      let(:objet) { build(:objet, commune:) }
+      let(:dossier) { build(:dossier, commune:, status: :submitted) }
+      let(:recensement) { build(:recensement, :with_photo, objet:, dossier:) }
+      let(:conservateur) { build(:conservateur, departements: build_list(:departement, 3) + [recensement.departement]) }
+      it { should permit(conservateur, recensement.photos[0]) }
+    end
+
+    context "photo d'une commune started dossier construction d'un departement du conservateur" do
+      let(:commune) { build(:commune, status: :started) }
+      let(:objet) { build(:objet, commune:) }
+      let(:dossier) { build(:dossier, commune:, status: :construction) }
+      let(:recensement) { build(:recensement, :with_photo, objet:, dossier:) }
+      let(:conservateur) { build(:conservateur, departements: build_list(:departement, 3) + [recensement.departement]) }
+      it { should_not permit(conservateur, recensement.photos[0]) }
+    end
+
+    context "photo d'une commune completed dossier submitted d'un autre departement que ceux du conservateur" do
+      let(:commune) { build(:commune, status: :completed) }
+      let(:objet) { build(:objet, commune:) }
+      let(:dossier) { build(:dossier, commune:, status: :submitted) }
+      let(:recensement) { build(:recensement, :with_photo, objet:, dossier:) }
+      let(:conservateur) { build(:conservateur, departements: build_list(:departement, 3)) }
+      it { should_not permit(conservateur, recensement.photos[0]) }
+    end
+  end
+end


### PR DESCRIPTION
## Miniatures

Desktop
![desktop](https://github.com/betagouv/collectif-objets/assets/883348/d19c33c7-90d6-4f99-a829-0f75cadb3a12)

Smartphone
![smartphone](https://github.com/betagouv/collectif-objets/assets/883348/d9f56760-41b9-47a9-af4a-09987c8364c4)

## Modales de confirmation

![modales](https://github.com/betagouv/collectif-objets/assets/883348/a90e9ca9-e0c4-4f24-af5a-e5afa5fe6567)


bonus 
- [ ] actions de zoom 

on pourrait utiliser la gem [dry-initializer](https://dry-rb.org/gems/dry-initializer/3.1/) pour réduire le code boilerplate d’initiation des view components et des objets en général. cf https://github.com/palkan/view_component-contrib#hanging-initialize-out-to-dry