### PR TITLE
3. import : création communes manquantes + MàJ des emails

### DIFF
--- a/app/jobs/synchronizer/communes/batch/base.rb
+++ b/app/jobs/synchronizer/communes/batch/base.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Communes
+    module Batch
+      class Base
+        include Parser
+
+        def initialize(csv_rows, logger: nil)
+          @csv_rows = csv_rows
+          @logger = logger
+          @eager_load_store = EagerLoadStore.new(self)
+          @restrict = restrict
+        end
+
+        def revisions
+          @revisions ||=
+            csv_rows
+              .map { Row.new(_1) }
+              .select(&:in_scope?)
+              .map { parse_row_to_commune_and_user_attributes(_1) }
+              .map { { attributes: _1, **eager_loaded_records_for_row(_1) } }
+              .select { _1[:objets_count].positive? }
+              .map { Revision.new(_1[:attributes], persisted_commune: _1[:commune], logger:) }
+        end
+
+        def synchronize(if_block: nil)
+          revisions.each do |revision|
+            revision.synchronize if if_block.nil? || if_block.call(revision)
+            yield if block_given?
+          end
+        end
+
+        def skipped_rows_count = csv_rows.count - revisions.count
+
+        def unique_code_insees
+          @unique_code_insees ||= csv_rows.pluck("code_insee_commune").uniq
+        end
+
+        private
+
+        attr_reader :csv_rows, :logger, :eager_load_store, :restrict
+
+        def eager_loaded_records_for_row(row)
+          code_insee = row[:commune][:code_insee]
+          {
+            objets_count: eager_load_store.objets_count_by_code_insee[code_insee],
+            commune: eager_load_store.communes_by_code_insee[code_insee]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/communes/batch/eager_load_store.rb
+++ b/app/jobs/synchronizer/communes/batch/eager_load_store.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Communes
+    module Batch
+      # Groups SQL queries and stores dependent records in indexed hashes. Avoids N+1 queries
+      class EagerLoadStore
+        def initialize(batch)
+          @batch = batch
+        end
+
+        def communes_by_code_insee
+          @communes_by_code_insee ||= Commune
+            .where(code_insee: @batch.unique_code_insees)
+            .includes(:users)
+            .to_a
+            .index_by(&:code_insee)
+        end
+
+        def objets_count_by_code_insee
+          @objets_count_by_code_insee ||=
+            Hash.new(0).merge(
+              Objet
+                .where(lieu_actuel_code_insee: @batch.unique_code_insees)
+                .group(:lieu_actuel_code_insee)
+                .count
+            )
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/communes/parser.rb
+++ b/app/jobs/synchronizer/communes/parser.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Communes
+    module Parser
+      def parse_row_to_commune_and_user_attributes(row)
+        code_insee = row["code_insee_commune"]
+        {
+          commune: {
+            code_insee:,
+            nom: row["nom"].gsub(/^Mairie - ?/, "").strip,
+            phone_number: parse_phone_number(row["telephone"]),
+            departement_code: code_insee.starts_with?("97") ? code_insee[0..2] : code_insee[0..1]
+          },
+          user: {
+            email: (row["adresse_courriel"] || "").split(";")[0]
+          }
+        }
+      end
+
+      def parse_phone_number(value)
+        return nil if value.blank?
+
+        parsed = JSON.parse(value).first["valeur"]
+        return nil if parsed.blank? || parsed == "f"
+
+        parsed
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/communes/revision.rb
+++ b/app/jobs/synchronizer/communes/revision.rb
@@ -37,8 +37,8 @@ module Synchronizer
         @action_user ||=
           if commune.persisted? && destroy_user?
             :destroy
-          elsif commune.persisted? && persisted_user
-            :update
+          elsif commune.persisted? && persisted_user&.email_changed?
+            :update_email
           else
             :create
           end
@@ -95,7 +95,7 @@ module Synchronizer
               counter: :update_commune
         end
 
-        if action_user == :update
+        if action_user == :update_email
           log "saving email change #{persisted_user.email} -> #{user_attributes[:email]}",
               counter: :user_update_email
         elsif action_user == :destroy

--- a/app/jobs/synchronizer/communes/row.rb
+++ b/app/jobs/synchronizer/communes/row.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Communes
+    class Row
+      include ActiveModel::Validations
+
+      delegate :[], :key?, to: :@values
+
+      attr_reader :code_insee, :type_service_local, :nom
+
+      def initialize(csv_row)
+        @values = csv_row.to_h
+        @code_insee = @values["code_insee_commune"].presence
+        @type_service_local = parse_type_service_local(@values["pivot"])
+        @nom = @values["nom"] || ""
+      end
+
+      alias in_scope? valid?
+
+      validates :code_insee, presence: true
+      validates :type_service_local, inclusion: { in: ["mairie"] }
+
+      validate :validate_mairie_principale
+
+      def validate_mairie_principale
+        return true if
+          !nom.match(/Mairi(e|é) (déléguée|annexe)/i) &&
+          !nom.match(/ - (annexe|antenne) /i) &&
+          !nom.match(/bureau annexe/i)
+
+        errors.add(:nom, "n’est pas une mairie principale")
+        false
+      end
+
+      def parse_type_service_local(value)
+        JSON.parse(value || "[]")&.first&.dig("type_service_local")
+      rescue JSON::ParserError
+        log "error when parsing pivot : #{value} ", counter: :parse_error_pivot
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/communes/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/communes/synchronize_all_job.rb
@@ -2,84 +2,64 @@
 
 module Synchronizer
   module Communes
+    # La synchronisation des communes nécessite trois parcours consécutifs du CSV :
+    # 1. le premier pour identifier les codes INSEE avec plusieurs mairies principales
+    # 2. le second pour supprimer les Users dont l’email a disparu dans le CSV
+    # 3. le troisième pour upsert toutes les communes et Users
+    # L’étape 2. permet de libérer les emails des Users supprimés pour qu’ils soient potentiellement
+    # réutilisés à l’étape 3
     class SynchronizeAllJob < ApplicationJob
       BATCH_SIZE = 1000
 
       def perform
         Rails.logger.info("starting iteration by batch of #{BATCH_SIZE}...")
-        @progressbar = ProgressBar.create(total: client.count_all, format: "%t: |%B| %p%% %e %c/%u")
-        client.each_slice(BATCH_SIZE) { synchronize_batch(_1) }
-
-        return if revisions_for_code_insees_with_multiple_communes.empty?
-
-        Rails.logger.info(
-          "iterating #{revisions_for_code_insees_with_multiple_communes} revisions" \
-          "for code insees with multiple communes..."
-        )
-        revisions_for_code_insees_with_multiple_communes.each(&:synchronize)
+        create_progressbar
+        set_code_insees_with_multiple_mairies
+        client.each_slice(BATCH_SIZE) { synchronize_batch(_1, if_block: ->(revision) { revision.destroy_user? }) }
+        client.each_slice(BATCH_SIZE) { synchronize_batch(_1) } # rubocop:disable Style/CombinableLoops
+        logger.close
       end
 
       private
 
-      def synchronize_batch(batch)
-        revisions = batch
-          .map { Revision.new(_1) }
-          .select { _1.mairie? && !_1.mairie_annexe? }
-          .select { code_insees_with_multiple_mairies.exclude?(_1.code_insee) }
+      def create_progressbar
+        return if Rails.env.test?
 
-        communes_by_code_insee = Commune
-          .joins(:objets)
-          .where(code_insee: revisions.map(&:code_insee))
-          .includes(:users)
-          .to_a
-          .index_by(&:code_insee)
+        @progressbar = ProgressBar.create(total: client.count_all * 3, format: "%t: |%B| %p%% %e %c/%u")
+      end
 
-        (batch.count - revisions.count).times { @progressbar.increment }
-        revisions.each do |revision|
-          revision.commune = communes_by_code_insee[revision.code_insee]
-          revision.synchronize if revision.commune
-          @progressbar.increment
-        end
+      def logger
+        @logger ||= Synchronizer::Logger.new(filename_prefix: "synchronize-communes")
       end
 
       def client
         @client ||= ApiClientAnnuaireAdministration.new
       end
 
-      def iterate_revisions(&block)
-        client.each { block.call(Revision.new(_1)) }
-      end
+      def set_code_insees_with_multiple_mairies
+        @code_insees_with_multiple_mairies = begin
+          logger.log "searching for code insees with multiple mairies principales..."
+          counts = Hash.new(0)
+          client.each do |csv_row|
+            @progressbar&.increment
+            row = Row.new(csv_row)
+            next if row.invalid?
 
-      def code_insees_with_multiple_mairies
-        @code_insees_with_multiple_mairies ||= compute_code_insees_with_multiple_mairies
-      end
-
-      def compute_code_insees_with_multiple_mairies
-        counts = Hash.new(0)
-        iterate_revisions do |revision|
-          next if !revision.mairie? || revision.mairie_annexe?
-
-          counts[revision.code_insee] += 1
+            counts[row["code_insee_commune"]] += 1
+          end
+          codes = counts.select { |_code, count| count > 1 }.map(&:first)
+          logger.log "found #{codes.count} codes insees that match multiple mairies principales : #{codes}"
+          codes
         end
-        codes = counts.select { |_code, count| count > 1 }.map(&:first)
-        Rails.logger.info "found #{codes.count} codes insees that match " \
-                          "multiple mairies principales : #{codes[0..10]}..."
-        codes
       end
 
-      def revisions_for_code_insees_with_multiple_communes
-        revisions_by_code_insee = Hash.new { |h, k| h[k] = [] } # code_insee => [revisions]
-        iterate_revisions do |revision|
-          next if !revision.mairie? || revision.mairie_annexe?
-          next if code_insees_with_multiple_mairies.exclude?(revision.code_insee)
+      def synchronize_batch(csv_rows, if_block: nil)
+        excluded, included = csv_rows
+          .partition { @code_insees_with_multiple_mairies.include?(_1["code_insee_commune"]) }
 
-          revisions_by_code_insee[revision.code_insee] << revision
-        end
-        # revisions_by_code_insee.each do |code_insee, revisions|
-        #   Rails.logger.info "code_insee #{code_insee}"
-        #   revisions.each { Rails.logger.info _1 }
-        # end
-        []
+        batch = Batch::Base.new(included, logger:)
+        batch.synchronize(if_block:) { @progressbar&.increment }
+        (excluded.count + batch.skipped_rows_count).times { @progressbar&.increment }
       end
     end
   end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -59,7 +59,9 @@ class Commune < ApplicationRecord
     inverse_of: :commune, dependent: :restrict_with_exception
   )
 
