### PR TITLE
fusion d’édifices avec le meme code insee et le meme slug

### DIFF
--- a/db/migrate/20240106113952_fusionner_edifices_doublons.rb
+++ b/db/migrate/20240106113952_fusionner_edifices_doublons.rb
@@ -1,0 +1,46 @@
+class FusionnerEdificesDoublons < ActiveRecord::Migration[7.1]
+  def up
+    code_insee_and_slugs = get_problematic_code_insee_and_slugs
+    total_edifices_count = code_insee_and_slugs.sum { Edifice.where(_1).count }
+    puts "#{total_edifices_count} edifices sont invalides et partagent le même code_insee et slug"
+
+    code_insee_and_slugs.each { corriger_doublons(**_1) }
+    count_after = get_problematic_code_insee_and_slugs.sum { Edifice.where(_1).count }
+    raise "il reste #{count_after} edifices invalides" if count_after.positive?
+  end
+
+  private
+
+  def get_problematic_code_insee_and_slugs
+    sql = "SELECT code_insee, slug FROM edifices GROUP BY code_insee, slug HAVING COUNT(*) >= 2"
+    return ActiveRecord::Base.connection.execute(sql).map { _1.to_h.symbolize_keys }
+  end
+
+  def corriger_doublons(code_insee:, slug:)
+    edifices = Edifice.where(code_insee:, slug:)
+    raise "il y a #{edifices.count} edifices pour #{code_insee}-#{slug}" if edifices.count != 2
+
+    avec_objets, sans_objets = edifices.partition { _1.objets.any? }
+    if sans_objets.any?
+      puts "Pour #{code_insee}-#{slug} il y a (au moins) un édifice sans objet, on le supprime"
+      fusionner_edifices(a_supprimer: sans_objets.first, a_garder: avec_objets.first || sans_objets.second)
+      return
+    end
+
+    avec_ref, sans_ref = edifices.partition { _1.merimee_REF.present? }
+    if avec_ref.count == 1 && sans_ref.count == 1
+      puts "Pour #{code_insee}-#{slug} il y a un édifice avec ref (#{avec_ref.first.id}) et un autre sans (#{sans_ref.first.id}), on supprime ce dernier"
+      fusionner_edifices(a_garder: avec_ref.first, a_supprimer: sans_ref.first)
+      return
+    end
+
+    raise "impossible de décider quel édifice garder pour #{edifices.map(&:attributes)}"
+  end
+
+  def fusionner_edifices(a_garder:, a_supprimer:)
+    raise unless a_garder.code_insee == a_supprimer.code_insee
+
+    a_supprimer.objets.update_all(edifice_id: a_garder.id)
+    a_supprimer.destroy!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_06_111305) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_06_113952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"


### PR DESCRIPTION
en prod, il y a 246 édifices qui sont invalides car leur doublon [code_insee, slug] n’est pas unique
cette migration les parcourt et les fusionne

1. on parcourt les paires problématiques [code_insee, slug]
3. on vérifie qu’il n’y a que deux édifices pour chaque paire
4. parmi ces deux on choisit prioritairement de garder celui qui a des objets si l’autre n’en n’a pas, ou celui qui a une ref merimee si l’autre n’en n’a pas

on vérifie à la fin que ça suffit à corriger tous les problèmes, c’est le cas, youpi

output du run local sur un dump de prod

