### PR TITLE
désactivation de raise_on_missing_callback_actions sur tous les envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module CollectifObjets
     config.x.inbound_emails_domain = "test.domain.fr"
 
     config.view_component.default_preview_layout = "component_preview"
+
+    config.action_controller.raise_on_missing_callback_actions = false
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -93,6 +93,4 @@ Rails.application.configure do
   config.log_file_size = 100_000_000
 
   config.view_component.preview_paths << Rails.root.join("app/components/")
-
-  config.action_controller.raise_on_missing_callback_actions = true
 end


### PR DESCRIPTION
c’est problématique pour nous d’activer cette nouvelle config de rails 7.1 car on a ce genre de lignes au niveau de base controllers :

`after_action :verify_authorized, except: :index`

certains enfants de ces base controllers n’implémentent pas l’action index. c’est un peu relou à modifier et c’est (c’était ?) la manière de faire recommandée de pundit 