### PR TITLE
refactor du raise on purpose JS pour utiliser un stimulus controller

### DIFF
--- a/app/frontend/entrypoints/raise_on_purpose.js
+++ b/app/frontend/entrypoints/raise_on_purpose.js
@@ -1,3 +1,0 @@
-class OnPurposeJSError extends Error {}
-
-throw new OnPurposeJSError("testing!");

--- a/app/frontend/stimulus_controllers/raise_js_error_controller.js
+++ b/app/frontend/stimulus_controllers/raise_js_error_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+class OnPurposeJSError extends Error { }
+
+export default class extends Controller {
+  connect() {
+    throw new OnPurposeJSError("testing!");
+  }
+}

--- a/app/views/health/js_error.html.haml
+++ b/app/views/health/js_error.html.haml
@@ -1,3 +1,3 @@
-%main.fr-py-12w This page should throw a JS Error
+%main.fr-py-12w{data: {controller: "raise-js-error"}}
+  This page should throw a JS Error
 
-= vite_javascript_tag :raise_on_purpose


### PR DESCRIPTION
mini PR de refacto pour supprimer un entrypoint JS utilisé uniquement sur la page de test des erreurs JS

préliminaire au retrait de Vite en faveur des importmaps