-  accepts_nested_attributes_for :dossier, :users
+  accepts_nested_attributes_for :dossier
+  accepts_nested_attributes_for :users, allow_destroy: true
+  validates_associated :users
 
   # Le "statut global" est une sorte de fusion des champs status de la commune, du dossier et de l'examen,
   # et permet l'affichage d'un statut unique dans les vues et un filtre facile via Ransack.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :commune
 
+  has_many :recensements, dependent: :nullify
+
   attr_accessor :impersonating
 
   def rotate_login_token(valid_for: 60.minutes)

--- a/db/migrate/20240216134435_allow_recensements_user_id_nil.rb
+++ b/db/migrate/20240216134435_allow_recensements_user_id_nil.rb
@@ -1,0 +1,5 @@
+class AllowRecensementsUserIdNil < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :recensements, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_151633) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_134435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -360,7 +360,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_151633) do
     t.string "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.string "analyse_etat_sanitaire"
     t.string "analyse_etat_sanitaire_edifice"
     t.string "analyse_securisation"

--- a/spec/jobs/synchronizer/communes/batch/base_spec.rb
+++ b/spec/jobs/synchronizer/communes/batch/base_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Synchronizer
+  module Communes
+    # Ces tests sont moyennement agréables à lire, ils stubbent beaucoup de dépendances.
+    # Ils sont cependant indispensables pour vérifier que seules les lignes pertinents sont synchronisées.
+    describe Batch::Base do
+      context "panaché de lignes" do
+        let(:csv_row_new_commune) { { "code_insee_commune" => "01001" } }
+        let(:csv_row_out_of_scope) { { "code_insee_commune" => "02001" } }
+        let(:csv_row_0_objets) { { "code_insee_commune" => "03001" } }
+        let(:csv_row_existing_commune) { { "code_insee_commune" => "97201" } }
+
+        let(:parsed_row_new_commune) { { commune: { code_insee: "01001" }, user: {} } }
+        # no parsed row for 02001 because it will be out of scope
+        let(:parsed_row_0_objets) { { commune: { code_insee: "03001" }, user: {} } }
+        let(:parsed_row_existing_commune) { { commune: { code_insee: "97201" }, user: {} } }
+
+        let(:row_new_commune) { instance_double(Row, in_scope?: true) }
+        let(:row_out_of_scope) { instance_double(Row, in_scope?: false) }
+        let(:row_0_objets) { instance_double(Row, in_scope?: true) }
+        let(:row_existing_commune) { instance_double(Row, in_scope?: true) }
+
+        let(:revision_new_commune) { instance_double(Revision) }
+        let(:revision_existing_commune) { instance_double(Revision) }
+
+        let!(:commune97201) { create(:commune, nom: "Fort de france", code_insee: "97201") }
+
+        before do
+          create(:objet, lieu_actuel_code_insee: "01001", commune: nil)
+          create(:objet, lieu_actuel_code_insee: "02001", commune: nil)
+          create(:objet, lieu_actuel_code_insee: "97201", commune: commune97201)
+        end
+
+        it "works" do
+          batch = Batch::Base.new(
+            [csv_row_new_commune, csv_row_out_of_scope, csv_row_0_objets, csv_row_existing_commune]
+          )
+
+          expect(Row).to receive(:new).with(csv_row_new_commune).and_return(row_new_commune)
+          expect(Row).to receive(:new).with(csv_row_out_of_scope).and_return(row_out_of_scope)
+          expect(Row).to receive(:new).with(csv_row_0_objets).and_return(row_0_objets)
+          expect(Row).to receive(:new).with(csv_row_existing_commune).and_return(row_existing_commune)
+
+          expect(batch).to receive(:parse_row_to_commune_and_user_attributes)
+            .with(row_new_commune).and_return(parsed_row_new_commune)
+          expect(batch).to receive(:parse_row_to_commune_and_user_attributes)
+            .with(row_0_objets).and_return(parsed_row_0_objets)
+          expect(batch).to receive(:parse_row_to_commune_and_user_attributes)
+            .with(row_existing_commune).and_return(parsed_row_existing_commune)
+
+          expect(Revision).to receive(:new)
+            .with(parsed_row_new_commune, persisted_commune: nil, logger: nil)
+            .and_return(revision_new_commune)
+          expect(Revision).to receive(:new)
+            .with(parsed_row_existing_commune, persisted_commune: commune97201, logger: nil)
+            .and_return(revision_existing_commune)
+
+          expect(revision_new_commune).to receive(:synchronize)
+          expect(revision_existing_commune).to receive(:synchronize)
+
+          expect(batch.revisions.count).to eq 2
+          batch.synchronize
+        end
+      end
+    end
+
+    context "if_block limits to destroys" do
+      let(:csv_row_destroy_user) { { "code_insee_commune" => "01001" } }
+      let(:csv_row_no_destroy) { { "code_insee_commune" => "02001" } }
+
+      let(:parsed_row_destroy_user) { { commune: { code_insee: "01001" }, user: {} } }
+      let(:parsed_row_no_destroy) { { commune: { code_insee: "02001" }, user: {} } }
+
+      let(:row_destroy_user) { instance_double(Row, in_scope?: true) }
+      let(:row_no_destroy) { instance_double(Row, in_scope?: true) }
+
+      let(:revision_destroy_user) { instance_double(Revision, destroy_user?: true) }
+      let(:revision_no_destroy) { instance_double(Revision, destroy_user?: false) }
+
+      let!(:commune01001) { create(:commune, nom: "Bourg en bresse", code_insee: "01001") }
+      let!(:commune02001) { create(:commune, nom: "Macon", code_insee: "02001") }
+
+      before do
+        create(:objet, lieu_actuel_code_insee: "01001", commune: commune01001)
+        create(:objet, lieu_actuel_code_insee: "02001", commune: commune02001)
+      end
+
+      it "only the revision that destroys a user is ran" do
+        batch = Batch::Base.new [csv_row_destroy_user, csv_row_no_destroy]
+
+        expect(Row).to receive(:new).with(csv_row_destroy_user).and_return(row_destroy_user)
+        expect(Row).to receive(:new).with(csv_row_no_destroy).and_return(row_no_destroy)
+
+        expect(batch).to receive(:parse_row_to_commune_and_user_attributes)
+          .with(row_destroy_user).and_return(parsed_row_destroy_user)
+        expect(batch).to receive(:parse_row_to_commune_and_user_attributes)
+          .with(row_no_destroy).and_return(parsed_row_no_destroy)
+
+        expect(Revision).to receive(:new)
+          .with(parsed_row_destroy_user, persisted_commune: commune01001, logger: nil)
+          .and_return(revision_destroy_user)
+        expect(Revision).to receive(:new)
+          .with(parsed_row_no_destroy, persisted_commune: commune02001, logger: nil)
+          .and_return(revision_no_destroy)
+
+        expect(revision_destroy_user).to receive(:synchronize)
+        expect(revision_no_destroy).not_to receive(:synchronize)
+
+        expect(batch.revisions.count).to eq 2
+        batch.synchronize(if_block: ->(revision) { revision.destroy_user? })
+      end
+    end
+  end
+end

