### PR TITLE
Correctif pour les dossiers sans submitted_at

### DIFF
--- a/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
+++ b/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
@@ -1,7 +1,7 @@
 class FixDossierWithSubmittedAtNil < ActiveRecord::Migration[7.1]
   def up
     Commune.joins(:dossier).where(status: :completed).where(dossier: { submitted_at: nil }).find_each do |commune|
-      commune.dossier.update(submitted_at: commune.completed_at)
+      commune.dossier.update!(submitted_at: commune.completed_at)
       puts "Mise à jour du dossier de la commune #{commune.nom} - code insee #{commune.code_insee} - id #{commune.id} avec un submitted_at à #{commune.dossier.submitted_at}"
     end
   end

--- a/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
+++ b/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
@@ -1,7 +1,8 @@
 class FixDossierWithSubmittedAtNil < ActiveRecord::Migration[7.1]
   def up
-    Commune.joins(:dossier).where(status: :completed).where(dossier: { submitted_at: nil }) do |commune|
+    Commune.joins(:dossier).where(status: :completed).where(dossier: { submitted_at: nil }).find_each do |commune|
       commune.dossier.update(submitted_at: commune.completed_at)
+      puts "Mise à jour du dossier de la commune #{commune.nom} - code insee #{commune.code_insee} - id #{commune.id} avec un submitted_at à #{commune.dossier.submitted_at}"
     end
   end
 end

--- a/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
+++ b/db/migrate/20240108153647_fix_dossier_with_submitted_at_nil.rb
@@ -1,0 +1,7 @@
+class FixDossierWithSubmittedAtNil < ActiveRecord::Migration[7.1]
+  def up
+    Commune.joins(:dossier).where(status: :completed).where(dossier: { submitted_at: nil }) do |commune|
+      commune.dossier.update(submitted_at: commune.completed_at)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_06_113952) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_08_153647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"


### PR DESCRIPTION
Dans [cette PR](https://github.com/betagouv/collectif-objets/pull/1058) on a besoin de comparer les dates d'envoi des dossiers pour savoir si on envoie l'email pour les communes n'ayant que des objets verts.

Or il arrive que certains dossiers soient dans le statut `submitted` mais que la date `submitted_at` soit `nil`.

Ça ne devrait pas arriver, alors on migre la base en mettant à jour la date `submitted_at` à la valeur de `completed_at` de la commune, qui doivent être les mêmes en théorie.