### PR TITLE
migration: ajout d’une foreign key sur users.commune_id

### DIFF
--- a/db/migrate/20240225180433_add_user_commune_id_foreign_key.rb
+++ b/db/migrate/20240225180433_add_user_commune_id_foreign_key.rb
@@ -1,0 +1,5 @@
+class AddUserCommuneIdForeignKey < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key :users, :communes, column: :commune_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_25_180433) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -427,4 +427,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
   add_foreign_key "messages", "communes"
   add_foreign_key "recensements", "objets"
   add_foreign_key "recensements", "users"
+  add_foreign_key "users", "communes"
 end


### PR DESCRIPTION
je me suis rendu compte au détour d’une ligne de code qu’il n’y avait pas cette contrainte de clé étrangère sur la colonne `users.commune_id`, ça me parait étonnant, cette PR la rajoute simplement

testé sur un dump de prod, ça ne pose pas de soucis, les données existantes sont cohérentes