### PR TITLE
1. Import des objets déplacés (DEPL, WEB & MOSA)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,6 +67,12 @@ Naming/MethodName:
   Exclude:
     - app/jobs/synchronizer/**/*
 
+# we use parameter names like merimee_REF in the synchronizer
+Naming/MethodParameterName:
+  Exclude:
+    - app/jobs/synchronizer/**/*
+
+# we use variable names like merimee_REF in the synchronizer
 Naming/VariableName:
   Exclude:
     - app/jobs/synchronizer/**/*

--- a/app/jobs/synchronizer/objets/batch/base.rb
+++ b/app/jobs/synchronizer/objets/batch/base.rb
@@ -51,7 +51,7 @@ module Synchronizer
         def skipped_rows_count = @csv_rows.count - revisions.count
 
         def unique_palissy_REFs = @csv_rows.pluck("reference").uniq
-        def unique_code_insees = all_objets_attributes.pluck(:palissy_INSEE).uniq
+        def unique_code_insees = all_objets_attributes.pluck(:lieu_actuel_code_insee).compact.uniq
       end
     end
   end

--- a/app/jobs/synchronizer/objets/batch/eager_loaded_records.rb
+++ b/app/jobs/synchronizer/objets/batch/eager_loaded_records.rb
@@ -15,20 +15,20 @@ module Synchronizer
         end
 
         def commune
-          @eager_loader.communes_by_code_insee[@objet_attributes[:palissy_INSEE]]
+          @eager_loader.communes_by_code_insee[@objet_attributes[:lieu_actuel_code_insee]]
         end
 
         def edifice_by_ref
-          return if @objet_attributes[:palissy_REFA].blank?
+          return if @objet_attributes[:lieu_actuel_edifice_ref].blank?
 
-          @eager_loader.edifices_by_ref[@objet_attributes[:palissy_REFA]]
+          @eager_loader.edifices_by_ref[@objet_attributes[:lieu_actuel_edifice_ref]]
         end
 
         def edifice_by_code_insee_and_slug
           @eager_loader.edifices_by_code_insee_and_slug[
             [
-              @objet_attributes[:palissy_INSEE],
-              ::Edifice.slug_for(@objet_attributes[:palissy_EDIF])
+              @objet_attributes[:lieu_actuel_code_insee],
+              ::Edifice.slug_for(@objet_attributes[:lieu_actuel_edifice_nom])
             ]
           ]
         end

--- a/app/jobs/synchronizer/objets/parser.rb
+++ b/app/jobs/synchronizer/objets/parser.rb
@@ -4,7 +4,7 @@ module Synchronizer
   module Objets
     module Parser
       def parse_row_to_objet_attributes(row)
