### PR TITLE
nullify recensements.user_id when soft-deleting

### DIFF
--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -5,7 +5,7 @@ class Recensement < ApplicationRecord
   include Recensements::BooleansConcern
 
   belongs_to :objet, optional: true
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :dossier, optional: true
   belongs_to :pop_export_memoire, class_name: "PopExport", inverse_of: :recensements_memoire, optional: true
   belongs_to :pop_export_palissy, class_name: "PopExport", inverse_of: :recensements_palissy, optional: true
@@ -169,6 +169,7 @@ class Recensement < ApplicationRecord
   def aasm_before_soft_delete_transaction(reason:, message: nil)
     assign_attributes \
       objet_id: nil,
+      user_id: nil,
       deleted_reason: reason,
       deleted_message: message.presence,
       deleted_objet_snapshot: objet.snapshot_attributes

--- a/db/migrate/20240225184817_nullify_user_id_on_deleted_recensements.rb
+++ b/db/migrate/20240225184817_nullify_user_id_on_deleted_recensements.rb
@@ -1,0 +1,6 @@
+class NullifyUserIdOnDeletedRecensements < ActiveRecord::Migration[7.1]
+  def up
+    Recensement.only_deleted.update_all(user_id: nil)
+  end
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_121849) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_25_184817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -254,18 +254,20 @@ RSpec.describe Recensement, type: :model do
         lieu_actuel_edifice_nom: "église saint-jean"
       )
     end
+    let!(:user) { create(:user, commune:) }
     subject { recensement.destroy_or_soft_delete!(reason:, message:) }
     let(:reason) { "objet-devenu-hors-scope" }
     let(:message) { "gros problème de sous-dossier" }
 
     context "recensement completed" do
-      let(:recensement) { create(:recensement, objet:) }
+      let(:recensement) { create(:recensement, objet:, user:) }
       it "soft deletes and stores reason and message" do
         expect(recensement.reload.deleted_at).to be_nil
         subject
         expect(recensement.reload.deleted_at).to be_within(1.second).of(Time.current)
         expect(recensement.reload.deleted_reason).to eq "objet-devenu-hors-scope"
         expect(recensement.reload.deleted_message).to eq "gros problème de sous-dossier"
+        expect(recensement.reload.user_id).to be_nil
         expect(recensement.reload.deleted_objet_snapshot["palissy_REF"]).to eq "PM02000023"
         expect(recensement.reload.deleted_objet_snapshot["palissy_TICO"]).to eq "grande peinture à l'huile"
         expect(recensement.reload.deleted_objet_snapshot["lieu_actuel_code_insee"]).to eq "01002"


### PR DESCRIPTION
Petit changement lors du soft delete : on rajoute `recensements.user_id = nil`

Je le fais pour que la présence de ce `user_id` ne pose pas de soucis quand on essaie de supprimer des communes cf #

Je pense que le fix correct dans le temps serait de supprimer cette colonne qui n’est probablement pas utilisée et redondante avec le commune_id (ou code INSEE) puisqu’une commune = un user.

