### PR TITLE
Refactors de la galerie avant ajout des actions

### DIFF
--- a/app/components/conservateurs/analyse_override_editable_component/analyse_override_editable_component.html.erb
+++ b/app/components/conservateurs/analyse_override_editable_component/analyse_override_editable_component.html.erb
@@ -21,7 +21,8 @@
     {},
     disabled: true,
     data: { "analyse-override-target": "select" },
-    class: "hide co--width-auto"
+    class: "hide co--width-auto",
+    form: "recensement"
   ) %>
 
   <a

--- a/app/components/galerie/frame_component.rb
+++ b/app/components/galerie/frame_component.rb
@@ -2,21 +2,34 @@
 
 module Galerie
   class FrameComponent < ViewComponent::Base
-    include ApplicationHelper
     include Turbo::FramesHelper
 
-    attr_reader :photos, :title, :turbo_frame, :current_photo_id, :path_without_query, :display_actions
+    attr_reader(
+      :photos,
+      :title,
+      :turbo_frame,
+      :current_photo_id,
+      :path_without_query,
+      :display_actions
+    )
 
     delegate :count, to: :photos
 
-    def initialize(photos:, title:, turbo_frame:, current_photo_id:, path_without_query:, display_actions: false)
+    def initialize(
+      photos:,
+      title:,
+      turbo_frame:,
+      current_photo_id:,
+      path_without_query:,
+      display_actions: false
+    )
       super
+      @photos = photos
       @title = title
       @turbo_frame = turbo_frame
       @current_photo_id = current_photo_id
       @path_without_query = path_without_query
       @display_actions = display_actions
-      @photos = photos
       @photos.each { augment_photo_presenter(_1) }
     end
 
@@ -27,6 +40,26 @@ module Galerie
 
     def close_path = path_without_query
     def current_photo_id_param_name = "#{turbo_frame}_photo_id"
+
+    def current_index
+      return nil if current_photo_id.nil?
+
+      photos.find_index { _1.id == current_photo_id.to_i }
+    end
+
+    def current_photo = current_index.present? && photos[current_index]
+
+    def previous_photo
+      return nil if current_photo.nil? || current_index.zero?
+
+      photos[current_index - 1]
+    end
+
+    def next_photo
+      return nil if current_photo.nil? || current_index + 1 >= count
+
+      photos[current_index + 1]
+    end
 
     def call
       turbo_frame_tag turbo_frame do

--- a/app/components/galerie/lightbox_component.rb
+++ b/app/components/galerie/lightbox_component.rb
@@ -4,30 +4,24 @@ module Galerie
   class LightboxComponent < ViewComponent::Base
     include ApplicationHelper
 
-    attr_reader :parent_galerie
-
     delegate(
-      :photos, :current_photo_id, :display_actions, :close_path, :turbo_frame, :count,
-      :path_without_query, to: :parent_galerie
+      :photos,
+      :current_photo_id,
+      :display_actions,
+      :close_path,
+      :turbo_frame,
+      :count,
+      :path_without_query,
+      :current_photo,
+      :previous_photo,
+      :next_photo,
+      :current_index,
+      to: :@galerie
     )
 
-    def initialize(parent_galerie)
+    def initialize(galerie)
       super
-      @parent_galerie = parent_galerie
-    end
-
-    def current_index
-      photos.find_index { _1.id == current_photo_id.to_i }
-    end
-
-    def current_photo = photos[current_index]
-
-    def previous_photo
-      photos[current_index - 1] if current_index.positive?
-    end
-
-    def next_photo
-      photos[current_index + 1] if current_index + 1 < count
+      @galerie = galerie
     end
   end
 end

--- a/app/components/galerie/lightbox_component/lightbox_component.css
+++ b/app/components/galerie/lightbox_component/lightbox_component.css
@@ -57,7 +57,7 @@
   background: white;
 }
 
