### PR TITLE
amélioration de la vue responsive des bannières d’environnement et d’incarnation

### DIFF
--- a/app/components/impersonate_callout_component/impersonate_callout_component.haml
+++ b/app/components/impersonate_callout_component/impersonate_callout_component.haml
@@ -1,5 +1,5 @@
 .fr-alert.fr-alert--sm{class: write? ? "fr-alert--warning" : "fr-alert--info"}
-  .co-flex.co-flex--space-between.co-flex--align-items-center
+  .co-flex.co-flex--space-between.co-flex--align-items-center.co-flex--wrap.co-flex--gap-05rem
     %div
       = icon_span "user-star"
       Vous incarnez #{name}
@@ -8,10 +8,10 @@
       - else
         %b en mode lecture-seule
     %div.co-flex--shrink-0.fr-pl-1w
-      = link_to toggle_path, class: "fr-btn fr-btn--tertiary fr-btn--icon-right #{write? ? "fr-icon-eye-line" : "fr-icon-warning-line"} fr-mr-2w", "data-turbo-method": "POST" do
+      = link_to toggle_path, class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-right #{write? ? "fr-icon-eye-line" : "fr-icon-warning-line"} fr-mr-2w", "data-turbo-method": "POST" do
         - if write?
           Mode lecture-seule
         - else
           Mode écriture
-      = link_to admin_communes_path, class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-logout-box-r-line" do
+      = link_to admin_communes_path, class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-right fr-icon-logout-box-r-line" do
         Arrêter

--- a/app/views/shared/_banners.html.haml
+++ b/app/views/shared/_banners.html.haml
@@ -1,13 +1,14 @@
 - if banners.any?
-  .co-background-color-inherit.co-position-sticky.co-top-0.co-z-index-600.co-print-hide{role: "alert"}
-    .fr-container.co-flex.co-flex--space-between.fr-mb-1w{data: { controller: "visibility-toggle", "visibility-toggle-target": "section" }}
-      %div.co-flex--grow
+  .co-background-color-inherit.co-position-sticky.co-top-0.co-z-index-600.co-print-hide.fr-text--sm{role: "alert",
+    data: { controller: "visibility-toggle", "visibility-toggle-target": "section" }}
+    .fr-container--fluid.co-flex.co-flex--space-between.co-flex--align-items-center.co-flex--wrap.co-flex--gap-05rem.fr-mb-1w
+      .co-flex--grow
         - if banners.include?(:environment)
           %div{class: "fr-alert fr-alert--sm fr-alert--#{Rails.configuration.x.environment_specific_name == "staging" ? "warning" : "error"} fr-icon-alarm-warning-line co-white-space-nowrap"}
             .co-environment-banner.co-flex.co-flex--space-between
-              %div Environnement #{Rails.configuration.x.environment_specific_name}
+              Env #{Rails.configuration.x.environment_specific_name}
               - if Rails.env.development?
-                %div= link_to "mailhog", "http://localhost:8025", class: "fr-link", target: "_blank", rel: "noopener"
+                %div= link_to "mailhog", "http://localhost:8025", class: "fr-link fr-link--sm", target: "_blank", rel: "noopener"
 
         - if banners.include?(:conservateur_impersonate)
           = render ImpersonateCalloutComponent.new name: "le conservateur #{current_conservateur}",
@@ -24,10 +25,10 @@
             .co-flex.co-flex--space-between.co-flex--align-items-center
               %div Vous parcourez une page de démo, les liens, les boutons et les formulaires ne fonctionneront pas
               %div
-                = link_to "Revenir au plan du site", plan_path, class: "fr-link fr-link--icon-left fr-icon-arrow-left-line"
+                = link_to "Revenir au plan du site", plan_path, class: "fr-link fr-link--sm fr-link--icon-left fr-icon-arrow-left-line"
 
       .co-text--right
         %button{type: "button",
           data: { action: "visibility-toggle#toggle" },
-          class: "fr-btn fr-btn--tertiary fr-btn--tertiary-no-outline fr-icon-close-line fr-btn--icon-right fr-btn--sm"}
+          class: "fr-btn fr-btn--tertiary fr-btn--tertiary fr-icon-close-line fr-btn--icon-right fr-btn--sm fr-mx-1w"}
           Cacher


### PR DESCRIPTION
textes plus petits partout
flex-wrap: wrap pour que les boutons reviennent à la ligne plutot que faire déborder le scroll horizontal

![banners](https://github.com/betagouv/collectif-objets/assets/883348/78f83019-98b3-4803-a5ac-34c60914ef8a)
