### PR TITLE
docs: précisions pour l'installation sous Mac et Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ install:
 	npm install --global husky
 	npm install
 	npx husky install
-	brew install mailhog redis libvips
+	brew install mailhog redis libvips postgis
+	brew services start postgresql
+	brew services start redis
 	rails db:drop db:create db:schema:load
 	rails r scripts/create_postgres_sequences_memoire_photos_numbers.rb
 	rails db:seed

--- a/README.md
+++ b/README.md
@@ -97,32 +97,11 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   Ajouter sa clé SSH dans son compte Scalingo en suivant ces instructions : https://doc.scalingo.com/platform/getting-started/setup-ssh-linux
 
-**Sous Linux avec asdf**
+**Utilisation d'asdf**
 
-- Installer les build essentials
+Il est possible d'utiliser [asdf](https://asdf-vm.com/guide/getting-started.html) pour installer la bonne version de Ruby et NodeJS. Cela évite d'avoir 2 outils différents (rbenv et nvm ou autres).
 
-   `sudo apt get curl git install build-essential libc-dev libz-dev libffi-dev libssl-dev libreadline-dev libyaml-dev`
-
-- Installer asdf : https://asdf-vm.com/guide/getting-started.html
-
-  `brew install asdf`
-
-
-- Installer la version de ruby spécifiée dans le Gemfile. Exemple :
-  
-  `asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git`
-
-  `asdf install ruby 3.2.2`
-
-- Installer Node.js, idéalement la même version qu'en production
-
-  `asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git`
-
-  `asdf install nodejs 18.19.0`
-
-- Installer les packages JS 
-
-  `asdf exec npm install`
+Cependant le Makefile n'est pas adapté à son utilisation, il faudrait donc lancer les commandes une à une et préfixer celles avec npm par `asdf exec`
 
 _**optionnel**_: pour une utilisation de rubocop plus rapide en local,
 [voir le mode serveur](https://docs.rubocop.org/rubocop/usage/server.html)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 - Lancer PostgreSQL : 
 
-  `brew services start postgresql@13`
+  `brew services start postgresql`
+
+- Lancer Redis
+
+  `brew services start redis`
 
 - Installer le CLI de Scalingo :
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,35 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 - Installer Homebrew : https://brew.sh/
 
-`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+  `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
 
 - Installer rbenv : brew install rbenv ruby-build : https://github.com/rbenv/rbenv
 
-`brew install rbenv ruby-build`
+  `brew install rbenv ruby-build`
 
-```rbenv install `cat .ruby-version` && make install && make dev```
+- Installer Ruby avec rbenv
+
+  ```rbenv install `cat .ruby-version` ```
+
+- Installer Bundler avec la version précisée dans le Gemfile.lock : 
+
+  `gem install bundler:2.4.13`
+
+- Installer Rails et les dépendances
+
+  `make install`
+
+- Lancer le serveur
+
+  `make dev`
+
+- Installer PostgreSQL : https://www.postgresql.org/. Idéalement utiliser la même version qu'en production.
+
+  `brew install postgresql@13`
+
+- Lancer PostgreSQL : 
+
+  `brew services start postgresql@13`
 
 **Sous Linux avec asdf**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 **Avec Docker**: `docker compose up && docker compose run web rails db:setup`
 
-**En local avec rbenv**: ```rbenv install `cat .ruby-version` && make install && make dev```
+**Sous Mac avec rbenv (devrait fonctionner sous Linux)**: 
+
+- Installer Homebrew : https://brew.sh/
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+
+- Installer rbenv : brew install rbenv ruby-build : https://github.com/rbenv/rbenv
+
+`brew install rbenv ruby-build`
+
+```rbenv install `cat .ruby-version` && make install && make dev```
 
 **Sous Linux avec asdf**
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,20 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 **Sous Linux avec asdf**
 
-`sudo apt get curl git install build-essential libc-dev libz-dev libffi-dev libssl-dev libreadline-dev libyaml-dev`
+- Installer les build essentials
 
-Installer asdf en suivant ces instructions : https://asdf-vm.com/guide/getting-started.html
+   `sudo apt get curl git install build-essential libc-dev libz-dev libffi-dev libssl-dev libreadline-dev libyaml-dev`
 
-Installer la version de ruby spécifiée dans le Gemfile. Exemple :
+- Installer asdf : https://asdf-vm.com/guide/getting-started.html
 
-`asdf install ruby 3.2.2`
+  `brew install asdf`
+
+
+- Installer la version de ruby spécifiée dans le Gemfile. Exemple :
+  
+  `asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git`
+
+  `asdf install ruby 3.2.2`
 
 _**optionnel**_: pour une utilisation de rubocop plus rapide en local,
 [voir le mode serveur](https://docs.rubocop.org/rubocop/usage/server.html)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ historiques et aux conservateurs d'examiner ces recensements.
 - Installer rbenv : brew install rbenv ruby-build : https://github.com/rbenv/rbenv
 
   `brew install rbenv ruby-build`
+  
+  `rbenv init`
 
 - Installer Ruby avec rbenv
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `asdf install ruby 3.2.2`
 
+- Installer Node.js, idéalement la même version qu'en production
+
+  `asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git`
+
+  `asdf install nodejs 18.19.0`
+
+- Installer les packages JS 
+
+  `asdf exec npm install`
+
 _**optionnel**_: pour une utilisation de rubocop plus rapide en local,
 [voir le mode serveur](https://docs.rubocop.org/rubocop/usage/server.html)
 

--- a/README.md
+++ b/README.md
@@ -71,18 +71,6 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `nvm install 18`
 
-- Installer PostgreSQL et Postgis, idéalement la même version qu'en production : https://www.postgresql.org/. (la commande va installer postgresql car postgis a une dépendance dessus)
-
-  `brew install postgis`
-
-- Lancer PostgreSQL : 
-
-  `brew services start postgresql`
-
-- Lancer Redis
-
-  `brew services start redis`
-
 - Installer Rails et les dépendances
 
   `make install`

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `gem install bundler:2.4.13`
 
+- Installer NodeJS, idéalement la même version qu'en production : https://github.com/nvm-sh/nvm#installing-and-updating
+
+  `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash`
+
+  `nvm install 18`
+
 - Installer Rails et les dépendances
 
   `make install`
@@ -73,7 +79,7 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `make dev`
 
-- Installer PostgreSQL : https://www.postgresql.org/. Idéalement utiliser la même version qu'en production.
+- Installer PostgreSQL, idéalement la même version qu'en production : https://www.postgresql.org/.
 
   `brew install postgresql@13`
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `curl -O https://cli-dl.scalingo.com/install && bash install`
 
+  Ajouter sa clé SSH dans son compte Scalingo en suivant ces instructions : https://doc.scalingo.com/platform/getting-started/setup-ssh-linux
+
 **Sous Linux avec asdf**
 
 - Installer les build essentials

--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 **En local avec rbenv**: ```rbenv install `cat .ruby-version` && make install && make dev```
 
-*optionnel*: pour une utilisation de rubocop plus rapide en local,
+**Sous Linux avec asdf**
+
+`sudo apt get curl git install build-essential libc-dev libz-dev libffi-dev libssl-dev libreadline-dev libyaml-dev`
+
+Installer asdf en suivant ces instructions : https://asdf-vm.com/guide/getting-started.html
+
+Installer la version de ruby spécifiée dans le Gemfile. Exemple :
+
+`asdf install ruby 3.2.2`
+
+_**optionnel**_: pour une utilisation de rubocop plus rapide en local,
 [voir le mode serveur](https://docs.rubocop.org/rubocop/usage/server.html)
 
 # Découverte du service, captures d'écran, types d’usagers, premiers pas

--- a/README.md
+++ b/README.md
@@ -79,13 +79,17 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `make dev`
 
-- Installer PostgreSQL, idéalement la même version qu'en production : https://www.postgresql.org/.
+- Installer PostgreSQL et Postgis, idéalement la même version qu'en production : https://www.postgresql.org/. (la commande va installer postgresql car postgis a une dépendance dessus)
 
-  `brew install postgresql@13`
+  `brew install postgis`
 
 - Lancer PostgreSQL : 
 
   `brew services start postgresql@13`
+
+- Installer le CLI de Scalingo :
+
+  `curl -O https://cli-dl.scalingo.com/install && bash install`
 
 **Sous Linux avec asdf**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ historiques et aux conservateurs d'examiner ces recensements.
 
 **Avec Docker**: `docker compose up && docker compose run web rails db:setup`
 
-**Sous Mac avec rbenv (devrait fonctionner sous Linux)**: 
+**Sous Mac / Linux**: 
 
 - Installer Homebrew : https://brew.sh/
 
@@ -71,14 +71,6 @@ historiques et aux conservateurs d'examiner ces recensements.
 
   `nvm install 18`
 
-- Installer Rails et les dépendances
-
-  `make install`
-
-- Lancer le serveur
-
-  `make dev`
-
 - Installer PostgreSQL et Postgis, idéalement la même version qu'en production : https://www.postgresql.org/. (la commande va installer postgresql car postgis a une dépendance dessus)
 
   `brew install postgis`
@@ -90,6 +82,14 @@ historiques et aux conservateurs d'examiner ces recensements.
 - Lancer Redis
 
   `brew services start redis`
+
+- Installer Rails et les dépendances
+
+  `make install`
+
+- Lancer le serveur
+
+  `make dev`
 
 - Installer le CLI de Scalingo :
 


### PR DESCRIPTION
Suite à une ré installation de ma machine, j'ai clarifié le processus d'installation et fait en sorte d'utiliser au maximum Homebrew qui fonctionne aussi sur Linux.

J'ai envisagé la possibilité de passer sur adsf plutôt que rbenv pour Ruby et NVM pour Node.js. À priori ça ne pose pas de problème, mais il faudrait adapter le Makefile.