--- a/spec/jobs/synchronizer/communes/revision_spec.rb
+++ b/spec/jobs/synchronizer/communes/revision_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Synchronizer::Communes::Revision do
       user = commune.users.first
       expect(user.email).to eq "contact@amberieu.fr"
       expect(revision.action_commune).to eq :update
-      expect(revision.action_user).to eq :update
+      expect(revision.action_user).to eq :update_email
     end
 
     context "email has disappeared" do

--- a/spec/jobs/synchronizer/communes/revision_spec.rb
+++ b/spec/jobs/synchronizer/communes/revision_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Synchronizer::Communes::Revision do
+  let(:revision) { described_class.new(commune_and_user_attributes, persisted_commune:) }
+  let!(:departement) { create(:departement, code: "01") }
+
+  let(:base_commune_and_user_attributes) do
+    {
+      commune: { code_insee: "01001", nom: "Ambérieu", phone_number: "01 02 03 04 05", departement_code: "01" },
+      user: { email: "contact@amberieu.fr" }
+    }
+  end
+
+  context "no existing commune" do
+    let(:commune_and_user_attributes) { base_commune_and_user_attributes }
+    let(:persisted_commune) { nil }
+
+    it "creates a new commune" do
+      expect(revision.synchronize).to eq true
+      commune = Commune.find_by(code_insee: "01001")
+      expect(commune.nom).to eq "Ambérieu"
+      expect(commune.phone_number).to eq "01 02 03 04 05"
+      expect(commune.departement_code).to eq "01"
+      user = commune.users.first
+      expect(user.email).to eq "contact@amberieu.fr"
+      expect(revision.action_commune).to eq :create
+      expect(revision.action_user).to eq :create
+    end
+  end
+
+  context "existing commune without user" do
+    let(:commune_and_user_attributes) { base_commune_and_user_attributes }
+
+    let!(:persisted_commune) do
+      Commune.create(code_insee: "01001", nom: "Ambérieu-sur-mer", phone_number: "01 01 01 01 01",
+                     departement_code: "01")
+    end
+
+    it "updates the commune & creates the user" do
+      expect(revision.synchronize).to eq true
+      commune = Commune.find_by(code_insee: "01001")
+      expect(commune.nom).to eq "Ambérieu"
+      expect(commune.phone_number).to eq "01 02 03 04 05"
+      expect(commune.departement_code).to eq "01"
+      user = commune.users.first
+      expect(user.email).to eq "contact@amberieu.fr"
+      expect(revision.action_commune).to eq :update
+      expect(revision.action_user).to eq :create
+    end
+  end
+
+  context "existing commune & existing user" do
+    let(:commune_and_user_attributes) { base_commune_and_user_attributes }
+
+    let!(:persisted_commune) do
+      create(
+        :commune, :with_user,
+        code_insee: "01001", nom: "Ambérieu-sur-mer", phone_number: "01 01 01 01 01",
+        departement_code: "01"
+      )
+    end
+
+    before do
+      persisted_commune.users.first.update!(email: "anciencontact@amberieu.fr")
+    end
+
+    it "updates the commune & updates the user email" do
+      expect(revision.synchronize).to eq true
+      commune = Commune.find_by(code_insee: "01001")
+      expect(commune.nom).to eq "Ambérieu"
+      expect(commune.phone_number).to eq "01 02 03 04 05"
+      expect(commune.departement_code).to eq "01"
+      user = commune.users.first
+      expect(user.email).to eq "contact@amberieu.fr"
+      expect(revision.action_commune).to eq :update
+      expect(revision.action_user).to eq :update
+    end
+
+    context "email has disappeared" do
+      let(:commune_and_user_attributes) { base_commune_and_user_attributes.merge(user: { email: nil }) }
+
+      it "commune should be updates & user destroyed" do
+        expect(revision.synchronize).to eq true
+        commune = Commune.find_by(code_insee: "01001")
+        expect(commune.nom).to eq "Ambérieu"
+        expect(commune.phone_number).to eq "01 02 03 04 05"
+        expect(commune.departement_code).to eq "01"
+        expect(commune.users).to be_empty
+        expect(revision.action_commune).to eq :update
+        expect(revision.action_user).to eq :destroy
+      end
+    end
+  end
+end