-.co-galerie > .content .footer {
+.co-galerie > .content .credits {
   position: absolute;
   bottom: 0;
   width: 100%;

--- a/app/components/galerie/lightbox_component/lightbox_component.html.haml
+++ b/app/components/galerie/lightbox_component/lightbox_component.html.haml
@@ -1,12 +1,21 @@
-.co-galerie{data: { controller: "galerie--lightbox-component", close_path:, next_photo_path: next_photo&.lightbox_path, previous_photo_path: previous_photo&.lightbox_path, turbo_frame: turbo_frame, action: "keydown.esc@document->galerie--lightbox-component#close keydown.left@document->galerie--lightbox-component#previous keydown.right@document->galerie--lightbox-component#next" } }
+.co-galerie{data: { controller: "galerie--lightbox-component",
+  close_path:,
+  next_photo_path: next_photo&.lightbox_path,
+  previous_photo_path: previous_photo&.lightbox_path,
+  turbo_frame: turbo_frame,
+  action: "keydown.esc@document->galerie--lightbox-component#close keydown.left@document->galerie--lightbox-component#previous keydown.right@document->galerie--lightbox-component#next" } }
   .header.fr-background-default--grey
     .left
       Photo #{current_index + 1} / #{count}
     .right
-      = link_to "Télécharger", current_photo.download_url, class: "fr-btn fr-btn--sm fr-btn--secondary action fr-btn--icon-left fr-icon-download-line"
+      = link_to("Télécharger",
+        current_photo.download_url,
+        class: "fr-btn fr-btn--sm fr-btn--secondary action fr-btn--icon-left fr-icon-download-line")
       - if display_actions
         -# TODO
-      = link_to "Fermer", close_path, class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-right fr-icon-close-line"
+      = link_to("Fermer",
+        close_path,
+        class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-right fr-icon-close-line")
 
   .content
     .arrow-link
@@ -27,7 +36,7 @@
         method: :get,
         params: next_photo&.lightbox_path_params,
         disabled: next_photo.nil?)
-    .footer
+    .credits
       = current_photo.credit || "Aucun crédit photo renseigné"
       - if current_photo.description
         = "·"

--- a/app/components/galerie/miniatures_component.rb
+++ b/app/components/galerie/miniatures_component.rb
@@ -4,15 +4,13 @@ module Galerie
   class MiniaturesComponent < ViewComponent::Base
     include ApplicationHelper
 
-    attr_reader :parent_galerie
-
-    delegate :photos, :title, :count, to: :parent_galerie
+    delegate :photos, :title, :count, :actions, to: :@galerie
 
     MAX_PHOTOS_SHOWN = 4
 
-    def initialize(parent_galerie)
+    def initialize(galerie)
       super
-      @parent_galerie = parent_galerie
+      @galerie = galerie
     end
 
     def thumbs_count
@@ -28,6 +26,5 @@ module Galerie
     end
 
     def credits = photos.map(&:credit).uniq
-    def texte_lien_titre = count > 1 ? "Voir la galerie" : "Agrandir"
   end
 end

--- a/app/components/galerie/miniatures_component/miniatures_component.css
+++ b/app/components/galerie/miniatures_component/miniatures_component.css
@@ -95,7 +95,7 @@
   }
 
   .co-galerie-miniatures .bottom-link {
-    display: none;
+    margin-top: 1rem;
   }
 }
 

--- a/app/components/galerie/miniatures_component/miniatures_component.html.haml
+++ b/app/components/galerie/miniatures_component/miniatures_component.html.haml
@@ -1,9 +1,6 @@
 .co-galerie-miniatures.fr-mb-4w
   .title
     = title
-    - if count > 0
-      %span.title-link
-        = link_to texte_lien_titre, photos[0].lightbox_path, class: "fr-ml-2w"
 
   - if count > 0
     .first
@@ -27,10 +24,10 @@
           %span.co-flex--grow
             = t("galerie.miniatures.last_thumb", count: hidden_photos_count)
 
-  - if count > 1
+  - if count >= 1
     .bottom-link
       = link_to photos[0].lightbox_path, class: "fr-link fr-link--icon-right fr-icon-zoom-in-line" do
-        Voir la galerie de #{count} photos
+        = t("galerie.miniatures.open", count:)
 
   - if credits.any?
     .co-text--muted.fr-mt-1w.fr-text--sm

