### PR TITLE
petits refactors sur Synchronizer::Communes::SynchronizeAllJob

### DIFF
--- a/app/jobs/synchronizer/communes/row.rb
+++ b/app/jobs/synchronizer/communes/row.rb
@@ -17,6 +17,7 @@ module Synchronizer
       end
 
       alias in_scope? valid?
+      alias out_of_scope? valid?
 
       validates :code_insee, presence: true
       validates :type_service_local, inclusion: { in: ["mairie"] }

--- a/app/jobs/synchronizer/communes/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/communes/synchronize_all_job.rb
@@ -39,9 +39,9 @@ module Synchronizer
           client.each do |csv_row|
             @progressbar&.increment
             row = Row.new(csv_row)
-            next if row.invalid?
+            next if row.out_of_scope?
 
-            counts[row["code_insee_commune"]] += 1
+            counts[row.code_insee] += 1
           end
           codes = counts.select { |_code, count| count > 1 }.map(&:first)
           logger.log "found #{codes.count} codes insees that match multiple mairies principales : #{codes}"


### PR DESCRIPTION
:lock: based on #1177 :lock:

- utiliser `Synchronizer::Communes::Row#code_insee` plutôt que d’accéder à la valeur brute dans la csv_row `commune_code_insee`
- utiliser `out_of_scope?` plutôt que `invalid?`