--- a/spec/jobs/synchronizer/communes/row_spec.rb
+++ b/spec/jobs/synchronizer/communes/row_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Synchronizer::Communes::Row do
+  let(:base_csv_row) do
+    {
+      "pivot" => "[{\"type_service_local\":\"mairie\"}]",
+      "code_insee_commune" => "01001",
+      "nom" => "Mairie - Ambérieu",
+      "telephone" => "[{\"valeur\":\"01 02 03 04 05\"}]",
+      "adresse_courriel" => "contact@amberieu.fr"
+    }
+  end
+  let(:row) { described_class.new(csv_row) }
+  before { row.valid? } # trigger validations
+
+  context "mairie classique" do
+    let(:csv_row) { base_csv_row }
+    it "est dans le scope" do
+      expect(row.errors).to be_empty
+      expect(row.in_scope?).to eq true
+    end
+  end
+
+  context "pivot hopital" do
+    let(:csv_row) do
+      base_csv_row.merge({ "pivot" => "[{\"type_service_local\":\"hopital\"}]" })
+    end
+    it "n’est pas dans le scope" do
+      expect(row.in_scope?).to eq false
+      expect(row.errors).to include(:type_service_local)
+    end
+  end
+
+  context "mairie annexe" do
+    let(:csv_row) do
+      base_csv_row.merge({ "nom" => "Mairie Annexe - Ambérieu" })
+    end
+    it "n’est pas dans le scope" do
+      expect(row.in_scope?).to eq false
+      expect(row.errors).to include(:nom)
+    end
+  end
+end

