### PR TITLE
clarifier la contrainte des communes inactives pour planifier les campagnes

### DIFF
--- a/app/views/conservateurs/campaign_recipients/show.html.haml
+++ b/app/views/conservateurs/campaign_recipients/show.html.haml
@@ -1,4 +1,4 @@
-- title = "#{@commune.nom} - Campagne #{campaign_title(@campaign)}"
+- title = @commune.nom
 - content_for(:head_title) { title }
 
 %main.fr-container.fr-pt-2w.fr-pb-4w

--- a/app/views/shared/campaign_recipients/_show_content.html.haml
+++ b/app/views/shared/campaign_recipients/_show_content.html.haml
@@ -1,10 +1,11 @@
 .fr-mb-8w
-  %p.fr-text--sm
-    Commune #{commune.code_insee} destinataire de la campagne
-    = link_to campaign_title(campaign), send("#{routes_prefix}_campaign_path", campaign)
-  %p.co-text--monospace.fr-text--sm
-    = user.email
-  %p
+  %ul
+    %li
+      Commune destinataire de la campagne
+      = link_to campaign_title(campaign), send("#{routes_prefix}_campaign_path", campaign)
+  %li= Code INSEE : #{commune.code_insee}
+  %li= user.email
+  %li
     = t("objets.count", count: commune.objets.count)
     = link_to "voir les objets", send("#{routes_prefix}_commune_path", commune)
 

--- a/app/views/shared/campaign_recipients/_show_content.html.haml
+++ b/app/views/shared/campaign_recipients/_show_content.html.haml
@@ -1,13 +1,23 @@
 .fr-mb-8w
+  - if recipient.commune.active? && campaign.draft?
+    .fr-grid-row
+      .fr-col-md-8.fr-mb-2w
+        = dsfr_alert(type: :warning, title: "Commune déjà active") do
+          Cette commune a déjà commencé à recenser.
+          %br
+          La campagne ne pourra pas être planifiée tant qu'elle n’a pas été retirée des destinataires.
+
   %ul
     %li
-      Commune destinataire de la campagne
+      campagne
       = link_to campaign_title(campaign), send("#{routes_prefix}_campaign_path", campaign)
-  %li= Code INSEE : #{commune.code_insee}
-  %li= user.email
-  %li
-    = t("objets.count", count: commune.objets.count)
-    = link_to "voir les objets", send("#{routes_prefix}_commune_path", commune)
+    %li= "Code INSEE : #{commune.code_insee}"
+    %li
+      email:
+      %span.co-text--monospace= user.email
+    %li
+      Cette commune abrite
+      = link_to t("objets.count", count: commune.objets.count), send("#{routes_prefix}_commune_path", commune)
 
   - if recipient.status.present?
     %p

--- a/app/views/shared/campaigns/_show_content.html.haml
+++ b/app/views/shared/campaigns/_show_content.html.haml
@@ -13,7 +13,12 @@
     .fr-callout
       %p.fr-callout__text
         Cette campagne est en brouillon. Pour qu'elle soit active et démarre effectivement le #{l(campaign.date_lancement, format: :long_with_weekday)}, il faut la marquer comme planifiée. Vous pourrez repasser la campagne en brouillon si nécessaire.
-      = f.submit "Planifier la campagne"
+
+        - if campaign.communes.any?(&:active?)
+          .fr-mt-2w
+            ⚠️ Attention : certaines communes destinataires ont déjà commencé à recenser, il faut les retirer des destinataires avant de pouvoir planifier la campagne.
+
+      = f.submit "Planifier la campagne", disabled: campaign.communes.any?(&:active?)
 
 - elsif campaign.planned? && campaign.date_lancement > Time.zone.today
   = form_for campaign, builder: FormBuilderDsfr, url: send("#{r}_campaign_update_status_path", campaign) do |f|
@@ -69,10 +74,14 @@
       %h2 #{campaign.communes.count} communes destinataires :
       %ul.co-columns--4
         - campaign.recipients.includes(:commune).order("communes.nom").each do |recipient|
-          %li{class: recipient.commune.active? && (campaign.draft? || campaign.planned?) ? "co-text--red" : ""}
+          %li
             = link_to recipient.commune.nom, send("#{r}_campaign_recipient_path", campaign, recipient)
             = campaign_recipient_status_badge(recipient)
             = campaign_recipient_opt_out_badge(recipient)
+            - if recipient.commune.active? && campaign.draft?
+              %span.fr-icon--sm.fr-icon-warning-line.fr-text--sm.co-text--red{"aria-hidden" => "true"}
+                active
+
             %span.fr-text--sm.co-text--muted= recipient.commune.code_insee
       - if excluded_communes.any?
         .fr-mt-4w


### PR DESCRIPTION
Il est impossible de planifier une campagne (càd la passer de brouillon vers planifiée) si une ou plusieurs communes sont actives.

Pour l’instant quasiment le seul garde fou est fait dans la state machine en guard clause, ça fait une belle erreur 500 si un conservateur essaie quand même cf https://sentry.incubateur.net/organizations/betagouv/issues/79027

Dans cette PR je fais en sorte d’afficher ça plus clairement

Sur la page campaigns#show :

- ajout de texte avec un icone warning explicatif dans le callout
- bouton planifier disabled
- clarification dans la liste des destinataires de quelle commune est active

![Screenshot 2023-12-27 at 15 02 34](https://github.com/betagouv/collectif-objets/assets/883348/81a0a830-ff94-4040-acb2-bfc005bcd8d4)

Sur la page destinataire, ajout d’un callout d’erreur

![Screenshot 2023-12-27 at 14 55 49](https://github.com/betagouv/collectif-objets/assets/883348/f8ad42d6-256d-419b-91e7-cc8876572b6c)
