### PR TITLE
synchro objets : minor improvements and refactors

### DIFF
--- a/app/controllers/objets_controller.rb
+++ b/app/controllers/objets_controller.rb
@@ -18,7 +18,7 @@ class ObjetsController < ApplicationController
   def show
     @objet = Objet.find(params[:id])
 
-    return true if @objet.palissy_INSEE.present?
+    return true if @objet.commune.present?
 
     redirect_to root_path, alert: "Cet objet n'est lié à aucune commune"
   end

--- a/app/jobs/synchronizer/objets/batch/base.rb
+++ b/app/jobs/synchronizer/objets/batch/base.rb
@@ -39,6 +39,8 @@ module Synchronizer
         end
 
         def synchronize_each_revision
+          logfile&.puts "--- new batch ---"
+          logfile&.flush
           revisions.each do |revision|
             success = revision.synchronize
             @eager_load_store.add_edifice(revision.objet.edifice) if success && revision.new_edifice?

--- a/app/jobs/synchronizer/objets/batch/eager_load_store.rb
+++ b/app/jobs/synchronizer/objets/batch/eager_load_store.rb
@@ -44,11 +44,10 @@ module Synchronizer
         end
 
         def add_edifice(edifice)
-          if edifice.merimee_REF.present?
-            edifices_by_ref[edifice.merimee_REF] = edifice
-          else
-            edifices_by_code_insee_and_slug[[edifice.code_insee, edifice.slug]] = edifice
-          end
+          @batch.logfile&.puts "édifice créé #{edifice.attributes.slice(*%w[code_insee merimee_REF slug nom id])}"
+          @batch.logfile&.flush
+          edifices_by_code_insee_and_slug[[edifice.code_insee, edifice.slug]] = edifice
+          edifices_by_ref[edifice.merimee_REF] = edifice if edifice.merimee_REF.present?
         end
       end
     end

--- a/app/jobs/synchronizer/objets/parser.rb
+++ b/app/jobs/synchronizer/objets/parser.rb
@@ -3,29 +3,24 @@
 module Synchronizer
   module Objets
     module Parser
-      OBJET_ATTRIBUTES_MAPPING = {
-        palissy_REF: "reference",
-        palissy_COM: "commune_forme_index",
-        palissy_INSEE: "cog_insee",
-        palissy_DPT: "departement_format_numerique",
-        palissy_DOSS: "typologie_du_dossier",
-        palissy_EDIF: "nom_de_l_edifice",
-        palissy_EMPL: "emplacement_de_l_oeuvre_dans_l_edifice",
-        palissy_TICO: "titre_editorial",
-        palissy_DPRO: "date_et_typologie_de_la_protection",
-        palissy_PROT: "typologie_de_la_protection",
-        palissy_REFA: "reference_a_une_notice_merimee_mh",
-        palissy_DENO: "denomination",
-        palissy_CATE: "categorie_technique",
-        palissy_SCLE: "siecle_de_creation",
-        palissy_DENQ: "date_du_recolement"
-      }.freeze
-
       def parse_row_to_objet_attributes(row)
-        parsed = OBJET_ATTRIBUTES_MAPPING.transform_values { row[_1] }
-        parsed[:palissy_INSEE] = parsed[:palissy_INSEE]&.split(",")&.first
-        parsed[:palissy_REFA] = parsed[:palissy_REFA]&.match(/PA[A-B0-9]{2}\d{6}/)&.to_s
-        parsed
+        {
+          palissy_REF: row["reference"],
+          palissy_COM: row["commune_forme_index"],
+          palissy_INSEE: row["cog_insee"]&.split(",")&.first,
+          palissy_DPT: row["departement_format_numerique"],
+          palissy_DOSS: row["typologie_du_dossier"],
+          palissy_EDIF: row["nom_de_l_edifice"],
+          palissy_EMPL: row["emplacement_de_l_oeuvre_dans_l_edifice"],
+          palissy_TICO: row["titre_editorial"],
+          palissy_DPRO: row["date_et_typologie_de_la_protection"],
+          palissy_PROT: row["typologie_de_la_protection"],
+          palissy_REFA: row["reference_a_une_notice_merimee_mh"]&.match(/PA[A-B0-9]{2}\d{6}/)&.to_s,
+          palissy_DENO: row["denomination"],
+          palissy_CATE: row["categorie_technique"],
+          palissy_SCLE: row["siecle_de_creation"],
+          palissy_DENQ: row["date_du_recolement"]
+        }
       end
     end
   end

--- a/app/jobs/synchronizer/objets/revision.rb
+++ b/app/jobs/synchronizer/objets/revision.rb
@@ -46,7 +46,7 @@ module Synchronizer
 
         @action = :"#{create_or_update}_rejected_invalid"
         log "#{create_or_update} de l'objet #{palissy_REF} rejeté car l’objet n'est pas valide " \
-            ": #{objet.errors.full_messages.to_sentence}"
+            ": #{objet.errors.full_messages.to_sentence} - #{all_attributes}"
         false
       end
 

--- a/app/jobs/synchronizer/objets/revision_insert_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_insert_concern.rb
@@ -15,7 +15,7 @@ module Synchronizer
 
       def set_action_and_log
         @action = :create
-        log "création de l’objet #{palissy_REF} avec #{objet_attributes.except(:palissy_REF)}"
+        log "création de l’objet #{palissy_REF} avec #{all_attributes.except(:palissy_REF)}"
       end
     end
   end

--- a/app/jobs/synchronizer/objets/revision_update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_update_concern.rb
@@ -7,10 +7,7 @@ module Synchronizer
 
       def objet
         @objet ||= begin
-          except_fields = ["REF"]
-          except_fields += %w[COM INSEE DPT EDIF EMPL] if ignore_commune_change?
-          attributes_to_assign = all_attributes.except(*except_fields.map { :"palissy_#{_1}" })
-          persisted_objet.assign_attributes(attributes_to_assign)
+          persisted_objet.assign_attributes(all_attributes.except(*except_fields))
           persisted_objet
         end
       end
@@ -18,6 +15,20 @@ module Synchronizer
       private
 
       def create_or_update = :update
+
+      def except_fields
+        f = %i[palissy_REF]
+        if ignore_commune_change?
+          f += %i[
+            palissy_COM
+            palissy_INSEE
+            palissy_DPT
+            palissy_EDIF
+            palissy_EMPL
+          ]
+        end
+        f
+      end
 
       def existing_recensement?
         @existing_recensement ||= persisted_objet.recensements.any?


### PR DESCRIPTION
- ajout de logs dans la synchro objets + amélioration des logs existants
- refactos préliminaires pour rendre la PR #1159 plus lisible
- correction cas particulier Synchronizer::Objets::Batch::EagerLoadStore#add_edifice : les édifices ayant une REF doivent aussi apparaitre dans le hash indexé par slug et code insee