--- a/spec/jobs/synchronizer/communes/synchronize_all_job_spec.rb
+++ b/spec/jobs/synchronizer/communes/synchronize_all_job_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Synchronizer
+  module Communes
+    # Ce test était dur à écrire et sera probablement dur à lire, il stubbe quasiment tout ce que fait le job.
+    # Je vois quand même un petit intérêt à vérifier qu’on exclue bien les communes dont le code insee
+    # est présent plusieurs fois dans le CSV qui vient de l’API de l’annuaire de l’administration
+    # Pistes d’amélioration :
+    # - supprimer ce test
+    # - extraire la partie excluant les communes avec plusieurs mairies principales et la tester
+    describe SynchronizeAllJob do
+      let(:csv_rows) do
+        rows_code_insees.map { |code_insee| { "code_insee_commune" => code_insee } }
+      end
+      let(:rows) do
+        csv_rows.map { instance_double(Row, invalid?: false) }
+      end
+      let(:logger) { instance_double(Synchronizer::Logger, log: nil, close: nil) }
+      let(:api_client) { instance_double(ApiClientAnnuaireAdministration, count_all: csv_rows.count) }
+      let(:batch) { instance_double(Batch::Base, skipped_rows_count: 0) }
+
+      before do
+        expect(ApiClientAnnuaireAdministration).to receive(:new).and_return(api_client)
+        expect(api_client).to receive(:each) do |&block|
+          csv_rows.each { block.call(_1) }
+        end
+        expect(api_client).to receive(:each_slice).exactly(:twice).and_yield(csv_rows)
+        csv_rows.count.times do |i|
+          expect(Row).to receive(:new).with(csv_rows[i]).and_return(rows[i])
+          expect(rows[i]).to receive(:[]).with("code_insee_commune").and_return(csv_rows[i]["code_insee_commune"])
+        end
+        expect(Synchronizer::Logger).to receive(:new).and_return(logger)
+        expect(batch).to receive(:synchronize).with(if_block: anything).twice
+      end
+
+      context "simple case" do
+        let(:rows_code_insees) { %w[01002 03001 97201] }
+        it "should work" do
+          expect(Batch::Base).to receive(:new).exactly(:twice).with(csv_rows, logger:).and_return(batch)
+          SynchronizeAllJob.new.perform
+        end
+      end
+
+      context "when there are multiple mairies principales for a single code insee" do
+        let(:rows_code_insees) { %w[01002 03001 97201 97201 13001] }
+        it "should exclude these lines" do
+          expect(Batch::Base).to \
+            receive(:new).exactly(:twice).with([csv_rows[0], csv_rows[1], csv_rows[4]], logger:).and_return(batch)
+          SynchronizeAllJob.new.perform
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/mettre-jour-les-emails-des-communes-1da9f6e6698c42b3906e83319e0cc8d3