-        {
+        parsed = {
           palissy_REF: row["reference"],
           palissy_COM: row["commune_forme_index"],
           palissy_INSEE: row["cog_insee"]&.split(",")&.first,
@@ -19,8 +19,41 @@ module Synchronizer
           palissy_DENO: row["denomination"],
           palissy_CATE: row["categorie_technique"],
           palissy_SCLE: row["siecle_de_creation"],
-          palissy_DENQ: row["date_du_recolement"]
+          palissy_DENQ: row["date_du_recolement"],
+          palissy_DEPL: row["lieu_de_deplacement_de_l_objet"].presence,
+          palissy_WEB: row["code_insee_commune_actuelle"].presence,
+          palissy_MOSA: row["edifice_actuel"].presence
         }
+        parsed.merge(lieu_actuel_attributes(**parsed))
+      end
+
+      def lieu_actuel_attributes(palissy_WEB:, palissy_MOSA:, palissy_DEPL:, palissy_INSEE:, palissy_EDIF:,
+                                 palissy_REFA:, **_)
+        if palissy_WEB.blank?
+          # WEB vide : pas de déplacement ni de changement de code INSEE
+          {
+            lieu_actuel_code_insee: palissy_INSEE,
+            lieu_actuel_edifice_nom: palissy_EDIF,
+            lieu_actuel_edifice_ref: palissy_REFA
+          }
+        elsif palissy_DEPL.blank?
+          # WEB rempli & DEPL vide = pas de déplacement mais la commune a changé de code INSEE
+          {
+            lieu_actuel_code_insee: palissy_WEB,
+            lieu_actuel_edifice_nom: palissy_EDIF,
+            lieu_actuel_edifice_ref: palissy_REFA
+          }
+        else
+          # WEB rempli & DEPL rempli = objet déplacé dans une autre commune
+          mosa_splitted = (palissy_MOSA || "").split(";").map(&:strip).map(&:presence)
+          {
+            lieu_actuel_code_insee: palissy_WEB,
+            lieu_actuel_edifice_nom: mosa_splitted[0],
+            lieu_actuel_edifice_ref: mosa_splitted[1]
+          }
+        end
+        # NOTE: il n’y a pas besoin de lieu_actuel_empl car EMPL contient déjà l’emplacement actuel
+        # même si c’est surprenant par rapport aux autres champs INSEE, EDIF et REFA
       end
     end
   end

--- a/app/jobs/synchronizer/objets/revision_edifice_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_edifice_concern.rb
@@ -16,11 +16,12 @@ module Synchronizer
       end
 
       def compute_edifice_attributes
-        if existing_edifice_by_ref && existing_edifice_by_ref.code_insee == @objet_attributes[:palissy_INSEE]
+        if existing_edifice_by_ref && existing_edifice_by_ref.code_insee == @objet_attributes[:lieu_actuel_code_insee]
           { edifice_id: existing_edifice_by_ref.id }
         elsif existing_edifice_by_code_insee_and_slug
           { edifice_id: existing_edifice_by_code_insee_and_slug.id }
-        elsif existing_edifice_by_ref && existing_edifice_by_ref.code_insee != @objet_attributes[:palissy_INSEE]
+        elsif existing_edifice_by_ref &&
+              existing_edifice_by_ref.code_insee != @objet_attributes[:lieu_actuel_code_insee]
           # l’édifice trouvé via le REFA est dans une autre commune, on ne l’utilise pas pour cet
           # objet et on en créé un nouveau dans la bonne commune sans REFA pour éviter un conflit
           { edifice_attributes: new_edifice_attributes.except(:merimee_REF) }
@@ -34,10 +35,10 @@ module Synchronizer
 
       def new_edifice_attributes
         {
-          merimee_REF: @objet_attributes[:palissy_REFA].presence,
-          code_insee: @objet_attributes[:palissy_INSEE],
-          slug: ::Edifice.slug_for(@objet_attributes[:palissy_EDIF]),
-          nom: @objet_attributes[:palissy_EDIF]
+          merimee_REF: @objet_attributes[:lieu_actuel_edifice_ref].presence,
+          code_insee: @objet_attributes[:lieu_actuel_code_insee],
+          slug: ::Edifice.slug_for(@objet_attributes[:lieu_actuel_edifice_nom]),
+          nom: @objet_attributes[:lieu_actuel_edifice_nom]
         }
       end
     end

--- a/app/jobs/synchronizer/objets/revision_update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_update_concern.rb
@@ -25,6 +25,12 @@ module Synchronizer
             palissy_DPT
             palissy_EDIF
             palissy_EMPL
+            palissy_DEPL
+            palissy_WEB
+            palissy_MOSA
+            lieu_actuel_code_insee
+            lieu_actuel_edifice_nom
+            lieu_actuel_edifice_ref
           ]
         end
         f

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -26,7 +26,7 @@ class Commune < ApplicationRecord
   has_many :users, dependent: :restrict_with_exception
   has_many(
     :objets,
-    foreign_key: :palissy_INSEE,
+    foreign_key: :lieu_actuel_code_insee,
     primary_key: :code_insee,
     inverse_of: :commune,
     dependent: :restrict_with_exception

--- a/app/models/concerns/communes/include_counts_concern.rb
+++ b/app/models/concerns/communes/include_counts_concern.rb
@@ -13,8 +13,8 @@ module Communes
         joins(
           %{
           LEFT OUTER JOIN (
-            #{Objet.select(:palissy_INSEE, 'COUNT(*) AS objets_count').group(:palissy_INSEE).to_sql}
-          ) a ON a."palissy_INSEE" = communes.code_insee
+            #{Objet.select(:lieu_actuel_code_insee, 'COUNT(*) AS objets_count').group(:lieu_actuel_code_insee).to_sql}
+          ) a ON a.lieu_actuel_code_insee = communes.code_insee
           }.squish
         ).select("communes.*, COALESCE(a.objets_count, 0) AS objets_count")
       end
