### PR TITLE
fix safeguard to prevent file deletions from prod & staging S3 buckets from local

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -2,52 +2,20 @@
 
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
-class UnsafePurgeError < StandardError
-  def initialize(blob)
-    super "Purging a file from Active Storage service '#{blob.service_name}' is not allowed from env #{Rails.env}"
-  end
-end
-
-module SafePurge
-  def safe_purge?(blob)
-    Rails.env.production? || %w[scaleway_development test local].include?(blob.service_name)
-  end
-end
-
 module PreventErroneousPurgeBlob
   include SafePurge
 
+  # monkey patch delete rather than purge because it seems to be the lowest level method
   def delete
-    return super if safe_purge?(self)
+    return super if Rails.env.production? || %w[scaleway_development test local].include?(service_name)
 
-    raise UnsafePurgeError, self
-  end
-end
-
-module PreventErroneousPurgeAttachment
-  include SafePurge
-
-  def purge
-    return super if safe_purge?(blob)
-
-    raise UnsafePurgeError, blob
-  end
-end
-
-module PreventErroneousPurgeJob
-  include SafePurge
-
-  def perform(blob)
-    return super if safe_purge?(blob)
-
-    Sidekiq.logger.warn "skipping purge of blob from Active Storage service #{blob.service_name} in env #{Rails.env}"
+    Rails.logger.warn "silently skipping unsafe file deletion from Active Storage service #{service_name} in env #{Rails.env}"
+    return false
   end
 end
 
 module Rotation
   def rotate!(degrees: 90)
-    raise UnsafePurgeError, blob unless safe_purge?
-
     rotated_tempfile = nil
     blob.open do |original_tempfile|
       rotated_tempfile = ImageProcessing::Vips.source(original_tempfile).rotate(degrees).call
@@ -109,10 +77,8 @@ end
 ActiveSupport.on_load(:active_storage_attachment) do
   ActiveStorage::Attachment.include Rotation
   ActiveStorage::Attachment.include RecensementPhoto
-  ActiveStorage::Attachment.prepend PreventErroneousPurgeAttachment
 end
 
 ActiveSupport.on_load(:active_storage_blob) do
-  ActiveStorage::PurgeJob.prepend PreventErroneousPurgeJob
   ActiveStorage::Blob.prepend PreventErroneousPurgeBlob
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -4,7 +4,7 @@ Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_
 
 class UnsafePurgeError < StandardError
   def initialize(blob)
-    super "Purge of from service #{blob.service_name} is not allowed from env #{Rails.env}"
+    super "Purging a file from Active Storage service '#{blob.service_name}' is not allowed from env #{Rails.env}"
   end
 end
 
@@ -17,7 +17,7 @@ module PreventErroneousPurgeBlob
   end
 
   def safe_purge?
-    Rails.env.production? || %w[scaleway_production scaleway].exclude?(service_name)
+    Rails.env.production? || %w[scaleway_development test local].include?(service_name)
   end
 end
 
@@ -29,7 +29,7 @@ module PreventErroneousPurgeAttachment
   end
 
   def safe_purge?
-    Rails.env.production? || %w[scaleway_production scaleway].exclude?(blob.service_name)
+    Rails.env.production? || %w[scaleway_development test local].include?(blob.service_name)
   end
 end
 
@@ -98,6 +98,6 @@ end
 ActiveSupport.on_load(:active_storage_attachment) do
   ActiveStorage::Attachment.include Rotation
   ActiveStorage::Attachment.include RecensementPhoto
-  ActiveStorage::Attachment.include PreventErroneousPurgeAttachment
-  ActiveStorage::Blob.include PreventErroneousPurgeBlob
+  ActiveStorage::Attachment.prepend PreventErroneousPurgeAttachment
+  ActiveStorage::Blob.prepend PreventErroneousPurgeBlob
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -3,8 +3,6 @@
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
 
 module PreventErroneousPurgeBlob
-  include SafePurge
-
   # monkey patch delete rather than purge because it seems to be the lowest level method
   def delete
     return super if Rails.env.production? || %w[scaleway_development test local].include?(service_name)

--- a/spec/active_storage_safe_purge_spec.rb
+++ b/spec/active_storage_safe_purge_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Active Storage safe purge monkey patches" do
+  let(:mock_service) { double("active_storage_service") }
+  let(:local_blob) do
+    ActiveStorage::Blob.create_and_upload!(
+      io: Rails.root.join("spec/fixture_files/peinture1.jpg").open("rb"),
+      filename: "peinture1.jpg",
+      content_type: "image/jpeg"
+    )
+  end
+
+  before do
+    class << local_blob
+      include RSpec::Mocks::ExampleMethods
+      def service
+        @service ||= double("active_storage_service")
+      end
+    end
+  end
+
+  context "blob uses local service" do
+    let(:blob) { local_blob }
+    it "should delete the blob" do
+      expect(blob.service).to receive(:delete)
+      expect(blob.service).to receive(:delete_prefixed)
+      res = blob.delete
+      expect(res).not_to eq(false)
+    end
+  end
+
+  context "blob uses prod service" do
+    let(:blob) { local_blob.tap { _1.update!(service_name: "scaleway_production") } }
+    it "should not delete the blob" do
+      expect(blob.service).not_to receive(:delete)
+      expect(blob.service).not_to receive(:delete_prefixed)
+      res = blob.delete
+      expect(res).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Corrections : 

- Le monkey patch des blobs n’était pas chargé au bon endroit, il faut se brancher au hook spécifiques aux blobs : `ActiveSupport.on_load(:active_storage_blob)` et pas celui des attachments

Modifications : 

- Le monkey patch de vérification de la dangerosité n’est plus fait qu’à un seul endroit, le plus bas possible : `ActiveStorage::Blob.delete`
- On ne raise plus mais on skippe silencieusement le delete
- ajout de specs
- passage d’une liste d’exclusion des buckets dangereux à une liste d’inclusion des buckets sans danger, ça me paraît plus prudent (la liste d’exclusion ne contenait notamment pas le bucket de staging)

Tests manuels en local : 

- j’import un dump full de staging 
- je me connecte en tant que conservateur 
- je vais sur un dossier à examiner, sur un recensement avec photo
- je récupère l’URL de la photo directement (sans proxy local) depuis la console rails (`Recensement.find(468).photos.first.url`) et je l’ouvre dans une autre tab
- je supprime la photo depuis la galerie 
- je vérifie que je peux recharger la tab avec la photo sur le bucket staging : elle n’a pas été supprimée
- je répète la manip avec la rotation


Pistes d’amélioration : 

Un rempart plus sur serait d’utiliser en local une clé d’API s3 R-O sur les buckets de staging et prod ! on essaiera ça une fois qu’on sera passés sur le S3 OVH. je fais un ticket GH 
