### PR TITLE
Importer les objets orphelins (sans commune dans la db)

### DIFF
--- a/app/jobs/synchronizer/objets/batch/base.rb
+++ b/app/jobs/synchronizer/objets/batch/base.rb
@@ -25,7 +25,6 @@ module Synchronizer
           @revisions ||=
             all_objets_attributes
             .map { [_1, EagerLoadedRecords.new(_1, @eager_load_store)] }
-            .select { |_objet_attributes, eager_loaded_records| eager_loaded_records.commune.present? }
             .map do |objet_attributes, eager_loaded_records|
               Revision.new(objet_attributes, eager_loaded_records:, logger:)
             end

--- a/app/jobs/synchronizer/objets/revision_update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision_update_concern.rb
@@ -64,9 +64,9 @@ module Synchronizer
           when :update
             m
           when :update_with_commune_change
-            "#{m} - changement de commune appliqué #{commune_before_update} → #{commune_after_update} "
+            "#{m} - changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'} "
           when :update_ignoring_commune_change
-            "#{m} - changement de commune ignoré #{commune_before_update} → #{commune_after_update} " \
+            "#{m} - changement de commune ignoré #{commune_before_update} → #{commune_after_update || 'ø'} " \
             "car l’objet a déjà un recensement"
           end
         end


### PR DESCRIPTION
Changement simple et concis : 

| on importe maintenant les objets POP dans CO même s’il n’y a pas encore de commune correspondante au code INSEE actuel dans la DB de CO.

L’idée est donc qu’on va lancer dans l’ordre :

1. la synchro des objets
2. la synchro des communes

et c’est à l’étape 2 que les communes "manquantes" seront créées si on trouve les infos dans Service Public pour ce code INSEE

## Effets attendus

logs d’un lancement sur un dump récent de prod : 

```
counters: {:not_changed=>246005, :update_with_commune_change=>159, :create=>2878, :update_ignoring_commune_change=>282}
```

- les 2878 `create` correspondent à des objets qu’on n’importait pas jusqu’ici car on n’a pas (encore) créé la commune correspondante en DB ; 
- les 159 `update_with_commune_change` correspondent à des objets qui ont été updatés vers une commune qui n’existe pas encore en db

ça fait donc 3037 objets orphelins pile après le lancement de cette synchro (vérifié avec `Objet.where.missing(:commune).count`)

Si on lance la synchro des communes dans la foulée on descend à seulement 454 objets orphelins.


