### PR TITLE
synchronisation des communes depuis l’API officielle Service Public

### DIFF
--- a/app/jobs/synchronizer/synchronize_communes_job.rb
+++ b/app/jobs/synchronizer/synchronize_communes_job.rb
@@ -4,12 +4,16 @@ module Synchronizer
   class SynchronizeCommunesJob
     include Sidekiq::Job
 
-    API_URL = "https://collectif-objets-datasette.fly.dev/data/mairies.json"
+    API_URL = "https://api-lannuaire.service-public.fr/api/explore/v2.1/catalog/datasets/api-lannuaire-administration/records"
+    ITEMS_PER_PAGE = 100
+    BASE_WHERE_CLAUSES = [
+      %|startswith(pivot, '[{"type_service_local": "mairie",')|,
+      "NOT startswith(nom, 'Mairie déléguée')"
+    ].freeze
     BASE_PARAMS = {
-      _size: "1000",
-      _sort: "code_insee",
-      _shape: "objects",
-      _nofacet: "1"
+      order_by: "code_insee_commune",
+      limit: ITEMS_PER_PAGE,
+      select: %w[code_insee_commune nom telephone]
     }.freeze
 
     def perform(departement = nil)
@@ -25,60 +29,77 @@ module Synchronizer
     def synchronize_departement(departement)
       logger.info "before: #{Commune.where(departement:).count} communes in #{departement}"
 
-      initial_url = "#{API_URL}?#{URI.encode_www_form(BASE_PARAMS.merge(code_insee__startswith: departement))}"
-      api_query(initial_url, initial: true)
+      api_query(where_clauses: [%{startswith(code_insee_commune, "#{departement}")}], offset: 0)
 
       logger.info "after: #{Commune.where(departement:).count} communes in #{departement}\n"
     end
 
-    def api_query(url, initial: false)
-      parsed = fetch_and_parse(url)
-      logger.info "-- query : #{parsed['query']}" if initial
-      logger.info "-- total rows filtered: #{parsed['filtered_table_rows_count']}" if initial
+    def api_query(where_clauses:, offset:)
+      parsed = fetch_and_parse(where_clauses)
+      logger.info "-- total rows filtered: #{parsed['total_count']}" if offset.zero?
 
-      parsed["rows"].each { create_new_commune(_1) }
+      parsed["results"].each { create_new_commune(_1) }
 
-      trigger_next_query(parsed)
+      trigger_next_query(where_clauses:, total_count: parsed["total_count"], offset:)
     end
 
-    def fetch_and_parse(url)
+    def fetch_and_parse(where_clauses)
+      params = BASE_PARAMS.merge(where: (BASE_WHERE_CLAUSES + where_clauses).join(" AND "))
+      url = "#{API_URL}?#{URI.encode_www_form(params)}"
+
       logger.info "fetching #{url} ..."
       res = Net::HTTP.get_response(URI.parse(url))
       raise "received #{res.code} on #{url}" unless res.code.starts_with?("2")
 
       parsed = JSON.parse(res.body)
-      logger.debug "request took #{parsed['query_ms'].round} ms"
+      parsed["results"] = parsed["results"].map { parse_result(_1) }
+      # display readable parsed
+      parsed["results"].each { logger.info _1 }
       parsed
     end
 
+    def parse_result(result)
+      {
+        code_insee: result["code_insee_commune"],
+        departement_code: parse_departement(result["code_insee_commune"]),
+        nom: result["nom"].gsub(/^Mairie - ?/, ""),
+        phone_number: result["telephone"].present? && JSON.parse(result["telephone"]).first["valeur"],
+        email: result["adresse_courriel"]
+      }
+    end
+
+    def parse_departement(code_insee)
+      code_insee.starts_with?("97") ? code_insee[0..2] : code_insee[0..1]
+    end
+
     def create_new_commune(raw_mairie)
-      return if should_skip_commune?(raw_mairie)
+      return if should_skip_commune?(raw_mairie[:code_insee])
 
       logger.info "upserting commune #{raw_mairie}"
-      commune = upsert_commune(raw_mairie)
+      commune = upsert_commune(**raw_mairie)
       unless commune.persisted?
         logger.info "error when upserting commune : #{commune.errors.full_messages.join} (#{raw_mairie})"
         return
       end
 
-      create_user(raw_mairie, commune)
+      create_user(raw_mairie[:email], commune)
     end
 
-    def upsert_commune(raw_mairie)
-      commune = Commune.find_or_initialize_by(code_insee: raw_mairie["code_insee"])
-
-      commune.assign_attributes(
-        **raw_mairie.slice("nom", "departement", "latitude", "longitude"),
-        phone_number: raw_mairie["telephone"]
-      )
-      commune.tap(&:save)
+    def upsert_commune(code_insee:, departement_code:, nom:, phone_number:, **)
+      commune = Commune.find_or_initialize_by(code_insee:)
+      commune.assign_attributes(departement_code:, nom:, phone_number:)
+      if commune.changed?
+        logger.info "saving changes to #{commune.new_record? ? 'new' : 'existing'} commune #{commune.changes}"
+        commune.save!
+      end
+      commune
     end
 
-    def create_user(raw_mairie, commune)
-      return if raw_mairie["email"].blank? || commune.users.any?
+    def create_user(email, commune)
+      return if email.blank? || commune.users.any?
 
       attributes = {
-        email: raw_mairie["email"],
+        email:,
         magic_token: SecureRandom.hex(10),
         role: User::ROLE_MAIRIE,
         commune_id: commune.id
@@ -87,15 +108,16 @@ module Synchronizer
       logger.info "error when saving user : #{user.errors.full_messages.join} (#{attributes})" if user.errors.any?
     end
 
-    def trigger_next_query(parsed)
-      return unless parsed["next_url"]
+    def trigger_next_query(where_clauses:, total_count:, offset:)
+      next_offset = offset + ITEMS_PER_PAGE
+      return if total_count.zero? || next_offset >= total_count
 
       sleep(0.5)
-      api_query(parsed["next_url"])
+      api_query(where_clauses:, offset: next_offset)
     end
 
-    def should_skip_commune?(raw_mairie)
-      Objet.where(commune_code_insee: raw_mairie["code_insee"]).empty? # we only create communes when there are objets
+    def should_skip_commune?(code_insee)
+      Objet.where(commune_code_insee: code_insee).empty? # we only create communes when there are objets
     end
   end
 end


### PR DESCRIPTION
https://api-lannuaire.service-public.fr/explore/dataset/api-lannuaire-administration/information/

c’est assez chouette. Les petits points d’attention sur cette API :

1. pagination par 100 et limitation des résultats aux 10.000 premiers
2. le type d’objet est dans un champ string qui contient un array JSON 👎 je fais un `startswith(pivot, '[{"type_service_local": "mairie",')` bien sale mais ça a l’air de marcher au vu du nombre de résultats
3. aucune info sur le rate limit de l’API mais ça a l’air de passer avec 0.5s d’écart entre les requêtes pour un refresh france entière en local

le 1. n’est pas un problème car on parcourait déjà département par département, et il y a moins de 10.000 communes par département

je me suis rendu compte qu’on ne met jamais à jour les emails des users de commune ayant changé dans service-public.fr par précaution. Il faudrait en discuter et le faire cf nouveau ticket kanban https://www.notion.so/atelier-numerique/3c1b452d1f5048719a4b879ec9208845?v=1e597ee6fb7046acb66be9cea14a0c19&p=1da9f6e6698c42b3906e83319e0cc8d3&pm=s