### PR TITLE
2. refacto synchro objets : nouveau logger + methode action

### DIFF
--- a/app/jobs/synchronizer/log_concern.rb
+++ b/app/jobs/synchronizer/log_concern.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module LogConcern
+    extend ActiveSupport::Concern
+
+    included do
+      private
+
+      attr_reader :logger
+
+      delegate :log, to: :logger, allow_nil: true
+      # allow_nil is useful in tests
+    end
+  end
+end

--- a/app/jobs/synchronizer/logger.rb
+++ b/app/jobs/synchronizer/logger.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  class Logger
+    def initialize(filename_prefix:)
+      @counters = Hash.new(0)
+      @file = File.open("tmp/#{filename_prefix}-#{timestamp}.log", "a+")
+      Rails.logger.info "opened log file : #{file.path}"
+    end
+
+    def log(message, counter: nil)
+      if message.present?
+        Rails.logger.info message
+        file.puts(message)
+      end
+      file.flush
+      counters[counter] += 1 if counter
+    end
+
+    def close
+      Rails.logger.info "counters: #{counters}"
+      file.puts "\n---\n"
+      file.puts "counters: #{counters}"
+      file.flush
+      file.close
+      Rails.logger.info "wrote logs to : #{file.path}"
+    end
+
+    private
+
+    attr_reader :file, :counters
+
+    def timestamp = Time.zone.now.strftime("%Y_%m_%d_%HH%M")
+  end
+end

--- a/app/jobs/synchronizer/objets/batch/base.rb
+++ b/app/jobs/synchronizer/objets/batch/base.rb
@@ -5,12 +5,11 @@ module Synchronizer
     module Batch
       class Base
         include Parser
+        include LogConcern
 
-        attr_reader :logfile
-
-        def initialize(csv_rows, logfile: nil)
+        def initialize(csv_rows, logger: nil)
           @csv_rows = csv_rows
-          @logfile = logfile
+          @logger = logger
           @eager_load_store = EagerLoadStore.new(self)
         end
 
@@ -22,25 +21,17 @@ module Synchronizer
               .map { parse_row_to_objet_attributes(_1) }
         end
 
-        def all_objets_attributes_with_eager_loaded_records
-          @all_objets_attributes_with_eager_loaded_records ||=
-            all_objets_attributes
-              .map { [_1, EagerLoadedRecords.new(_1, @eager_load_store)] }
-              .select { |_objet_attributes, eager_loaded_records| eager_loaded_records.commune.present? }
-          # TODO: we should rather create the commune
-        end
-
         def revisions
           @revisions ||=
-            all_objets_attributes_with_eager_loaded_records
-              .map do |objet_attributes, eager_loaded_records|
-              Revision.new(objet_attributes, eager_loaded_records:, logfile:)
+            all_objets_attributes
+            .map { [_1, EagerLoadedRecords.new(_1, @eager_load_store)] }
+            .select { |_objet_attributes, eager_loaded_records| eager_loaded_records.commune.present? }
+            .map do |objet_attributes, eager_loaded_records|
+              Revision.new(objet_attributes, eager_loaded_records:, logger:)
             end
         end
 
         def synchronize_each_revision
-          logfile&.puts "--- new batch ---"
-          logfile&.flush
           revisions.each do |revision|
             success = revision.synchronize
             @eager_load_store.add_edifice(revision.objet.edifice) if success && revision.new_edifice?

--- a/app/jobs/synchronizer/objets/batch/eager_load_store.rb
+++ b/app/jobs/synchronizer/objets/batch/eager_load_store.rb
@@ -5,8 +5,11 @@ module Synchronizer
     module Batch
       # Groups SQL queries and stores dependent records in indexed hashes. Avoids N+1 queries
       class EagerLoadStore
-        def initialize(batch)
+        include LogConcern
+
+        def initialize(batch, logger: nil)
           @batch = batch
+          @logger = logger
         end
 
         def objets_by_ref
@@ -48,8 +51,7 @@ module Synchronizer
         end
 
         def add_edifice(edifice)
-          @batch.logfile&.puts "édifice créé #{edifice.attributes.slice(*%w[code_insee merimee_REF slug nom id])}"
-          @batch.logfile&.flush
+          log "édifice créé #{edifice.attributes.slice(*%w[code_insee merimee_REF slug nom id])}"
           edifices_by_code_insee_and_slug[[edifice.code_insee, edifice.slug]] = edifice
           edifices_by_ref[edifice.merimee_REF] = edifice if edifice.merimee_REF.present?
         end

--- a/app/jobs/synchronizer/objets/revision.rb
+++ b/app/jobs/synchronizer/objets/revision.rb
@@ -4,13 +4,12 @@ module Synchronizer
   module Objets
     class Revision
       include RevisionEdificeConcern
+      include LogConcern
 
-      attr_reader :action, :objet_attributes
-
-      def initialize(objet_attributes, eager_loaded_records:, logfile: nil)
+      def initialize(objet_attributes, eager_loaded_records:, logger: nil)
         @objet_attributes = objet_attributes
         @eager_loaded_records = eager_loaded_records
-        @logfile = logfile
+        @logger = logger
         @persisted_objet = @eager_loaded_records.objet
         if persisted_objet
           @commune_before_update = persisted_objet.commune
