### PR TITLE
import: déplacement des objets recensés

### DIFF
--- a/app/jobs/synchronizer/objets/revision/base.rb
+++ b/app/jobs/synchronizer/objets/revision/base.rb
@@ -12,7 +12,10 @@ module Synchronizer
           @eager_loaded_records = eager_loaded_records
           @logger = logger
           @persisted_objet = @eager_loaded_records.objet
-          @commune_before_update = persisted_objet.commune if persisted_objet
+          if persisted_objet
+            @commune_before_update = persisted_objet.commune
+            @persisted_objet_snapshot_before_changes = persisted_objet.snapshot_attributes
+          end
 
           if persisted_objet && row.out_of_scope?
             extend DestroyConcern

--- a/app/jobs/synchronizer/objets/revision/destroy_concern.rb
+++ b/app/jobs/synchronizer/objets/revision/destroy_concern.rb
@@ -10,7 +10,8 @@ module Synchronizer
           log log_message, counter: action
           persisted_objet.destroy_and_soft_delete_recensement!(
             reason: "objet-devenu-hors-scope",
-            message: soft_delete_message
+            message: soft_delete_message,
+            objet_snapshot: @persisted_objet_snapshot_before_changes
           )
           true
         end

--- a/app/jobs/synchronizer/objets/revision/update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision/update_concern.rb
@@ -7,17 +7,26 @@ module Synchronizer
         extend ActiveSupport::Concern
 
         def objet
-          @objet ||= begin
-            persisted_objet.assign_attributes(all_attributes.except(*except_fields))
-            persisted_objet
-          end
+          @objet ||= persisted_objet.tap { _1.assign_attributes(all_attributes) }
         end
 
         def synchronize
           return false if row.out_of_scope? || !objet_valid?
 
           log log_message, counter: action
-          objet.save! if action != :not_changed
+
+          return true if action == :not_changed
+
+          ActiveRecord::Base.transaction do
+            if commune_changed? && existing_recensement
+              existing_recensement.destroy_or_soft_delete!(
+                reason: "changement-de-commune",
+                message: "changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'}",
+                objet_snapshot: @persisted_objet_snapshot_before_changes
+              )
+            end
+            objet.save!
+          end
           true
         end
 
@@ -25,10 +34,10 @@ module Synchronizer
 
         def action
           @action ||=
-            if apply_commune_change?
+            if commune_changed? && existing_recensement
+              :update_with_commune_change_recensement_deleted
+            elsif commune_changed?
               :update_with_commune_change
-            elsif ignore_commune_change?
-              :update_ignoring_commune_change
             elsif objet.changed?
               :update
             else
@@ -45,47 +54,30 @@ module Synchronizer
           false
         end
 
-        def except_fields
-          f = %i[palissy_REF]
-          if ignore_commune_change?
-            f += %i[
-              palissy_COM
-              palissy_INSEE
-              palissy_DPT
-              palissy_EDIF
-              palissy_EMPL
-              palissy_DEPL
-              palissy_WEB
-              palissy_MOSA
-              lieu_actuel_code_insee
-              lieu_actuel_edifice_nom
-              lieu_actuel_edifice_ref
-            ]
-          end
-          f
-        end
-
-        def existing_recensement?
-          @existing_recensement ||= persisted_objet.recensements.any?
+        def existing_recensement
+          @existing_recensement ||= persisted_objet.recensements.first
         end
 
         def commune_after_update = @eager_loaded_records.commune
         def commune_changed? = commune_before_update != commune_after_update
-        def apply_commune_change? = commune_changed? && !existing_recensement?
-        def ignore_commune_change? = commune_changed? && !apply_commune_change?
+
+        def commune_change_message
+          "changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'}"
+        end
 
         def log_message
+          return nil if action == :not_changed
+
           @log_message ||= begin
-            m = "mise à jour de l’objet #{palissy_REF} : #{persisted_objet.changes}"
+            m = ["mise à jour de l’objet #{palissy_REF} : #{persisted_objet.changes}"]
             case action
-            when :update
-              m
             when :update_with_commune_change
-              "#{m} - changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'} "
-            when :update_ignoring_commune_change
-              "#{m} - changement de commune ignoré #{commune_before_update} → #{commune_after_update || 'ø'} " \
-              "car l’objet a déjà un recensement"
+              m << commune_change_message
+            when :update_with_commune_change_recensement_deleted
+              m << commune_change_message
+              m << "recensement associé supprimé ou soft-deleted"
             end
+            m.join(" - ")
           end
         end
       end

