### PR TITLE
ajout d’un index sur objets.lieu_actuel_code_insee

### DIFF
--- a/db/migrate/20240219175302_add_index_objets_lieu_actuel_code_insee.rb
+++ b/db/migrate/20240219175302_add_index_objets_lieu_actuel_code_insee.rb
@@ -1,0 +1,5 @@
+class AddIndexObjetsLieuActuelCodeInsee < ActiveRecord::Migration[7.1]
+  def change
+    add_index :objets, :lieu_actuel_code_insee
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_16_134435) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_175302) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -337,6 +337,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_16_134435) do
     t.string "lieu_actuel_edifice_nom"
     t.string "lieu_actuel_edifice_ref"
     t.index ["edifice_id"], name: "index_objets_on_edifice_id"
+    t.index ["lieu_actuel_code_insee"], name: "index_objets_on_lieu_actuel_code_insee"
     t.index ["palissy_COM"], name: "index_objets_on_palissy_COM"
     t.index ["palissy_DPT"], name: "index_objets_on_palissy_DPT"
     t.index ["palissy_INSEE"], name: "index_objets_on_palissy_INSEE"


### PR DESCRIPTION
l’absence de cet index implique probablement des perfs bien dégradées

je n’avais pas pensé à l’ajouter en même temps que le nouveau champ 🤦 