### PR TITLE
Envoi des emails objets verts en asynchrone

### DIFF
--- a/app/jobs/campaigns/cron_job.rb
+++ b/app/jobs/campaigns/cron_job.rb
@@ -20,7 +20,7 @@ module Campaigns
           next unless commune.shall_receive_email_objets_verts?(date)
 
           commune.dossier.update(replied_automatically_at: date)
-          UserMailer.with(user: commune.users.first, commune:).commune_avec_objets_verts_email.deliver_now
+          UserMailer.with(user: commune.users.first, commune:).commune_avec_objets_verts_email.deliver_later
         end
       end
     end


### PR DESCRIPTION
Le job `Campaigns::CronJob` envoyait les emails de manière synchrone, ce qui pouvait le rendre long et risquait de le faire timeout côté Scalingo.

Ils sont désormais envoyés de manière asynchrone.