### PR TITLE
WIP import: suppression de communes (et users) dépréciés

### DIFF
--- a/app/jobs/synchronizer/communes/row.rb
+++ b/app/jobs/synchronizer/communes/row.rb
@@ -16,6 +16,10 @@ module Synchronizer
         @nom = @values["nom"] || ""
       end
 
+      def self.get_in_scope_code_insees(csv_rows:)
+        csv_rows.map { new(_1) }.select(&:in_scope?).map(&:code_insee)
+      end
+
       alias in_scope? valid?
 
       validates :code_insee, presence: true

--- a/app/jobs/synchronizer/communes/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/communes/synchronize_all_job.rb
@@ -8,10 +8,12 @@ module Synchronizer
       def perform
         Rails.logger.info("starting iteration by batch of #{BATCH_SIZE}...")
         create_progressbar
-        # La synchronisation des communes nécessite trois parcours consécutifs du CSV :
-        cycle_1_set_code_insees_with_multiple_mairies
-        cycle_2_destroy_users_with_disappeared_email
-        cycle_3_upsert_all
+        # La synchronisation des communes nécessite 4 parcours consécutifs du CSV :
+        cycle_1_delete_disappeared_communes
+        cycle_2_set_code_insees_with_multiple_mairies
+        cycle_3_destroy_users_with_disappeared_email
+        cycle_4_upsert_all
+        delete_communes_without_objets
         logger.close
       end
 
@@ -20,7 +22,7 @@ module Synchronizer
       def create_progressbar
         return if Rails.env.test?
 
-        @progressbar = ProgressBar.create(total: client.count_all * 3, format: "%t: |%B| %p%% %e %c/%u")
+        @progressbar = ProgressBar.create(total: client.count_all * 4, format: "%t: |%B| %p%% %e %c/%u")
       end
 
       def logger
@@ -31,7 +33,25 @@ module Synchronizer
         @client ||= ApiClientAnnuaireAdministration.new
       end
 
-      def cycle_1_set_code_insees_with_multiple_mairies
+      def cycle_1_delete_disappeared_communes
+        client.each_slice(BATCH_SIZE) do |csv_rows|
+          Commune
+            .where(code_insee: Row.get_in_scope_code_insees(csv_rows:))
+            .update_all(synchronized_at: now)
+          BATCH_SIZE.times { @progressbar&.increment }
+        end
+        Commune.where(synchronized_at: nil)
+          .or(Commune.where("synchronized_at < ?", now - 1.minute))
+          .find_each do |commune|
+            delete_commune_with(
+              commune,
+              reason: "it is not listed as a Mairie Principale anymore",
+              counter: :delete_commune_disappeared
+            )
+          end
+      end
+
+      def cycle_2_set_code_insees_with_multiple_mairies
         # identifie les codes INSEE avec plusieurs mairies principales
         @code_insees_with_multiple_mairies = begin
           logger.log "searching for code insees with multiple mairies principales..."
@@ -49,13 +69,13 @@ module Synchronizer
         end
       end
 
-      def cycle_2_destroy_users_with_disappeared_email
+      def cycle_3_destroy_users_with_disappeared_email
         # supprimer les Users dont l’email a disparu dans le CSV
         # extraire ce cycle du 3ème permet de libérer les emails qui peuvent être réutilisés
         client.each_slice(BATCH_SIZE) { synchronize_batch(_1, if_block: ->(revision) { revision.destroy_user? }) }
       end
 
-      def cycle_3_upsert_all
+      def cycle_4_upsert_all
         # upsert toutes les communes et Users
         client.each_slice(BATCH_SIZE) { synchronize_batch(_1) }
       end
@@ -67,6 +87,28 @@ module Synchronizer
         batch = Batch::Base.new(included, logger:)
         batch.synchronize(if_block:) { @progressbar&.increment }
         (excluded.count + batch.skipped_rows_count).times { @progressbar&.increment }