Une bonne moitié des 600 l+ sont des tests. 

Il y a deux changements fonctionnels principaux

1. créer les communes "manquantes" (selon les codes insees des objets présents dans CO)
2. remplacer les emails ayant changés sur Service Public

Cette PR fait à la fois un gros refacto et ces changements fonctionnels, ce n’est pas bien, mea culpa.

## Refacto

Le refacto aligne grandement l’organisation du module `Synchronizer::Communes` sur celle du module `Synchronizer::Objets` : 

- `Parser` : transforme une ligne CSV en attributs de `Commune` et de `User`
- `Row#in_scope?` : détermine si une ligne CSV est à exclure en utilisant des validations AR
- `Revision#synchronize` : applique les modifs dans la DB
- `Batch::Base` : processe 1000 lignes CSV : parse |> Row#in_scope |> Revision#synchronise
- `Batch::EagerLoadStore` : évite les N+1 en préchargeant les entités existantes en DB (communes, users et compte d’objets)

Il n’y a pas de `Batch::EagerLoadedRecords` mais une simple fonction `Batch::Base#eager_loaded_records_for_row`.


## SynchronizeAllJob

Le job `SynchronizeAllJob` nécessite trois parcours consécutifs du CSV :

1. le premier pour identifier les codes INSEE avec plusieurs mairies principales
2. le second pour supprimer les Users dont l’email a disparu dans le CSV
3. le troisième pour upsert toutes les Communes et Users

