### PR TITLE
Import des objets sur les communes actives

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,25 +543,15 @@ flowchart TD
   code_insee_existe -->|oui| pm_existe[PM existe déjà ?]
 
   pm_existe -->|oui| changement_de_commune[Code INSEE a changé ?]
-  pm_existe -.->|non| commune_ok[commune inactive \n ou dossier accepté ?]
+  pm_existe -.->|non| import_nouvel_objet(Import du nouvel objet)
 
-  subgraph nouvel objet
-  commune_ok -->|oui| import_nouvel_objet(Importer nouvel objet)
-  commune_ok -.->|non| interactive1[Acceptation interactive manuelle ?]
-
-  interactive1 -.->|non| ne_pas_importer_nouvel_objet(Ne pas importer \nle nouvel objet)
-  interactive1 -->|oui| import_nouvel_objet
-  end
 
   subgraph Mise à jour d'objet
   changement_de_commune -.->|non| mise_a_jour(Mise à jour de l'objet)
-  changement_de_commune -->|oui| 2_communes_ok[Commune destinataire inactive ou dossier accepté \n+ commune d'origine inactive ?]
+  changement_de_commune -->|oui| 2_communes_ok[la commune d’origine a déjà recensé l’objet ?]
 
-  2_communes_ok -->|oui| mise_a_jour_et_changement_commune(Changement de commune\net mise à jour de l'objet)
-  2_communes_ok -.->|non| interactive2[Acceptation interactive manuelle ?]
-
-  interactive2 -->|oui| mise_a_jour_et_changement_commune
-  interactive2 -.->|non| mise_a_jour_prudente(Mise à jour des champs sûrs\npas de changement de commune)
+  2_communes_ok -.->|oui| mise_a_jour_prudente(Mise à jour des champs sûrs\npas de changement de commune)
+  2_communes_ok -->|non| mise_a_jour_et_changement_commune(Changement de commune\net mise à jour de l'objet)
   end
 
   style mise_a_jour fill:#006600
@@ -569,7 +559,6 @@ flowchart TD
   style mise_a_jour_et_changement_commune fill:#006600
   style mise_a_jour_prudente fill:#003300
   style ne_pas_importer fill:#660000
-  style ne_pas_importer_nouvel_objet fill:#660000
 ```
 
 ## Photos

--- a/app/components/conservateurs/objet_card_component.rb
+++ b/app/components/conservateurs/objet_card_component.rb
@@ -40,8 +40,6 @@ module Conservateurs
     end
 
     def tags
-      return [] unless can_analyse
-
       @tags ||= [not_recensed_badge].compact
     end
 
@@ -50,7 +48,7 @@ module Conservateurs
     end
 
     def not_recensed_badge
-      return nil if recensement.present?
+      return nil if recensement&.completed?
 
       badge_struct.new("warning", "Pas encore recensé")
     end

--- a/app/jobs/synchronizer/objets/revision_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_concern.rb
@@ -12,7 +12,7 @@ module Synchronizer
 
         private
 
-        attr_reader :row, :commune, :logfile, :interactive, :dry_run
+        attr_reader :row, :commune, :logfile, :dry_run
       end
 
       private
@@ -24,25 +24,6 @@ module Synchronizer
         logfile.flush
       end
 
-      # rubocop:disable Rails/Output
-      def interactive_validation?
-        return false unless interactive?
-
-        @interactive_validation ||= begin
-          puts "\n----\n#{row}\n----"
-          response = nil
-          while response.nil?
-            puts "voulez-vous forcer la sauvegarde de cet objet ? 'oui' : 'non'"
-            raw = gets.chomp
-            response = false if raw == "non"
-            response = true if raw == "oui"
-          end
-          response
-        end
-      end
-      # rubocop:enable Rails/Output
-
-      def interactive? = interactive
       def dry_run? = dry_run
     end
   end

--- a/app/jobs/synchronizer/objets/revision_insert.rb
+++ b/app/jobs/synchronizer/objets/revision_insert.rb
@@ -5,10 +5,9 @@ module Synchronizer
     class RevisionInsert
       include RevisionConcern
 
-      def initialize(row, commune:, interactive: false, logfile: nil, dry_run: false)
+      def initialize(row, commune:, logfile: nil, dry_run: false)
         @row = row
         @commune = commune
-        @interactive = interactive
         @logfile = logfile
         @dry_run = dry_run
       end

--- a/app/jobs/synchronizer/objets/revision_insert.rb
+++ b/app/jobs/synchronizer/objets/revision_insert.rb
@@ -14,7 +14,7 @@ module Synchronizer
       end
 
       def synchronize
-        return false unless check_objet_valid && check_safe_insert
+        return false unless check_objet_valid
 
         objet.save! unless dry_run?
         @action = :create
@@ -34,16 +34,6 @@ module Synchronizer
         @action = :create_rejected_invalid
         log "création de l'objet #{palissy_ref} rejetée car l’objet n'est pas valide " \
             ": #{objet.errors.full_messages.to_sentence}"
-        false
-      end
-
-      def check_safe_insert
-        return true if commune.inactive? || commune.dossier&.accepted? || interactive_validation?
-
-        @action = :create_rejected_commune_active
-        message = "création de l'objet #{palissy_ref} rejetée car la commune #{commune} est #{commune.status}"
-        message += " et son dossier est #{commune.dossier.status}" if commune.completed?
-        log message
         false
       end
 

--- a/app/jobs/synchronizer/objets/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/objets/synchronize_all_job.rb
@@ -13,7 +13,6 @@ module Synchronizer
         @logfile = File.open("tmp/synchronize-objets-#{timestamp}.log", "a+")
         limit = params.with_indifferent_access[:limit]
         @dry_run = params.with_indifferent_access[:dry_run]
-        @interactive = params.with_indifferent_access[:interactive] || false
         code_insee = params.with_indifferent_access[:code_insee]
         ApiClientSql.objets(logger:, limit:, code_insee:).iterate_batches { synchronize_rows(_1) }
         close
@@ -21,11 +20,11 @@ module Synchronizer
 
       private
 
-      attr_reader :interactive, :logfile, :dry_run
+      attr_reader :logfile, :dry_run
 
       def synchronize_rows(rows)
         RevisionsBatch
-          .new(rows, revision_kwargs: { interactive:, logfile:, dry_run: })
+          .new(rows, revision_kwargs: { logfile:, dry_run: })
           .revisions
           .each do |revision|
             revision.synchronize

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -17,7 +17,7 @@ class Dossier < ApplicationRecord
     event :submit, after: :aasm_after_submit do
       transitions from: :construction, to: :submitted
     end
-    event :accept do
+    event :accept, after: :aasm_after_accept do
       transitions from: :submitted, to: :accepted
     end
     event :return_to_construction, after: :aasm_after_return_to_construction do
@@ -87,6 +87,10 @@ class Dossier < ApplicationRecord
 
   def aasm_after_return_to_construction
     commune.return_to_started! unless commune.started?
+  end
+
+  def aasm_after_accept
+    commune.recensements.where.not(status: "completed").find_each(&:destroy!)
   end
 
   def self.ransackable_attributes(_ = nil) = %w[status submitted_at]

--- a/app/views/conservateurs/communes/show.html.haml
+++ b/app/views/conservateurs/communes/show.html.haml
@@ -10,15 +10,15 @@
   - elsif @dossier&.can_generate_rapport?
     = render "conservateurs/dossiers/accept_cta", dossier: @dossier
   - elsif @commune.statut_global == Commune::ORDRE_REPONSE_AUTOMATIQUE
-    .fr-mb-4w 
+    .fr-mb-4w
       = dsfr_alert type: :success, size: :sm do
         Il n'y a pas d'objet à revoir, la commune a déjà reçu un email automatique, vous pouvez tout de même modifier ou commenter les recensements pour envoyer votre examen à la commune.
   - elsif @commune.statut_global == Commune::ORDRE_A_EXAMINER || @commune.statut_global == Commune::ORDRE_EN_COURS_D_EXAMEN
-    .fr-mb-4w 
+    .fr-mb-4w
       = dsfr_alert type: :info, size: :sm do
         Examinez l’ensemble des objets en péril ou disparus pour envoyer des informations complémentaires à la commune.
         = link_to_button "Envoyer l'examen à la commune", "#", class: "fr-btn", disabled: true, data: { turbo_action: "advance" }
-  
+
   .fr-mb-4w
     - if @dossier&.notes_commune.present?
       %p
@@ -33,4 +33,4 @@
       - reordered = @dossier ? edifice.objets.order_by_recensement_priorite : edifice.objets
       - reordered.each do |objet|
         .fr-col-md-4
-          = render Conservateurs::ObjetCardComponent.new objet, recensement: objet.current_recensement, can_analyse: objet.current_recensement && conservateurs_policy(Analyse.new(recensement: objet.current_recensement)).edit?, commune: @commune
+          = render Conservateurs::ObjetCardComponent.new objet, recensement: objet.current_recensement, can_analyse: objet.current_recensement&.completed? && conservateurs_policy(Analyse.new(recensement: objet.current_recensement)).edit?, commune: @commune

--- a/spec/jobs/synchronizer/objets/revision_insert_spec.rb
+++ b/spec/jobs/synchronizer/objets/revision_insert_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe Synchronizer::Objets::RevisionInsert do
   context "commune en cours de recensement" do
     let(:commune) { build(:commune, code_insee: "01004", status: :started) }
     let(:revision) { described_class.new(base_row, commune:) }
-    it "ne créé pas l’objet" do
-      expect(revision.synchronize).to eq false
-      expect(revision.action).to eq :create_rejected_commune_active
+    it "créé l’objet" do
+      expect(revision.synchronize).to eq true
+      expect(revision.action).to eq :create
+      expect(revision.objet.palissy_REF).to eq "PM01000001"
+      expect(revision.objet.palissy_DENO).to eq "tableau"
     end
   end
 
@@ -45,9 +47,11 @@ RSpec.describe Synchronizer::Objets::RevisionInsert do
     let!(:dossier) { create(:dossier, :submitted, commune:) }
     before { commune.update!(dossier:) }
     let(:revision) { described_class.new(base_row, commune:) }
-    it "ne créé pas l’objet" do
-      expect(revision.synchronize).to eq false
-      expect(revision.action).to eq :create_rejected_commune_active
+    it "créé l’objet" do
+      expect(revision.synchronize).to eq true
+      expect(revision.action).to eq :create
+      expect(revision.objet.palissy_REF).to eq "PM01000001"
+      expect(revision.objet.palissy_DENO).to eq "tableau"
     end
   end
 
@@ -59,6 +63,8 @@ RSpec.describe Synchronizer::Objets::RevisionInsert do
     it "créé l’objet" do
       expect(revision.synchronize).to eq true
       expect(revision.action).to eq :create
+      expect(revision.objet.palissy_REF).to eq "PM01000001"
+      expect(revision.objet.palissy_DENO).to eq "tableau"
     end
   end
 end


### PR DESCRIPTION
https://www.notion.so/atelier-numerique/import-Importer-les-objets-sur-les-communes-actives-758a50dcbea8405e820d64417c723291

- on créé et déplace maintenant des objets dans des communes actives
- on ne déplace cependant toujours pas depuis une commune active ayant déjà recensé l’objet
- suppression du mode interactif

![import-active](https://github.com/betagouv/collectif-objets/assets/883348/cdac58e4-0648-4d2d-bb27-7f4ba9220589)

## Test Cas 1 : nouvel objet importé alors que le dossier est en attente d’examen

côté commune : 

- badge pas encore recensé dans la liste
- l’objet peut être recensé

côté conservateur : 

- badge pas encore recensé dans la liste
- impossible à examiner, mais pas (plus) de bug
- si le conservateur examine et accepte le dossier, ça fonctionne, et l’objet apparait toujours en "pas encore recensé" mais il n’apparait pas dans le rapport. ça marche aussi côté commune post-examen

Il y a deux sous-cas si la commune commence à recenser le nouvel objet avant l’examen du dossier par le conservateur.

Sous-cas 1 : la commune entame mais ne complète pas le recensement de ce nouvel objet :

- le conservateur continue à voir cet objet comme non-recensé
- le conservateur peut examiner le dossier (sans ce recensement non complété), et à ce moment on **supprime tous les recensements non complétés de la commune** ⚠️ 💀 🛑 🙅 

Sous-cas 2 : la commune complète le recensement de ce nouvel objet

- le conservateur voit ce nouveau recensement et doit l’examiner pour accepter le dossier


## Test cas 2 : nouvel objet importé alors que le dossier a été examiné (et accepté)

côté commune

- badge pas encore recensé dans la liste
- l’objet ne peut pas être recensé
- l’objet n’apparait pas dans l’examen

côté conservateur : 

- badge pas encore recensé dans la liste
- l’objet n’apparait pas dans l’examen