+      end
+
+      def delete_communes_without_objets
+        Commune.where.missing(:objets).find_each do |commune|
+          delete_commune_with(
+            commune,
+            reason: "it does not have any objets anymore",
+            counter: :delete_commune_without_objets
+          )
+        end
+      end
+
+      def delete_commune_with(commune, reason:, counter:)
+        messages = ["delete commune #{commune.code_insee} (#{commune.nom})"]
+        messages << "reason : #{reason}"
+        success = commune.destroy
+        messages << "failure : #{commune.errors.full_messages.to_sentence}" unless success
+        logger.log messages.join(" - "), counter:
+      end
+
+      def now
+        @now ||= Time.current
       end
     end
   end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -23,16 +23,15 @@ class Commune < ApplicationRecord
     end
   end
 
-  has_many :users, dependent: :restrict_with_exception
-  has_many(
+  has_many :users, dependent: :destroy
+  has_many( # rubocop:disable Rails/HasManyOrHasOneDependent
     :objets,
     foreign_key: :lieu_actuel_code_insee,
     primary_key: :code_insee,
-    inverse_of: :commune,
-    dependent: :restrict_with_exception
+    inverse_of: :commune
   )
   has_many :recensements, through: :objets
-  has_many :past_dossiers, class_name: "Dossier", dependent: :nullify
+  has_many :past_dossiers, class_name: "Dossier", dependent: :restrict_with_error
   belongs_to :dossier, optional: true
   has_many :campaign_recipients, dependent: :destroy
   has_many :admin_comments, dependent: :destroy, as: :resource
@@ -55,8 +54,10 @@ class Commune < ApplicationRecord
 
   has_many(
     :edifices,
-    foreign_key: :code_insee, primary_key: :code_insee,
-    inverse_of: :commune, dependent: :restrict_with_exception
+    foreign_key: :code_insee,
+    primary_key: :code_insee,
+    inverse_of: :commune,
+    dependent: :destroy
   )
 
   accepts_nested_attributes_for :dossier

--- a/app/models/edifice.rb
+++ b/app/models/edifice.rb
@@ -2,7 +2,7 @@
 
 class Edifice < ApplicationRecord
   belongs_to :commune, foreign_key: :code_insee, primary_key: :code_insee, optional: true, inverse_of: :edifices
-  has_many :objets, dependent: :restrict_with_error
+  has_many :objets, dependent: :nullify
   has_one_attached :bordereau, dependent: :destroy
 
   validates :code_insee, presence: true

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -690,6 +690,8 @@ fr:
       wrong_length:
         one: ne fait pas la bonne longueur (doit comporter un seul caractère)
         other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
+      restrict_dependent_destroy:
+        has_many: "Impossible de supprimer %{model} parce qu’il y a 1 ou plusieurs %{record}"
     template:
       body: 'Veuillez vérifier les champs suivants : '
       header:

--- a/db/migrate/20240225165526_add_synchronized_at_to_communes.rb
+++ b/db/migrate/20240225165526_add_synchronized_at_to_communes.rb
@@ -1,0 +1,5 @@
+class AddSynchronizedAtToCommunes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :communes, :synchronized_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_25_180433) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -139,6 +139,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
     t.float "latitude"
     t.float "longitude"
     t.string "inbound_email_token", null: false
+    t.datetime "synchronized_at"
     t.index ["code_insee"], name: "communess_unique_code_insee", unique: true
     t.index ["departement_code"], name: "index_communes_on_departement_code"
     t.index ["dossier_id"], name: "index_communes_on_dossier_id"
@@ -427,4 +428,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
   add_foreign_key "messages", "communes"
   add_foreign_key "recensements", "objets"
   add_foreign_key "recensements", "users"
+  add_foreign_key "users", "communes"
 end


### PR DESCRIPTION
🔒 based on #1177 🔒 

On considère une commune dépréciée pour CO dans deux cas :
1. la commune n’a plus d’objet (dans le périmètre)
2. la commune n’apparait plus comme une mairie principale

L’intérêt de supprimer ces communes dépréciées dans notre db est surtout de supprimer les users associés et libérer les emails pour leur éventuelle réutilisation. 