Faire l’étape 2. avant la 3. permet de libérer les emails des Users supprimés pour qu’ils soient potentiellement réutilisés à l’étape 3.

Le fait que ce job très haut niveau comprenne la logique d’exclusion des lignes doublons n’est pas parfait :
- c’est unique par rapport à `Synchronizer::Objets`
- ça complique un peu les tests à écrire. 

mais ça ne peut pas être fait au niveau du Batch car il faut un parcours complet du CSV pour identifier les doublons.

## Nested attributes

J’ai harmonisé pour utiliser les nested attributes dans les `Revisions`, 
comme c’est fait dans la synchro des objets pour les édifices. 

Cela veut dire qu’on ne fait qu’un appel `commune.save` toujours identique peu importe que la Commune et le User soient déjà persistés ou non.
De plus il arrive aussi que cet appel détruise un User grace au nested attribute `{_destroy: true}`.
Il faut en effet libérer les emails qui ont disparus de Service Public dans CO pour libérer la contrainte d’unicité.
C’est important car on peut imaginer qu’un email d’une mairie A qui a disparu soit réutilisé par la mairie de la commune qui a absorbé A.


## Expected updates

Lancement sur un dump de prod frais 

`counters: {:user_destroyed=>39, :update_commune=>10, :user_update_email=>1935, :error=>25}`