### PR TITLE
ajout d’un sanity check sur les generations de bordereaux de recolement

### DIFF
--- a/app/jobs/sanity_checks_job.rb
+++ b/app/jobs/sanity_checks_job.rb
@@ -7,6 +7,7 @@ class SanityChecksJob < ApplicationJob
     check_commune_started_dossier_construction
     check_commune_completed_dossier_submitted
     check_campaign_statuses_and_dates
+    check_bordereaux_created
   end
 
   protected
@@ -46,5 +47,19 @@ class SanityChecksJob < ApplicationJob
       logger.info text
       AdminMailer.with(email: EMAIL, campaign:, text:).sanity_check_alert.deliver_later
     end
+  end
+
+  def check_bordereaux_created
+    edifices_with_problems = Edifice
+      .where.missing(:bordereau_attachment)
+      .where("bordereau_generation_enqueued_at < ?", 5.minutes.ago)
+      .includes(:commune)
+
+    return if edifices_with_problems.empty?
+
+    text = "Les édifices suivants ont un bordereau en attente de génération depuis plus de 5 minutes : " \
+           "#{edifices_with_problems.pluck(:id).join(', ')}"
+    logger.info text
+    AdminMailer.with(email: EMAIL, text:).sanity_check_alert.deliver_later
   end
 end

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,7 +3,7 @@
 class AdminMailer < ApplicationMailer
   def sanity_check_alert
     @email, @commune, @text = params.values_at(:email, :commune, :text)
-    mail to: @email, subject: "#{title_prefix} - Sanity Check Alert - #{@commune}"
+    mail to: @email, subject: [title_prefix, "Sanity Check Alert", @commune].compact.join(" - ")
   end
 
   def campaign_planned(conservateur, campaign)

--- a/app/views/admin_mailer/sanity_check_alert.text.erb
+++ b/app/views/admin_mailer/sanity_check_alert.text.erb
@@ -2,6 +2,8 @@
 
 Un problème a été détecté lors des sanity checks :
 
-Commune: <%= @commune %>
+<% if @commune %>
+  Commune: <%= @commune %>
+<% end %>
 
 <%= @text %>


### PR DESCRIPTION
j’ai écrit ce petit sanity check supplémentaire pour verifier que les jobs de generation de bordereaux de recolement se depilent correctement

j’ai eu un doute car en local ce n’était pas le cas, mais j’ai lancé en prod et tout va bien.