@@ -26,15 +26,15 @@ module Communes
         joins(
           %{
             LEFT OUTER JOIN (
-              #{Recensement.select(%{objets."palissy_INSEE",
+              #{Recensement.select(%{objets.lieu_actuel_code_insee,
                 SUM(CASE WHEN #{Recensement::RECENSEMENT_ABSENT_SQL} THEN 1 ELSE 0 END) AS disparus_count,
                 SUM(CASE WHEN #{Recensement::RECENSEMENT_EN_PERIL_SQL} THEN 1 ELSE 0 END) AS en_peril_count
                  })
                 .left_outer_joins(:objet)
                 .where(Recensement::RECENSEMENT_PRIORITAIRE_SQL)
-                .group(:palissy_INSEE).to_sql}
+                .group(:lieu_actuel_code_insee).to_sql}
             ) AS recensements_prioritaires
-            ON recensements_prioritaires."palissy_INSEE" = communes.code_insee
+            ON recensements_prioritaires.lieu_actuel_code_insee = communes.code_insee
           }.squish
         ).select(%(
           COALESCE(recensements_prioritaires.disparus_count, 0) AS disparus_count,

--- a/app/models/concerns/dossiers/include_counts_concern.rb
+++ b/app/models/concerns/dossiers/include_counts_concern.rb
@@ -13,7 +13,7 @@ module Dossiers
           LEFT JOIN (
             SELECT communes.id, COUNT(*) AS objets_count
               FROM communes
-              INNER JOIN objets ON communes.code_insee = "objets"."palissy_INSEE"
+              INNER JOIN objets ON communes.code_insee = "objets".lieu_actuel_code_insee
               GROUP BY communes.id
           ) AS nombre_objets_par_commune
           ON nombre_objets_par_commune.id = dossiers.commune_id

--- a/app/models/departement.rb
+++ b/app/models/departement.rb
@@ -28,7 +28,7 @@ class Departement < ApplicationRecord
         LEFT OUTER JOIN (
           SELECT communes.departement_code, COUNT(objets.id) objets_count
           FROM objets
-          LEFT JOIN communes ON communes.code_insee = objets."palissy_INSEE"
+          LEFT JOIN communes ON communes.code_insee = objets.lieu_actuel_code_insee
           GROUP BY communes.departement_code
         ) b ON b."departement_code" = departements.code
       }

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -4,7 +4,8 @@ class Objet < ApplicationRecord
   include ActionView::Helpers::TextHelper # for truncate
 
   scope :with_images, -> { where("cardinality(palissy_photos) >= 1") }
-  belongs_to :commune, foreign_key: :palissy_INSEE, primary_key: :code_insee, optional: true, inverse_of: :objets
+  belongs_to :commune, foreign_key: :lieu_actuel_code_insee, primary_key: :code_insee, optional: true,
+                       inverse_of: :objets
   belongs_to :edifice, optional: true
   has_many :recensements, dependent: :restrict_with_exception
 
@@ -50,7 +51,7 @@ class Objet < ApplicationRecord
   alias_attribute :nom, :palissy_TICO
   alias_attribute :categorie, :palissy_CATE
   alias_attribute :commune_nom, :palissy_COM
-  alias_attribute :commune_code_insee, :palissy_INSEE
+  alias_attribute :commune_code_insee, :lieu_actuel_code_insee
   # alias_attribute :departement, :palissy_DPT
   alias_attribute :crafted_at, :palissy_SCLE
   alias_attribute :last_recolement_at, :palissy_DENQ

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -41,6 +41,8 @@ class Objet < ApplicationRecord
                      .where.not(MIS_DE_COTE_SQL)
                    }
   scope :protégés, -> { classés.or(inscrits) }
+  scope :code_insee_a_changé, -> { where.not(palissy_WEB: nil).where.not(palissy_DEPL: nil) }
+  scope :déplacés, -> { where.not(palissy_WEB: nil).where(palissy_DEPL: nil) }
 
   after_create { RefreshCommuneRecensementRatioJob.perform_later(commune.id) if commune }
   after_destroy { RefreshCommuneRecensementRatioJob.perform_later(commune.id) if commune }
@@ -98,4 +100,6 @@ class Objet < ApplicationRecord
   end
 
   def to_s = palissy_TICO
+  def déplacé? = palissy_WEB.present? && palissy_DEPL.present?
+  def code_insee_a_changé? = palissy_WEB.present? && palissy_DEPL.blank?
 end

--- a/app/models/pop_export.rb
+++ b/app/models/pop_export.rb
@@ -28,7 +28,7 @@ class PopExport < ApplicationRecord
       .where(record_type: "Recensement", exportable: true)
       .joins("LEFT JOIN recensements ON recensements.id = active_storage_attachments.record_id")
       .joins("LEFT JOIN objets ON objets.id = recensements.objet_id")
