### PR TITLE
page examen, extraction des liens vers les fiches hors des labels de checkboxes

### DIFF
--- a/app/views/conservateurs/analyses/_recensement_attributes.html.haml
+++ b/app/views/conservateurs/analyses/_recensement_attributes.html.haml
@@ -10,9 +10,9 @@
   - elsif recensement.absent?
     .fr-checkbox-group.fr-mt-2w
       = check_box_tag "recensement[analyse_fiches][]", "depot_plainte", recensement.analyse_fiches.include?("depot_plainte"), id: "recensement_analyse_fiches_depot_plainte"
-      = f.label :analyse_fiches_depot_plainte do
-        Informer la commune sur le&nbsp;
-        = link_to "dépôt de plainte", fiche_path("depot_plainte"), target: "_blank", rel: "noopener"
+      = f.label :analyse_fiches_depot_plainte, "Informer la commune sur le dépôt de plainte"
+    .fr-mt-2w
+      = link_to "Voir le contenu de cette fiche conseil", fiche_path("depot_plainte"), target: "_blank", rel: "noopener"
 
 - if recensement.recensable?
   .fr-my-4w.attribute-group

--- a/app/views/conservateurs/analyses/_recensement_attributes.html.haml
+++ b/app/views/conservateurs/analyses/_recensement_attributes.html.haml
@@ -21,20 +21,16 @@
     = render analyse_attribute_component(recensement:, form_builder: f, recensement_presenter:, attribute_name: "etat_sanitaire")
     .fr-checkbox-group.fr-mt-2w
       = check_box_tag "recensement[analyse_fiches][]", "entretien_objets", recensement.analyse_fiches.include?("entretien_objets"), id: "recensement_analyse_fiches_entretien_objets"
-      = f.label :analyse_fiches_entretien_objets do
-        Informer la commune sur les&nbsp;
-        = link_to "mesures d’entretien préventives", fiche_path("entretien_objets"), target: "_blank", rel: "noopener"
+      = f.label :analyse_fiches_entretien_objets, "Informer la commune sur les mesures d’entretien préventives"
+
     .fr-checkbox-group.fr-mt-2w
       = check_box_tag "recensement[analyse_fiches][]", "restauration", recensement.analyse_fiches.include?("restauration"), id: "recensement_analyse_fiches_restauration"
-      = f.label :analyse_fiches_restauration do
-        Informer la commune sur les&nbsp;
-        = link_to "étapes préalables à la restauration", fiche_path("restauration"), target: "_blank", rel: "noopener"
+      = f.label :analyse_fiches_restauration, "Informer la commune sur les étapes préalables à la restauration"
     .fr-checkbox-group.fr-mt-2w
       = check_box_tag "recensement[analyse_fiches][]", "entretien_edifices", recensement.analyse_fiches.include?("entretien_edifices"), id: "recensement_analyse_fiches_nuisibles"
-      = f.label :analyse_fiches_nuisibles do
-        Informer la commune sur les&nbsp;
-        = link_to "mesures d’entretien des édifices", fiche_path("entretien_edifices"), target: "_blank", rel: "noopener"
-        et de prévention d’attaques de nuisibles
+      = f.label :analyse_fiches_nuisibles, "Informer la commune sur les mesures d’entretien des édifices et de prévention d’attaques de nuisibles"
+    .fr-mt-2w
+      = link_to "Voir le contenu de ces fiches conseils", fiches_path, target: "_blank", rel: "noopener"
 
   .fr-my-4w.attribute-group
     .fr-pb-1w.co-text--bold
@@ -42,9 +38,9 @@
     = render analyse_attribute_component(recensement:, form_builder: f, recensement_presenter:, attribute_name: "securisation")
     .fr-checkbox-group.fr-mt-2w
       = check_box_tag "recensement[analyse_fiches][]", "securisation", recensement.analyse_fiches.include?("securisation"), id: "recensement_analyse_fiches_securisation"
-      = f.label :analyse_fiches_securisation do
-        Informer la commune sur les&nbsp;
-        = link_to "mesures de sécurisation des objets", fiche_path("securisation"), target: "_blank", rel: "noopener"
+      = f.label :analyse_fiches_securisation, "Informer la commune sur les mesures de sécurisation des objets"
+    .fr-mt-2w
+      = link_to "Voir le contenu de cette fiche conseil", fiche_path("securisation"), target: "_blank", rel: "noopener"
 
 - elsif !recensement.absent?
   -# only display the badge when it's found but not recensable

--- a/spec/features/conservateurs/accept_dossier_spec.rb
+++ b/spec/features/conservateurs/accept_dossier_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Conservateurs - Accept Dossier", type: :feature, js: true do
       click_on "Modifier"
       select "L’objet est en péril", from: "recensement[analyse_etat_sanitaire]"
     end
-    find("a", text: /entretien des édifices/).find(:xpath, "ancestor::label").click
+    find("label", text: /Informer la commune sur les mesures d’entretien des édifices/).click
     fill_in "recensement[analyse_notes]", with: "Est-ce qu'il est le pepito bleu?"
 
     click_on "Sauvegarder"


### PR DESCRIPTION
![fiches](https://github.com/betagouv/collectif-objets/assets/883348/21715a4b-5b0d-4bc6-b2e1-9000c2f14a93)

Changements validés avec Enora qui vont dans la direction de ces maquettes de refonte de la page examen

Les liens dans les labels des checkboxes sont un peu genants.

D’un, on clique souvent sur le label pour cocher les checkbox, quand il y a un lien c’est perturbant il faut cliquer a coté 

De deux, ça cause des soucis avec les E2E features specs capybara qui failent de temps en temps dès que je modifie un peu la page examen meme sur des choses non liées. J’ai observé et ce qu’il semble se passer c’est qu’il clique sur le lien au lieu de cliquer sur le label. ex de fail bizarre visible ici https://github.com/betagouv/collectif-objets/actions/runs/7263321701/job/19788341340

on utilisait cette méthode pour checker la checkbox

`find("a", text: /entretien des édifices/).find(:xpath, "ancestor::label").click` 

je la remplace ici par 

`find("label", text: /Informer la commune sur les mesures d’entretien des édifices/).click`

qui est un peu mieux, mais pas aussi bien que 

`check "Informer la commune sur les mesures d’entretien des édifices"` qui serait possible si le DSFR ne cachait pas les checkboxes en CSS 😬 , Capybara refuse de checker des choses invisibles, à juste titre il me semble