--- a/app/views/conservateurs/analyses/_recensement_attributes.html.haml
+++ b/app/views/conservateurs/analyses/_recensement_attributes.html.haml
@@ -9,8 +9,14 @@
       %input.fr-input.co-text--black{disabled: "disabled", type: "text", value: "#{recensement.edifice_nom}"}
   - elsif recensement.absent?
     .fr-checkbox-group.fr-mt-2w
-      = check_box_tag "recensement[analyse_fiches][]", "depot_plainte", recensement.analyse_fiches.include?("depot_plainte"), id: "recensement_analyse_fiches_depot_plainte"
-      = f.label :analyse_fiches_depot_plainte, "Informer la commune sur le dépôt de plainte"
+      = check_box_tag("recensement[analyse_fiches][]",
+        "depot_plainte",
+        recensement.analyse_fiches.include?("depot_plainte"),
+        id: "recensement_analyse_fiches_depot_plainte",
+        form: "recensement")
+      = f.label(:analyse_fiches_depot_plainte,
+        "Informer la commune sur le dépôt de plainte",
+        form: "recensement")
     .fr-mt-2w
       = link_to "Voir le contenu de cette fiche conseil", fiche_path("depot_plainte"), target: "_blank", rel: "noopener"
 
@@ -20,15 +26,33 @@
       État de l’objet
     = render analyse_attribute_component(recensement:, form_builder: f, recensement_presenter:, attribute_name: "etat_sanitaire")
     .fr-checkbox-group.fr-mt-2w
-      = check_box_tag "recensement[analyse_fiches][]", "entretien_objets", recensement.analyse_fiches.include?("entretien_objets"), id: "recensement_analyse_fiches_entretien_objets"
-      = f.label :analyse_fiches_entretien_objets, "Informer la commune sur les mesures d’entretien préventives"
+      = check_box_tag("recensement[analyse_fiches][]",
+        "entretien_objets",
+        recensement.analyse_fiches.include?("entretien_objets"),
+        id: "recensement_analyse_fiches_entretien_objets",
+        form: "recensement")
+      = f.label(:analyse_fiches_entretien_objets,
+        "Informer la commune sur les mesures d’entretien préventives",
+        form: "recensement")
 
     .fr-checkbox-group.fr-mt-2w
-      = check_box_tag "recensement[analyse_fiches][]", "restauration", recensement.analyse_fiches.include?("restauration"), id: "recensement_analyse_fiches_restauration"
-      = f.label :analyse_fiches_restauration, "Informer la commune sur les étapes préalables à la restauration"
+      = check_box_tag("recensement[analyse_fiches][]",
+        "restauration",
+        recensement.analyse_fiches.include?("restauration"),
+        id: "recensement_analyse_fiches_restauration",
+        form: "recensement")
+      = f.label(:analyse_fiches_restauration,
+        "Informer la commune sur les étapes préalables à la restauration",
+        form: "recensement")
     .fr-checkbox-group.fr-mt-2w
-      = check_box_tag "recensement[analyse_fiches][]", "entretien_edifices", recensement.analyse_fiches.include?("entretien_edifices"), id: "recensement_analyse_fiches_nuisibles"
-      = f.label :analyse_fiches_nuisibles, "Informer la commune sur les mesures d’entretien des édifices et de prévention d’attaques de nuisibles"
+      = check_box_tag("recensement[analyse_fiches][]",
+        "entretien_edifices",
+        recensement.analyse_fiches.include?("entretien_edifices"),
+        id: "recensement_analyse_fiches_nuisibles",
+        form: "recensement")
+      = f.label(:analyse_fiches_nuisibles,
+        "Informer la commune sur les mesures d’entretien des édifices et de prévention d’attaques de nuisibles",
+        form: "recensement")
     .fr-mt-2w
       = link_to "Voir le contenu de ces fiches conseils", fiches_path, target: "_blank", rel: "noopener"
 