@@ -21,16 +20,16 @@ module Synchronizer
       end
 
       def synchronize
-        return false if !check_objet_valid || !check_changed
+        return false unless check_objet_valid
 
-        set_action_and_log
-        objet.save!
+        log log_message, counter: action
+        objet.save! if action != :not_changed
         true
       end
 
       private
 
-      attr_reader :logfile, :persisted_objet, :commune_before_update
+      attr_reader :objet_attributes, :persisted_objet, :commune_before_update
 
       def commune = @eager_loaded_records.commune
       alias commune_after_update commune
@@ -44,24 +43,10 @@ module Synchronizer
       def check_objet_valid
         return true if objet.valid?
 
-        @action = :"#{create_or_update}_rejected_invalid"
         log "#{create_or_update} de l'objet #{palissy_REF} rejeté car l’objet n'est pas valide " \
-            ": #{objet.errors.full_messages.to_sentence} - #{all_attributes}"
+            ": #{objet.errors.full_messages.to_sentence} - #{all_attributes}",
+            :"#{create_or_update}_rejected_invalid"
         false
-      end
-
-      def check_changed
-        return true if objet.changed?
-
-        @action = :not_changed
-        false
-      end
-
-      def log(message)
-        return if logfile.nil? || message.blank?
-
-        logfile.puts(message)
-        logfile.flush
       end
     end
   end

--- a/app/jobs/synchronizer/objets/revision_insert_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_insert_concern.rb
@@ -9,14 +9,13 @@ module Synchronizer
         @objet ||= Objet.new(all_attributes)
       end
 
+      def action = :create
+
       private
 
       def create_or_update = :create
 
-      def set_action_and_log
-        @action = :create
-        log "création de l’objet #{palissy_REF} avec #{all_attributes.except(:palissy_REF)}"
-      end
+      def log_message = "création de l’objet #{palissy_REF} avec #{all_attributes.except(:palissy_REF)}"
     end
   end
 end

--- a/app/jobs/synchronizer/objets/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/objets/synchronize_all_job.rb
@@ -5,37 +5,23 @@ module Synchronizer
     class SynchronizeAllJob < ApplicationJob
       BATCH_SIZE = 1000
 
-      def initialize
-        super
-        @counters = Hash.new(0)
-      end
-
       def perform
-        @logfile = File.open("tmp/synchronize-objets-#{timestamp}.log", "a+")
         @progressbar = ProgressBar.create(total: client.count_all, format: "%t: |%B| %p%% %e %c/%u")
         client.each_slice(BATCH_SIZE) { synchronize_batch(_1) }
-        close
+        logger.close
       end
 
       private
 
-      attr_reader :logfile
-
       def synchronize_batch(csv_rows)
-        batch = Batch::Base.new(csv_rows, logfile:)
-        batch.synchronize_each_revision do |revision|
-          @counters[revision.action] += 1
-          @progressbar.increment
-        end
+        batch = Batch::Base.new(csv_rows, logger:)
+        batch.synchronize_each_revision { @progressbar.increment }
         batch.skipped_rows_count.times { @progressbar.increment }
       end
 
-      def close
-        @logfile.puts "counters: #{@counters}"
-        @logfile.close
+      def logger
+        @logger ||= Synchronizer::Logger.new(filename_prefix: "synchronize-objets")
       end
-
-      def timestamp = Time.zone.now.strftime("%Y_%m_%d_%HH%M")
 
       def client
         @client ||= ApiClientPalissy.new

--- a/spec/jobs/synchronizer/objets/revision_spec.rb
+++ b/spec/jobs/synchronizer/objets/revision_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Synchronizer::Objets::Revision do
       before { allow(eager_loaded_records).to receive(:commune).and_return(commune_before_update) }
       it "ne fait rien" do
         expect(revision.objet.changes).to be_empty
-        expect(revision.synchronize).to eq false
+        expect(revision.synchronize).to eq true
         expect(revision.action).to eq :not_changed
       end
     end
@@ -290,7 +290,7 @@ RSpec.describe Synchronizer::Objets::Revision do
       before { allow(eager_loaded_records).to receive(:commune).and_return(commune_before_update) }
       let(:revision) { described_class.new(objet_attributes, eager_loaded_records:) }
       it "ne fait rien" do
-        expect(revision.synchronize).to eq false
+        expect(revision.synchronize).to eq true
         expect(revision.action).to eq :not_changed
       end
     end


### PR DESCRIPTION
🔒  BASED ON #1159 🔒 

extraction d’une classe `Synchronizer::Logger` qui va être réutilisée côté synchro des communes. Ce Logger est maintenant responsable d’écrire dans un fichier ET de maintenir les compteurs. 

petit refacto de `Synchronizer::Objets::Revision` pour ajouter : 
- `#action` (qui vaut `:create, :update, :update_with_commune_change, :update_ignoring_commune_change` ou `:not_changed`) 
- et `#log_message`

un mini refacto qui en découle c’est que `revision#synchronize` renvoie maintenant `true` quand il n’y a aucun changement appliqué.

`Synchronizer::Objets::Revision#objet_attributes` devient private

`Synchronizer::Objets::Batch::Base#all_objets_attributes_with_eager_loaded_records` est inliné dans son seul usage dans le même fichier