### PR TITLE
fix active storage disk mode in feature specs

### DIFF
--- a/app/views/shared/rapport/_recensement.html.haml
+++ b/app/views/shared/rapport/_recensement.html.haml
@@ -19,7 +19,7 @@
       - recensement.photos.each_with_index do |photo, index|
         .fr-col-md-3.co-rapport-photo
           -# TODO: replace with galerie
-          = link_to photo.url, class: "co-cursor--zoom-in" do
+          = link_to url_for(photo), class: "co-cursor--zoom-in" do
             = vite_or_raw_image_tag photo.variant(:medium), alt: "© Licence ouverte"
 
   .fr-grid-row.fr-grid-row--gutters.fr-mt-1w

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/integer/time"
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
-Rails.application.default_url_options = { host: 'localhost', port: 3009 }
+Rails.application.default_url_options = { host: 'localhost', port: 31337 }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/spec/factories/recensement.rb
+++ b/spec/factories/recensement.rb
@@ -56,6 +56,23 @@ FactoryBot.define do
       end
     end
 
+    trait :with_photos do
+      transient do
+        photos_count { 2 }
+      end
+
+      after(:build) do |recensement, evaluator|
+        evaluator.photos_count.times do |i|
+          recensement.photos.attach(
+            io: Rails.root.join("spec/fixture_files/tableau#{i + 1}.jpg").open,
+            filename: "tableau#{i + 1}.jpg",
+            content_type: "image/jpeg",
+            service_name: "test"
+          )
+        end
+      end
+    end
+
     trait :disparu do
       recensable { false }
       localisation { Recensement::LOCALISATION_ABSENT }

--- a/spec/features/conservateurs/accept_dossier_spec.rb
+++ b/spec/features/conservateurs/accept_dossier_spec.rb
@@ -16,6 +16,8 @@ RSpec.feature "Conservateurs - Accept Dossier", type: :feature, js: true do
   let!(:recensement_bouquet) do
     create(
       :recensement,
+      :with_photos,
+      photos_count: 3,
       objet: objet_bouquet, user:, dossier:,
       etat_sanitaire: Recensement::ETAT_BON,
       securisation: Recensement::SECURISATION_CORRECTE,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,7 @@ Capybara.javascript_driver = ENV.fetch("CAPYBARA_JS_DRIVER", "headless_firefox")
 Capybara.save_path = Rails.root.join("tmp/artifacts/capybara")
 
 Capybara.default_max_wait_time = 10
+Capybara.server_port = 31337
 
 begin
   require "pry"


### PR DESCRIPTION
dans cette PR je fais deux choses

1. correction de la configuration d’active storage dans les features specs

je fixe le port du serveur rails lancé pendant les specs à `31337`, je le signale à Capybara ET à Active Storage
Sans ça, Active Storage n’arrive pas à générer des URLs d’images correctes. 
On ne s’en rendait pas compte car ça ne raise pas, mais jusque là les photos uploadées avec active storage en disk mode pendant les specs faisaient des erreurs 404 à l’affichage.

2. modification de `features/conservateurs/accept_spec.rb`

Je rajoute trois photos uploadées avec Active Storage Disk mode sur un des recensements testés dans cette spec 
Cela prépare au test de la galerie.