-      .joins('LEFT JOIN communes ON communes.code_insee = objets."palissy_INSEE"')
+      .joins("LEFT JOIN communes ON communes.code_insee = objets.lieu_actuel_code_insee")
       .where(recensements: { pop_export_memoire_id: id })
       .order('communes.nom ASC, objets."palissy_REF" ASC')
   end

--- a/app/views/shared/_objet_attributes.html.haml
+++ b/app/views/shared/_objet_attributes.html.haml
@@ -28,6 +28,19 @@
   %br
   = objet.palissy_DPRO || "N/A"
 
+- if objet.palissy_WEB.present? && objet.palissy_DEPL.present?
+  %p
+    %b Déplacement
+    %br
+    Cet objet a été déplacé depuis sa protection, il se trouvait à l’origine dans la commune #{objet.palissy_COM}.
+
+- elsif objet.palissy_WEB.present? && objet.palissy_DEPL.blank?
+  %p
+    %b Changement de code INSEE
+    %br
+    Cet objet se trouvait à l’origine dans la commune #{objet.palissy_COM} (code INSEE #{objet.palissy_INSEE}).
+    Cette commune a probablement fusionné dans la commune actuelle #{objet.commune.nom} (code INSEE #{objet.lieu_actuel_code_insee}).
+
 %p
   %b Récolement
   %br

--- a/app/views/shared/_objet_attributes.html.haml
+++ b/app/views/shared/_objet_attributes.html.haml
@@ -28,13 +28,13 @@
   %br
   = objet.palissy_DPRO || "N/A"
 
-- if objet.palissy_WEB.present? && objet.palissy_DEPL.present?
+- if objet.déplacé?
   %p
     %b Déplacement
     %br
     Cet objet a été déplacé depuis sa protection, il se trouvait à l’origine dans la commune #{objet.palissy_COM}.
 
-- elsif objet.palissy_WEB.present? && objet.palissy_DEPL.blank?
+- elsif objet.code_insee_a_changé?
   %p
     %b Changement de code INSEE
     %br

--- a/db/migrate/20240208151633_add_palissy_depl_web_mosa_to_objets.rb
+++ b/db/migrate/20240208151633_add_palissy_depl_web_mosa_to_objets.rb
@@ -1,0 +1,23 @@
+class AddPalissyDeplWebMosaToObjets < ActiveRecord::Migration[7.1]
+  def change
+    add_column :objets, "palissy_DEPL", :string
+    add_column :objets, "palissy_WEB", :string
+    add_column :objets, "palissy_MOSA", :string
+    add_column :objets, "lieu_actuel_code_insee", :string
+    add_column :objets, "lieu_actuel_edifice_nom", :string
+    add_column :objets, "lieu_actuel_edifice_ref", :string
+
+    reversible do |dir|
+      dir.up do
+        ActiveRecord::Base.connection.execute \
+          <<~SQL
+            UPDATE objets
+            SET
+              "lieu_actuel_code_insee" = "palissy_INSEE",
+              "lieu_actuel_edifice_nom" = "palissy_EDIF",
+              "lieu_actuel_edifice_ref" = "palissy_REFA";
+          SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_090850) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_151633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -330,6 +330,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_090850) do
     t.bigint "edifice_id"
     t.string "palissy_PROT"
     t.string "palissy_DPRO"
+    t.string "palissy_DEPL"
+    t.string "palissy_WEB"
+    t.string "palissy_MOSA"
+    t.string "lieu_actuel_code_insee"
+    t.string "lieu_actuel_edifice_nom"
+    t.string "lieu_actuel_edifice_ref"
     t.index ["edifice_id"], name: "index_objets_on_edifice_id"
     t.index ["palissy_COM"], name: "index_objets_on_palissy_COM"
     t.index ["palissy_DPT"], name: "index_objets_on_palissy_DPT"


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/G-rer-les-d-placements-d-objets-lors-de-l-import-79469ac8661b4286b24b60516d692b05

## PR préliminaire

Je me suis permis de déployer une PR de petits refactos et un correctif : eef08e4bee9669ce0c8a7352f6a0cb2a04cbcc60 . Ça permet de rendre cette PR plus concise et lisible. 

J’ai aussi extrait dans une PR successive la MàJ du diagramme de schéma de base de données parce que ce changement faisait exploser le nombre de lignes modifiées dans cette PR 😬  #1162 

## Description des changements dans cette PR

On importe trois nouveaux champs de Palissy :

- `palissy_DEPL` (`lieu_de_deplacement_de_l_objet`)
- `palissy_WEB` (`code_insee_commune_actuelle`)
- `palissy_MOSA` (`edifice_actuel`)