@@ -37,8 +61,14 @@
       Sécurisation de l’objet
     = render analyse_attribute_component(recensement:, form_builder: f, recensement_presenter:, attribute_name: "securisation")
     .fr-checkbox-group.fr-mt-2w
-      = check_box_tag "recensement[analyse_fiches][]", "securisation", recensement.analyse_fiches.include?("securisation"), id: "recensement_analyse_fiches_securisation"
-      = f.label :analyse_fiches_securisation, "Informer la commune sur les mesures de sécurisation des objets"
+      = check_box_tag("recensement[analyse_fiches][]",
+        "securisation",
+        recensement.analyse_fiches.include?("securisation"),
+        id: "recensement_analyse_fiches_securisation",
+        form: "recensement")
+      = f.label(:analyse_fiches_securisation,
+        "Informer la commune sur les mesures de sécurisation des objets",
+        form: "recensement")
     .fr-mt-2w
       = link_to "Voir le contenu de cette fiche conseil", fiche_path("securisation"), target: "_blank", rel: "noopener"
 
@@ -48,5 +78,5 @@
     .fr-badge.fr-badge--sm.fr-badge--warning
       Recensement impossible
 
-%input{name:"recensement[analyse_fiches][]", type:"hidden", value: ""}
+%input{name:"recensement[analyse_fiches][]", type:"hidden", value: "", form: "recensement"}
 -# to make sure the array is sent even if empty

--- a/app/views/conservateurs/analyses/edit.html.haml
+++ b/app/views/conservateurs/analyses/edit.html.haml
@@ -37,56 +37,51 @@
             - photo = PhotoPresenter.new(url: @objet.palissy_photos.any? ? @objet.palissy_photos_presenters.first&.url : "images/illustrations/photo-manquante-pop.png")
             = render("shared/card_photo", photo:)
 
-  = form_for @recensement,
-    url: conservateurs_objet_recensement_analyse_path(@objet, @recensement),
-    builder: FormBuilderDsfr,
-    data: { turbo_action: "advance" } do |f|
-    #recensement
-      .co-background--light-teal.fr-my-2w.fr-px-4w.fr-py-2w
-        %h3 Recensement
+  - f = nil
+  = form_with(model: @recensement, url: conservateurs_objet_recensement_analyse_path(@objet, @recensement), builder: FormBuilderDsfr, id: "recensement", data: { turbo_action: "advance" }) do |fb|
+    - f = fb
 
-        .fr-grid-row.fr-grid-row--gutters.fr-pb-6w.fr-mt-3w
-          %div{class: @recensement.photos.any? ? "fr-col-md-8" : "fr-col-md-12"}
-            - if @recensement.missing_photos?
-              %p.fr-badge.fr-badge--sm.fr-badge--warning.fr-mb-4w
-                = t("recensement.photos.taken_count", count: 0)
-            = render "recensement_attributes", recensement_presenter: @recensement_presenter, recensement: @recensement, f:
-            .fr-pb-1w
-              %b= t("activerecord.attributes.recensement.notes")
-            %div
-              - if @recensement.notes.present?
-                = blockquote(@recensement.notes, class: "fr-my-2w")
-              - else
-                %p.co-text--italic Aucune commentaire laissé par la commune pour cet objet
-          - if @recensement.photos.any?
-            .fr-col-md-4.co-flex-md-reverse-order
-              = render galerie_recensement(@recensement)
-
-    .fr-grid-row
-      .fr-col-md-12
-        - unless @recensement.objet.commune.completed?
-          .fr-alert.fr-alert--error.fr-mb-4w
-            %p= t("recensement.analyse.not_completed")
-        - if @recensement.errors.any?
-          .fr-alert.fr-alert--error.fr-mb-6w
-            %p Votre examen n'a pas pu être enregistrée :
-            %ul
-              - @recensement.errors.attribute_names.each do |attribute|
-                %li
-                  = attribute
-                  = @recensement.errors.messages_for(attribute).first
-    .fr-px-4w
-      .fr-grid-row.fr-mb-4w
-        .fr-col-md-6
-          = f.label :analyse_notes
-          = f.text_area :analyse_notes, disabled: !@recensement.analysable?
-      .fr-grid-row
+  #recensement
+    .co-background--light-teal.fr-my-2w.fr-px-4w.fr-py-2w
+      %h3 Recensement
+      .fr-grid-row.fr-grid-row--gutters.fr-pb-6w.fr-mt-3w
         .fr-col-md-8
