### PR TITLE
remove users.role (with migration)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,7 +13,7 @@ module Admin
     end
 
     def create
-      @user = User.new(email: params[:user][:email], commune_id: params[:user][:commune_id], role: "mairie",
+      @user = User.new(email: params[:user][:email], commune_id: params[:user][:commune_id],
                        magic_token: SecureRandom.hex(10))
       if @user.save
         redirect_to admin_commune_path(id: params[:user][:commune_id]), notice: "L'usager a été ajouté"

--- a/app/controllers/users/magic_links_controller.rb
+++ b/app/controllers/users/magic_links_controller.rb
@@ -2,7 +2,7 @@
 
 module Users
   class MagicLinksController < ApplicationController
-    before_action :prevent_missing_email, :prevent_admin
+    before_action :prevent_missing_email
 
     def create
       MagicLink.new(email).create => {success:, error:}
@@ -23,12 +23,6 @@ module Users
 
     def user
       @user ||= User.find_by("email ILIKE ?", email)
-    end
-
-    def prevent_admin
-      return true if user.nil? || user&.mairie?
-
-      redirect_to(new_user_session_path, alert: "Impossible de se connecter avec un compte d'administrateur")
     end
 
     def prevent_missing_email

--- a/app/jobs/synchronizer/communes/revision.rb
+++ b/app/jobs/synchronizer/communes/revision.rb
@@ -82,7 +82,6 @@ module Synchronizer
         user = User.create(
           email:,
           magic_token: SecureRandom.hex(10),
-          role: User::ROLE_MAIRIE,
           commune_id: commune.id
         )
         return unless user.errors.any?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :recoverable, :rememberable, :validatable, :registerable
 
   belongs_to :commune, optional: true
-  validates :role, presence: true, inclusion: { in: ROLES }
 
   accepts_nested_attributes_for :commune
 
@@ -22,7 +21,6 @@ class User < ApplicationRecord
   end
 
   def password_required? = false
-  def mairie? = role == ROLE_MAIRIE
   def safe_email? = SAFE_DOMAINS.include?(email.split("@").last)
   def to_s = email.split("@")[0]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  ROLE_MAIRIE = "mairie"
-  ROLES = [ROLE_MAIRIE].freeze
   SAFE_DOMAINS = %w[beta.gouv.fr dipasquale.fr failfail.fr mailcatch.com gmail.com].freeze
 
   devise :database_authenticatable, :recoverable, :rememberable, :validatable, :registerable

--- a/db/migrate/20240119181855_remove_users_role.rb
+++ b/db/migrate/20240119181855_remove_users_role.rb
@@ -1,0 +1,10 @@
+class RemoveUsersRole < ActiveRecord::Migration[7.1]
+  def up
+    remove_column :users, :role, :string
+  end
+
+  def down
+    add_column :users, :role, :string
+    User.update_all(role: "mairie")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_19_170321) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_19_181855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -323,7 +323,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_19_170321) do
     t.datetime "updated_at", null: false
     t.bigint "commune_id"
     t.string "magic_token"
-    t.string "role", null: false
     t.string "nom"
     t.string "job_title"
     t.string "email_personal"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user-#{n + 1}@mairie-tests.fr" }
-    role { "mairie" }
     sequence(:magic_token) { |n| "#{n}-#{SecureRandom.hex(5)}" }
   end
 end

--- a/spec/features/communes/read_rapport_spec.rb
+++ b/spec/features/communes/read_rapport_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Communes - Read rapport", type: :feature, js: true do
   let!(:departement) { create(:departement, code: "26", nom: "Drôme") }
   let!(:commune) { create(:commune, status: "completed", nom: "Albon", code_insee: "26002", departement:) }
-  let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:, magic_token: "magiemagie") }
+  let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:, magic_token: "magiemagie") }
   let!(:conservateur) do
     create(:conservateur,
            first_name: "Jean", last_name: "Lobo", email: "jeanne@culture.gouv.fr",

--- a/spec/features/communes/recensement_spec.rb
+++ b/spec/features/communes/recensement_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
 
   let!(:departement) { create(:departement, code: "26", nom: "Drôme") }
   let!(:commune) { create(:commune, nom: "Albon", code_insee: "26002", departement:) }
-  let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:, magic_token: "magiemagie") }
+  let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:, magic_token: "magiemagie") }
   let!(:edifice) { create(:edifice, code_insee: commune.code_insee) }
   let!(:objet_bouquet) do
     create(:objet, palissy_TICO: "Bouquet d’Autel", palissy_EDIF: "Eglise st Jean", commune:, edifice:)

--- a/spec/features/communes/send_message_spec.rb
+++ b/spec/features/communes/send_message_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Communes - send message", type: :feature, js: true do
   let!(:departement) { create(:departement, code: "26", nom: "Drôme") }
   let!(:commune) { create(:commune, nom: "Albon", code_insee: "26002", departement:) }
-  let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:, magic_token: "magiemagie") }
+  let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:, magic_token: "magiemagie") }
 
   it "should let user send a message" do
     login_as(user, scope: :user)

--- a/spec/features/communes/sign_in_with_token_spec.rb
+++ b/spec/features/communes/sign_in_with_token_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.feature "Sign in with token", type: :feature, js: true do
   let!(:departement) { create(:departement, code: "26", nom: "Drôme") }
   let!(:commune) { create(:commune, nom: "Albon", code_insee: "26002", departement:) }
-  let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:, magic_token: "magiemagie") }
+  let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:, magic_token: "magiemagie") }
 
   include ActiveJob::TestHelper
 

--- a/spec/features/conservateurs/accept_dossier_spec.rb
+++ b/spec/features/conservateurs/accept_dossier_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Conservateurs - Accept Dossier", type: :feature, js: true do
   let!(:edifice) { create(:edifice, code_insee: "26002", nom: "Église St Jean", slug: "eglise-st-jean") }
   let!(:dossier) { create(:dossier, :submitted, commune:) }
   before { commune.update!(dossier:) }
-  let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:) }
+  let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:) }
   let!(:objet_bouquet) { create(:objet, palissy_TICO: "Bouquet d'Autel", edifice:, commune:) }
   let!(:recensement_bouquet) do
     create(

--- a/spec/models/bordereau/pdf_spec.rb
+++ b/spec/models/bordereau/pdf_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Bordereau::Pdf" do
     let!(:departement) { create(:departement, code: "26", nom: "Drôme") }
     let!(:commune) { create(:commune, status: "completed", nom: "Albon", code_insee: "26002", departement:) }
     let!(:edifice) { create(:edifice, nom: "Eglise st Jean", commune:) }
-    let!(:user) { create(:user, email: "mairie-albon@test.fr", role: "mairie", commune:, magic_token: "magiemagie") }
+    let!(:user) { create(:user, email: "mairie-albon@test.fr", commune:, magic_token: "magiemagie") }
     let!(:conservateur) do
       create(:conservateur,
              first_name: "Jean", last_name: "Lobo", email: "jeanne@culture.gouv.fr",


### PR DESCRIPTION
closes #929

aucun changements fonctionnels

la méthode `prevent_admin` ne faisait en fait rien, c’est un héritage de quand on avait une seule table `users` avec les admins et les users 