Et on ajoute trois champs supplémentaires dans la table objets: 

- `lieu_actuel_code_insee`
- `lieu_actuel_edifice_nom`
- `lieu_actuel_edifice_ref`

Ces trois champs sont redondants : ils contiennent des infos déductibles des infos Palissy en appliquant ces règles : 

- WEB vide : pas de déplacement ni de changement de code INSEE
- WEB rempli & DEPL vide = pas de déplacement mais la commune a changé de code INSEE
- WEB rempli & DEPL rempli = objet déplacé dans une autre commune

On choisit d’appliquer ces règles à l’import et de stocker en dur les infos redondantes pour simplifier l’usage dans l’app. 


> [!IMPORTANT]  
> Le gros changement principal de cette PR : La clé de jointure entre communes et objets change : `lieu_actuel_code_insee` plutôt que `palissy_INSEE`. 

## Changements attendus et effectifs lors de la prochaine synchro

La première synchro sur cette branche en local sur un dump de la db a pris 3 minutes.

dans le CSV Palissy de data.culture.gouv.fr je compte :

1. 3_491 lignes où WEB et DEPL sont remplis (= déplacement d’objet) 
2. 7_520 lignes où WEB est rempli mais DEPL vide (= fusion de commune)  

<details>
<summary>Commandes XSV pour arriver à ces chiffres</summary>

requete 1 :
 
```sh
xsv search --select Code_INSEE_commune_actuelle '\d+' --delimiter ';' ~/Downloads/liste-des-objets-mobiliers-propriete-publique-classes-au-titre-des-monuments-1.csv| xsv search --select Lieu_de_deplacement_de_l_objet '\w' | xsv count
```

requete 2 : 

```
xsv search --select Code_INSEE_commune_actuelle '\d+' --delimiter ';' ~/Downloads/liste-des-objets-mobiliers-propriete-publique-classes-au-titre-des-monuments-1.csv| xsv search --select Lieu_de_deplacement_de_l_objet '^$' | xsv count
```
</details>

= jusqu’à 11_011 objets devraient changer de commune suite à cette PR (certains sont probablement hors-scope CO)

en lançant sur un dump récent de la prod, la synchro avec le code de cette PR donne :
- 6_263 créations d’objets 
- 2_740 mises à jour avec changement de communes
- 250  mises à jour avec changement de communes bloquées car il y a des recensements préexistants (ce sujet sera traité dans une autre PR)

Les nombreuses créations d’objets sont logiques : on n’importe pour l’instant que les objets pour lesquels il existe une commune en base de données. Or on ne créé pour l’instant que les communes provenant de l’API Service Public et il n’y a que les communes actuelles dans cette API. Dans notre base il n’y a donc pas les anciennes communes ayant fusionnées. Ces objets ne pouvaient donc pas être importés jusque là.

on arrive en tout à 9_253 objets qui changent de communes dans les logs de la synchro de cette PR 
c’est bien inférieur 11_0111, il y a un écart un peu plus important que ce que j’imaginais mais c’est probablement car on ne créé pas encore les communes à la volée donc une partie des objets ne peuvent pas être importés. 

## Déploiement

Il n’y a en fait pas besoin de downtime pour le déploiement de cette PR et ça peut se faire en un seul deploy.

- Lors de la migration lancée en post-deploy hook, on écrit en dur `objets.lieu_actuel_code_insee = palissy_INSEE` sur tous les objets. La migration prend 14s en local sur un dump de prod, on peut s’attendre à quelques minutes en prod.
- juste après la migration, le nouveau code sera donc appliqué et la jointure se fera sur base de `lieu_actuel_code_insee` mais il n’y aura donc aucune différence avec avant.
- on pourra ensuite lancer la synchro des objets et les objets seront déplacés (càd que leur `lieu_actuel_code_insee` changera)

Post déploiement, bien penser à prévenir équipe de changer toutes les jointures dans metabase !

## Note

Il n’y a pour l’instant aucune référence Mérimée post-déploiement dans Palissy. On s’est mis d’accord avec la MPP pour que cette info soit dans le champ `MOSA` à côté du nom de l’édifice mais il n’y en a pour l’instant aucun.

Il faudrait envoyer un mail à la MPP pour confirmer avec eux qu’ils ont bien toujours ça en tête et quel format ils souhaitent utiliser. j’ai supposé que noms et références seront séparés par un `;` dans cette PR mais il faudra re-valider avec eux, je crois que ce n’était pas clair dans nos derniers échanges.