```
== 20240106113952 FusionnerEdificesDoublons: migrating ========================
246 edifices sont invalides et partagent le même code_insee et slug
Pour 29106-chapelle-notre-dame-quilinen il y a un édifice avec ref (49928) et un autre sans (22230), on supprime ce dernier
Pour 32155-eglise-saint-aubin il y a un édifice avec ref (49126) et un autre sans (23348), on supprime ce dernier
Pour 77313-eglise-saint-martin il y a un édifice avec ref (4954) et un autre sans (42824), on supprime ce dernier
Pour 39476-eglise il y a un édifice avec ref (49198) et un autre sans (26336), on supprime ce dernier
Pour 70292-eglise il y a un édifice avec ref (49462) et un autre sans (39237), on supprime ce dernier
Pour 12089-eglise-notre-dame il y a (au moins) un édifice sans objet, on le supprime
Pour 61460-eglise-saint-pierre il y a un édifice avec ref (49340) et un autre sans (35047), on supprime ce dernier
Pour 2A308-couvent-saint-francois il y a un édifice avec ref (49952) et un autre sans (18092), on supprime ce dernier
Pour 49050-chateau il y a un édifice avec ref (49234) et un autre sans (29608), on supprime ce dernier
Pour 55184-eglise-saint-pierre-saint-paul il y a un édifice avec ref (49275) et un autre sans (31959), on supprime ce dernier
Pour 08025-eglise il y a (au moins) un édifice sans objet, on le supprime
Pour 37014-chateau il y a un édifice avec ref (49670) et un autre sans (25487), on supprime ce dernier
Pour 74224-eglise il y a un édifice avec ref (49487) et un autre sans (41010), on supprime ce dernier
Pour 60010-eglise-saint-martin il y a un édifice avec ref (49336) et un autre sans (34651), on supprime ce dernier
Pour 13035-eglise il y a un édifice avec ref (48986) et un autre sans (10706), on supprime ce dernier
Pour 01194-eglise-notre-dame-assomption il y a un édifice avec ref (48929) et un autre sans (11745), on supprime ce dernier
Pour 72149-eglise-saint-maximin-montreuil il y a (au moins) un édifice sans objet, on le supprime
Pour 77326-eglise-saint-leger il y a (au moins) un édifice sans objet, on le supprime
Pour 15045-eglise-saint-blaise-saint-martin il y a un édifice avec ref (49012) et un autre sans (16609), on supprime ce dernier
Pour 71014-eglise-saint-jean il y a un édifice avec ref (50037) et un autre sans (39831), on supprime ce dernier
Pour 31282-eglise-saint-barthelemy il y a (au moins) un édifice sans objet, on le supprime
Pour 52398-eglise-saint-aignan il y a un édifice avec ref (49254) et un autre sans (7907), on supprime ce dernier
Pour 13108-eglise-saint-jacques il y a un édifice avec ref (48991) et un autre sans (10622), on supprime ce dernier
Pour 86070-eglise-saint-pierre il y a un édifice avec ref (49586) et un autre sans (46053), on supprime ce dernier
Pour 27056-eglise-sainte-croix il y a un édifice avec ref (49065) et un autre sans (21202), on supprime ce dernier
Pour 52250-eglise-notre-dame il y a un édifice avec ref (49253) et un autre sans (7829), on supprime ce dernier
Pour 71076-eglise-saint-pierre il y a un édifice avec ref (49863) et un autre sans (39866), on supprime ce dernier
Pour 02242-eglise il y a un édifice avec ref (49842) et un autre sans (12085), on supprime ce dernier
Pour 68298-temple-reforme il y a un édifice avec ref (49435) et un autre sans (38337), on supprime ce dernier
Pour 85156-eglise il y a (au moins) un édifice sans objet, on le supprime
Pour 29019-eglise-saint-louis il y a un édifice avec ref (49916) et un autre sans (22170), on supprime ce dernier
Pour 29111-eglise-saint-herve il y a un édifice avec ref (49938) et un autre sans (22232), on supprime ce dernier
Pour 77256-eglise-saint-georges il y a un édifice avec ref (5139) et un autre sans (42540), on supprime ce dernier
Pour 77045-eglise il y a un édifice avec ref (49535) et un autre sans (42338), on supprime ce dernier
Pour 2B178-eglise-sainte-julie il y a un édifice avec ref (49088) et un autre sans (18270), on supprime ce dernier
Pour 68203-eglise-catholique-saints-pierre-paul il y a un édifice avec ref (49426) et un autre sans (38425), on supprime ce dernier
Pour 31341-chateau il y a un édifice avec ref (49120) et un autre sans (22868), on supprime ce dernier
Pour 39016-eglise il y a un édifice avec ref (49175) et un autre sans (26017), on supprime ce dernier
Pour 52121-hopital il y a (au moins) un édifice sans objet, on le supprime
Pour 29134-chapelle-notre-dame-bonne-nouvelle il y a un édifice avec ref (49939) et un autre sans (22245), on supprime ce dernier
Pour 59657-chateau-briarde il y a (au moins) un édifice sans objet, on le supprime
Pour 52534-eglise il y a un édifice avec ref (49256) et un autre sans (8040), on supprime ce dernier
Pour 18119-eglise-saint-andre il y a un édifice avec ref (49644) et un autre sans (17633), on supprime ce dernier
Pour 95241-eglise-saint-aquillin il y a un édifice avec ref (49637) et un autre sans (47528), on supprime ce dernier
Pour 39141-eglise il y a un édifice avec ref (49193) et un autre sans (26099), on supprime ce dernier
Pour 75104-eglise-saint-paul-saint-louis il y a un édifice avec ref (49500) et un autre sans (41275), on supprime ce dernier
Pour 29145-eglise-notre-dame-confort il y a un édifice avec ref (49923) et un autre sans (22253), on supprime ce dernier
Pour 77222-eglise-saint-jacques-mineur il y a un édifice avec ref (2480) et un autre sans (49533), on supprime ce dernier
Pour 70279-eglise-notre-dame il y a un édifice avec ref (49461) et un autre sans (39690), on supprime ce dernier
Pour 06158-eglise il y a un édifice avec ref (48950) et un autre sans (13617), on supprime ce dernier
Pour 49007-eglise-sainte-therese il y a un édifice avec ref (49237) et un autre sans (30192), on supprime ce dernier
Pour 64445-eglise-saint-martin il y a un édifice avec ref (50023) et un autre sans (37096), on supprime ce dernier
Pour 66149-eglise-saint-pierre il y a un édifice avec ref (49362) et un autre sans (37588), on supprime ce dernier
Pour 93007-eglise-saint-charles-borromee il y a (au moins) un édifice sans objet, on le supprime
Pour 29146-chapelle-trinite il y a un édifice avec ref (49931) et un autre sans (22472), on supprime ce dernier
Pour 39333-eglise-saint-nicolas il y a un édifice avec ref (49679) et un autre sans (26518), on supprime ce dernier
Pour 09085-eglise-saint-barthelemy il y a (au moins) un édifice sans objet, on le supprime
Pour 29128-eglise-saint-eguiner il y a un édifice avec ref (49930) et un autre sans (22434), on supprime ce dernier
Pour 76255-collegiale-notre-dame-saint-laurent il y a un édifice avec ref (49526) et un autre sans (42013), on supprime ce dernier
Pour 57672-eglise-saint-maximin il y a (au moins) un édifice sans objet, on le supprime
Pour 34172-eglise-saint-mathieu il y a un édifice avec ref (49959) et un autre sans (24274), on supprime ce dernier
Pour 53077-archisculpture-musee-robert-tatin il y a (au moins) un édifice sans objet, on le supprime
Pour 76341-eglise-saint-martin il y a un édifice avec ref (49531) et un autre sans (49518), on supprime ce dernier
Pour 77188-eglise-saint-martin il y a un édifice avec ref (1389) et un autre sans (42483), on supprime ce dernier
Pour 60508-eglise-saint-gervais il y a un édifice avec ref (49338) et un autre sans (34508), on supprime ce dernier
Pour 25413-eglise-paroissiale il y a un édifice avec ref (49913) et un autre sans (20876), on supprime ce dernier
Pour 77051-eglise-sainte-croix il y a un édifice avec ref (4713) et un autre sans (42344), on supprime ce dernier
Pour 52180-eglise il y a un édifice avec ref (49250) et un autre sans (7759), on supprime ce dernier
Pour 29080-eglise-notre-dame-bonne-nouvelle il y a un édifice avec ref (49921) et un autre sans (22218), on supprime ce dernier
Pour 11206-eglise-saint-martin il y a un édifice avec ref (48977) et un autre sans (15016), on supprime ce dernier
Pour 81069-chapelle-saint-crucifix il y a un édifice avec ref (49553) et un autre sans (44467), on supprime ce dernier
Pour 77071-eglise-saint-pierre-saint-paul il y a un édifice avec ref (5744) et un autre sans (42361), on supprime ce dernier
Pour 71195-eglise il y a (au moins) un édifice sans objet, on le supprime
Pour 91553-eglise-saint-vincent-saint-germain il y a (au moins) un édifice sans objet, on le supprime
Pour 51099-eglise-saint-etienne il y a un édifice avec ref (49240) et un autre sans (9638), on supprime ce dernier
Pour 27502-eglise-saint-germain il y a un édifice avec ref (49068) et un autre sans (21548), on supprime ce dernier
Pour 77293-eglise-saint-martin il y a un édifice avec ref (4580) et un autre sans (42579), on supprime ce dernier
Pour 65338-eglise-saint-martin il y a (au moins) un édifice sans objet, on le supprime
Pour 75107-eglise-saint-francois-xavier il y a (au moins) un édifice sans objet, on le supprime
Pour 29046-eglise-saint-jacques-pouldavid il y a un édifice avec ref (49920) et un autre sans (22200), on supprime ce dernier
Pour 31417-eglise il y a un édifice avec ref (49114) et un autre sans (22903), on supprime ce dernier
Pour 13055-eglise-saint-cannat il y a (au moins) un édifice sans objet, on le supprime
Pour 29193-eglise-saint-pierre il y a un édifice avec ref (49933) et un autre sans (22304), on supprime ce dernier
Pour 11069-eglise-saint-gimer il y a un édifice avec ref (49849) et un autre sans (48973), on supprime ce dernier
Pour 72262-eglise-saint-pierre-saint-julien-lavenay il y a (au moins) un édifice sans objet, on le supprime
Pour 83126-eglise-notre-dame-bon-voyage il y a un édifice avec ref (49571) et un autre sans (45258), on supprime ce dernier
Pour 52060-eglise il y a un édifice avec ref (49249) et un autre sans (7665), on supprime ce dernier
Pour 85133-eglise il y a un édifice avec ref (49824) et un autre sans (45720), on supprime ce dernier
Pour 33063-eglise-saint-pierre il y a un édifice avec ref (49132) et un autre sans (23751), on supprime ce dernier
Pour 43108-eglise-saint-andre il y a un édifice avec ref (49701) et un autre sans (27639), on supprime ce dernier
Pour 27438-eglise-saint-martin il y a un édifice avec ref (49066) et un autre sans (21497), on supprime ce dernier
Pour 22330-eglise-saint-thelo il y a un édifice avec ref (49908) et un autre sans (19797), on supprime ce dernier
Pour 77508-eglise-notre-dame-nativite il y a un édifice avec ref (5710) et un autre sans (42759), on supprime ce dernier
Pour 77446-eglise-saint-denis-saint-lie il y a un édifice avec ref (6900) et un autre sans (42708), on supprime ce dernier
Pour 77198-eglise-saint-martin il y a (au moins) un édifice sans objet, on le supprime
Pour 31033-eglise-saint-paul il y a un édifice avec ref (49109) et un autre sans (22718), on supprime ce dernier
Pour 47323-eglise-sainte-catherine il y a un édifice avec ref (49858) et un autre sans (29118), on supprime ce dernier
Pour 11289-eglise-saint-genest il y a un édifice avec ref (48980) et un autre sans (15413), on supprime ce dernier
Pour 31107-eglise il y a un édifice avec ref (49110) et un autre sans (22752), on supprime ce dernier
Pour 76540-eglise-saint-vivien il y a un édifice avec ref (49523) et un autre sans (41765), on supprime ce dernier
Pour 25056-eglise-saint-maurice il y a un édifice avec ref (49053) et un autre sans (20681), on supprime ce dernier
Pour 77431-eglise-saint-pierre il y a (au moins) un édifice sans objet, on le supprime
Pour 29053-eglise-saint-sauveur il y a un édifice avec ref (49074) et un autre sans (22206), on supprime ce dernier
Pour 29162-eglise-saint-germain-calvaire-ossuaire il y a un édifice avec ref (49076) et un autre sans (22270), on supprime ce dernier
Pour 70227-eglise-saint-georges il y a un édifice avec ref (49457) et un autre sans (39155), on supprime ce dernier
Pour 88020-eglise il y a (au moins) un édifice sans objet, on le supprime
Pour 29151-eglise-saint-melaine il y a un édifice avec ref (49077) et un autre sans (22262), on supprime ce dernier
Pour 22095-eglise-saint-maudez il y a un édifice avec ref (49899) et un autre sans (19840), on supprime ce dernier
Pour 02789-imprimerie-journal-democrate-aisne il y a un édifice avec ref (49840) et un autre sans (48935), on supprime ce dernier
Pour 24396-eglise-saint-cyprien il y a un édifice avec ref (49049) et un autre sans (20362), on supprime ce dernier
Pour 54329-eglise-saint-jacques il y a un édifice avec ref (49261) et un autre sans (31248), on supprime ce dernier
Pour 74191-chalet-sol-i-neu il y a (au moins) un édifice sans objet, on le supprime
Pour 77176-eglise-saint-sulpice il y a un édifice avec ref (4327) et un autre sans (42807), on supprime ce dernier
Pour 36247-eglise-saint-vincent il y a un édifice avec ref (49146) et un autre sans (25109), on supprime ce dernier
Pour 84019-eglise-saint-martin il y a un édifice avec ref (49576) et un autre sans (45507), on supprime ce dernier
Pour 39445-chapelle-binans il y a un édifice avec ref (49197) et un autre sans (26317), on supprime ce dernier
Pour 29032-eglise-saint-hilaire il y a un édifice avec ref (49917) et un autre sans (22186), on supprime ce dernier
Pour 18156-eglise-saint-symphorien il y a un édifice avec ref (49645) et un autre sans (17651), on supprime ce dernier
Pour 89414-eglise-saint-pierre-saint-paul il y a (au moins) un édifice sans objet, on le supprime
Pour 57606-chapelle-sainte-croix il y a (au moins) un édifice sans objet, on le supprime
Pour 38138-eglise il y a un édifice avec ref (49156) et un autre sans (25627), on supprime ce dernier
Pour 80228-eglise-saint-pierre il y a (au moins) un édifice sans objet, on le supprime
Pour 58103-eglise il y a un édifice avec ref (49859) et un autre sans (10223), on supprime ce dernier
== 20240106113952 FusionnerEdificesDoublons: migrated (1.2233s) ===============
```