-          = f.submit "Sauvegarder", disabled: !@recensement.analysable?
-          .fr-text--sm.fr-mt-1w
-            %i
-              Ces informations ne seront pas envoyées à la mairie tout de suite.
-              Vous pourrez les modifier avant de valider votre examen dans son ensemble.
+          = render "recensement_attributes", recensement_presenter: @recensement_presenter, recensement: @recensement, f:
+          .fr-pb-1w
+            %b= t("activerecord.attributes.recensement.notes")
+          %div
+            - if @recensement.notes.present?
+              = blockquote(@recensement.notes, class: "fr-my-2w")
+            - else
+              %p.co-text--italic Aucune commentaire laissé par la commune pour cet objet
+        .fr-col-md-4.co-flex-md-reverse-order
+          = render galerie_recensement(@recensement, display_actions: false)
+
+  .fr-grid-row
+    .fr-col-md-12
+      - unless @recensement.objet.commune.completed?
+        .fr-alert.fr-alert--error.fr-mb-4w
+          %p= t("recensement.analyse.not_completed")
+      - if @recensement.errors.any?
+        .fr-alert.fr-alert--error.fr-mb-6w
+          %p Votre examen n'a pas pu être enregistrée :
+          %ul
+            - @recensement.errors.attribute_names.each do |attribute|
+              %li
+                = attribute
+                = @recensement.errors.messages_for(attribute).first
+  .fr-px-4w
+    .fr-grid-row.fr-mb-4w
+      .fr-col-md-6
+        = f.label :analyse_notes, form: "recensement"
+        = f.text_area :analyse_notes, disabled: !@recensement.analysable?, form: "recensement"
+    .fr-grid-row
+      .fr-col-md-8
+        = f.submit "Sauvegarder", disabled: !@recensement.analysable?, form: "recensement"
+        .fr-text--sm.fr-mt-1w
+          %i
+            Ces informations ne seront pas envoyées à la mairie tout de suite.
+            Vous pourrez les modifier avant de valider votre examen dans son ensemble.
 
   .fr-px-4w.fr-mb-2w
     = dsfr_link_to "Retour à la liste des recensements",

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -415,6 +415,9 @@ fr:
         zero: "voir la galerie"
         one: "1 autre photo …"
         other: "%{count} autres photos …"
+      open:
+        one: Agrandir
+        other: Voir la galerie
   pdf_embed_component:
     download: Télécharger le fichier PDF
   campaign_v1_mailer:


### PR DESCRIPTION
refactors quasiment sans changements pour préparer le terrain et rendre la PR d’ajout des actions plus lisible

le seul changement est qu’on ne fait plus apparaître un titre à côté du titre de la galerie dans certains cas, ce n’était pas très utile

Quelques renommages bénins de variables et classes, et déplacements de fonctions entre composants de vue de la galerie

Passage des appels et définitions avec beaucoup de kwargs d’une ligne à plusieurs pour rendre lisible l’ajout et la suppression

# Formulaires imbriqués

Dans le template `analyses/edit` je fais un changement un peu bizarre. Je sors le tag de formulaire et je l’affiche vide `<form id="recensement" action="..." ...></form>`. 

Puis pour chaque input et label je rajoute attribut form qui pointe sur l’id : `<input form="recensement" type="..." />`. 

Le but est de permettre dans la PR qui va venir d’**imbriquer d’autres formulaires (suppression, ajout...) dans le DOM du formulaire de recensement**. 

C’est en effet invalide d’imbriquer des `<form>` et le comportement est cassé, le navigateur ne sait pas comment soumettre.

# tests

testé sur

- Mac Os Firefox
- Mac Os Edge
- Mac Os Chrome
- Mac Os Safari

support  97.73% des navigateurs en usage, mais pas IE 
cf https://caniuse.com/form-attribute