### PR TITLE
WIP fixing slow public objets pages request

### DIFF
--- a/app/components/objet_card_component.rb
+++ b/app/components/objet_card_component.rb
@@ -15,13 +15,13 @@ class ObjetCardComponent < ViewComponent::Base
     @commune = kwargs[:commune] || @objet.commune # pass to avoid n+1 queries
     @main_photo_origin = kwargs[:main_photo_origin] || :memoire
     @link_html_attributes_custom = kwargs[:link_html_attributes] || {}
-    @recensement = kwargs[:recensement] || @objet.current_recensement
+    @recensement = kwargs[:recensement]
     super
   end
 
   private
 
-  attr_reader :objet, :header_badges, :start_badges, :tags, :commune, :recensement, :main_photo_origin
+  attr_reader :objet, :header_badges, :start_badges, :tags, :commune, :main_photo_origin
 
   delegate :nom, :palissy_DENO, :edifice_nom, :palissy_photos_presenters, to: :objet
 
@@ -36,11 +36,14 @@ class ObjetCardComponent < ViewComponent::Base
   def main_photo
     return @main_photo if @main_photo.present?
 
-    {
-      memoire: main_photo_palissy,
-      recensement: main_photo_recensement,
-      recensement_or_memoire: main_photo_recensement || main_photo_palissy
-    }[main_photo_origin]
+    case main_photo_origin
+    when :recensement
+      main_photo_recensement
+    when :memoire
+      main_photo_palissy
+    when :recensement_or_memoire
+      main_photo_recensement || main_photo_palissy
+    end
   end
 
   def link_html_attributes
@@ -57,5 +60,9 @@ class ObjetCardComponent < ViewComponent::Base
     PhotoPresenter.new \
       url: recensement.photos.first.variant(:medium),
       description: "Photo de recensement de l’objet #{objet.nom}"
+  end
+
+  def recensement
+    @recensement ||= @objet.current_recensement
   end
 end

--- a/app/controllers/objets_controller.rb
+++ b/app/controllers/objets_controller.rb
@@ -10,7 +10,10 @@ class ObjetsController < ApplicationController
       @pagy, @objets = pagy(@objets_list.objets)
     else
       @pagy, @objets = pagy(
-        Objet.where.associated(:commune).order(Arel.sql("MD5(TEXT(objets.id + #{Time.zone.today.yday}))"))
+        Objet
+          .where.associated(:commune)
+          .includes(:commune)
+          .order(:palissy_REF)
       )
     end
   end


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/acc-l-rer-chargement-pages-objets-06d460f5d5394cf48b0742f53f3582a8

les requetes de count ont l’air plus rapides avec ces changements, mais la requete coeur de filtre avec limit et offset est toujours lente, 

a priori c’est parce qu’on n’utilise pas bien l’index qui ne contient qu’une colonne en faisant 

`SELECT * FROM table ORDER BY col_with_index LIMIT OFFSET`

il semble que ca soit plsu rapide de faire 

`SELECT * FROM table where col_with_index IN(SELECT col_with_index FROM table ORDER BY col_with_index LIMIT OFFSET)`

ce qui est un peu bizarre 🤷 

on peut tester https://github.com/planetscale/fast_page#pagy