--- a/app/jobs/synchronizer/objets/revision/update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision/update_concern.rb
@@ -18,13 +18,7 @@ module Synchronizer
           return true if action == :not_changed
 
           ActiveRecord::Base.transaction do
-            if commune_changed? && existing_recensement
-              existing_recensement.destroy_or_soft_delete!(
-                reason: "changement-de-commune",
-                message: "changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'}",
-                objet_snapshot: @persisted_objet_snapshot_before_changes
-              )
-            end
+            destroy_or_soft_delete_existing_recensement! if commune_changed? && existing_recensement
             objet.save!
           end
           true
@@ -63,6 +57,14 @@ module Synchronizer
 
         def commune_change_message
           "changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'}"
+        end
+
+        def destroy_or_soft_delete_existing_recensement!
+          existing_recensement.destroy_or_soft_delete!(
+            reason: "changement-de-commune",
+            message: "changement de commune appliqué #{commune_before_update} → #{commune_after_update || 'ø'}",
+            objet_snapshot: @persisted_objet_snapshot_before_changes
+          )
         end
 
         def log_message

--- a/app/views/conservateurs/deleted_recensements/show.html.haml
+++ b/app/views/conservateurs/deleted_recensements/show.html.haml
@@ -35,10 +35,17 @@
             %p
               Ce recensement a été supprimé automatiquement le
               = l(recensement.deleted_at.to_date)
-              - if recensement.deleted_reason == "objet-devenu-hors-scope"
+              - case recensement.deleted_reason
+              - when "objet-devenu-hors-scope"
                 car il a été modifié dans Palissy et n’est plus concerné par Collectif Objets
                 - if recensement.deleted_message.present?
                   = " (#{recensement.deleted_message})"
+              - when "changement-de-commune"
+                car son code INSEE a changé dans Palissy.
+                Il peut s’agir d’un déplacement ou bien d’une fusion de communes.
+                - if recensement.deleted_message.present?
+                  %br
+                  = recensement.deleted_message
 
         - presenter = RecensementPresenter.new(recensement)
         = render "shared/rapport/recensement_attributes", recensement:, presenter:

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Recensement, type: :model do
 
     context "recensement completed" do
       let(:recensement) { create(:recensement, objet:) }
-      it "soft deletes and stores reason and message" do
+      it "soft deletes and stores everything" do
         expect(recensement.reload.deleted_at).to be_nil
         subject
         expect(recensement.reload.deleted_at).to be_within(1.second).of(Time.current)


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/g-rer-le-transfert-d-un-objet-d-une-commune-A-une-commune-B-lors-de-l-import-alors-que-la-commune--fb300ea12c9643c0ae1d381a4118b677

## Changements fonctionnels

Cas considéré :

- un objet a été importé une première fois pour une commune A
- la commune a l’a recensé
- il change de code INSEE dans Palissy (ou bien un code WEB différent apparait = la commune a fusionné, ou bien l’objet est déplacé)

Lors du réimport, pour l’instant on ne change pas l’objet de commune et on laisse le recensement.

**Cette PR change l’objet de commune et soft delete le recensement.**

## Code

une petite PR pour une fois :) 

![Screenshot 2024-02-21 at 20 02 54](https://github.com/betagouv/collectif-objets/assets/883348/3b61cf83-c070-410a-93b8-4e66f18be686)


On génère maintenant le snapshot de l’objet dès l’instanciation des `Revision` et on le passe en paramètre à `Recensement#destroy_or_soft_delete!`. 

Jusqu’ici on laissait cette méthode générer elle-même le snapshot. 

Ça fonctionnait bien pour les suppressions d’objet mais pas pour les mises à jour : **on veut stocker le snapshot de l’objet AVANT sa mise à jour**

Le but est en effet de fournir du contexte pour intérpréter le recensement au moment où il a été fait. En tant que conservateur qui observe ce recensement supprimé, il est en effet plus pertinent de montrer les infos que voyait le maire lorsqu’il a recensé l’objet, par exemple dans quel édifice il était supposément.

D’ailleurs, on aurait peut-être voulu stocker ce snapshot même si on stockait en db tous les objets, y compris ceux hors-scope

## Logs lancement 

- 282 objets déplacés avec recensements supprimés

## Exemple pris au hasard

![Screenshot 2024-02-21 at 20 00 23](https://github.com/betagouv/collectif-objets/assets/883348/646be9cd-1a0d-4807-bac4-0d4a138ec3be)

C’est d’ailleurs un cas intéressant : le·la maire d’Épinal avait répondu que l’objet avait bien été déplacé vers Senones ! 