### PR TITLE
migration: ajout de objets.lieu_actuel_departement_code

### DIFF
--- a/app/jobs/synchronizer/communes/parser.rb
+++ b/app/jobs/synchronizer/communes/parser.rb
@@ -10,7 +10,7 @@ module Synchronizer
             code_insee:,
             nom: row["nom"].gsub(/^Mairie - ?/, "").strip,
             phone_number: parse_phone_number(row["telephone"]),
-            departement_code: code_insee.starts_with?("97") ? code_insee[0..2] : code_insee[0..1]
+            departement_code: Departement.parse_from_code_insee(code_insee)
           },
           user: {
             email: (row["adresse_courriel"] || "").split(";")[0]

--- a/app/jobs/synchronizer/objets/parser.rb
+++ b/app/jobs/synchronizer/objets/parser.rb
@@ -24,7 +24,9 @@ module Synchronizer
           palissy_WEB: row["code_insee_commune_actuelle"].presence,
           palissy_MOSA: row["edifice_actuel"].presence
         }
-        parsed.merge(lieu_actuel_attributes(**parsed))
+        parsed.merge!(lieu_actuel_attributes(**parsed))
+        parsed.merge!(lieu_actuel_departement_code: Departement.parse_from_code_insee(parsed[:lieu_actuel_code_insee]))
+        parsed
       end
 
       def lieu_actuel_attributes(palissy_WEB:, palissy_MOSA:, palissy_DEPL:, palissy_INSEE:, palissy_EDIF:,

--- a/app/lib/co/departement_stats.rb
+++ b/app/lib/co/departement_stats.rb
@@ -7,11 +7,12 @@ module Co
     end
 
     def objets_count
-      @objets_count ||= Objet.where(palissy_DPT: @departement).count
+      @objets_count ||= Objet.where(lieu_actuel_departement_code: @departement).count
     end
 
     def objets_recenses_count
-      @objets_recenses_count ||= Objet.where(palissy_DPT: @departement).where.associated(:recensements).count
+      @objets_recenses_count ||=
+        Objet.where(lieu_actuel_departement_code: @departement).where.associated(:recensements).count
     end
 
     def objets_recenses_percentage

--- a/app/models/departement.rb
+++ b/app/models/departement.rb
@@ -43,4 +43,13 @@ class Departement < ApplicationRecord
   alias display_name to_s
   def memoire_sequence_name = "memoire_photos_number_#{code}"
   def self.ransackable_attributes(_ = nil) = %w[code]
+
+  def self.parse_from_code_insee(code_insee)
+    if code_insee.length != 5
+      Rails.logger.warn "le code INSEE '#{code_insee}' ne fait pas 5 caractères"
+      return nil
+    end
+
+    code_insee.starts_with?("97") ? code_insee[0..2] : code_insee[0..1]
+  end
 end

--- a/db/migrate/20240226161226_add_lieu_actuel_departement_code_to_objets.rb
+++ b/db/migrate/20240226161226_add_lieu_actuel_departement_code_to_objets.rb
@@ -1,0 +1,20 @@
+class AddLieuActuelDepartementCodeToObjets < ActiveRecord::Migration[7.1]
+  def up
+    add_column :objets, :lieu_actuel_departement_code, :string
+
+    # this could be done with a simple update! by objet but it’s a bit too slow
+    Objet.order(:lieu_actuel_code_insee).find_in_batches(batch_size: 1000) do |batch|
+      batch
+        .group_by { Departement.parse_from_code_insee(_1.lieu_actuel_code_insee) }
+        .each do |departement_code, objets|
+          Objet
+            .where(id: objets.pluck(:id))
+            .update_all(lieu_actuel_departement_code: departement_code)
+        end
+    end
+  end
+
+  def down
+    remove_column :objets, :lieu_actuel_departement_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_25_184817) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_161226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -336,6 +336,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_25_184817) do
     t.string "lieu_actuel_code_insee"
     t.string "lieu_actuel_edifice_nom"
     t.string "lieu_actuel_edifice_ref"
+    t.string "lieu_actuel_departement_code"
     t.index ["edifice_id"], name: "index_objets_on_edifice_id"
     t.index ["lieu_actuel_code_insee"], name: "index_objets_on_lieu_actuel_code_insee"
     t.index ["palissy_COM"], name: "index_objets_on_palissy_COM"

--- a/spec/jobs/synchronizer/objets/parser_spec.rb
+++ b/spec/jobs/synchronizer/objets/parser_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Synchronizer::Objets::Parser do
       expect(attributes[:lieu_actuel_code_insee]).to eq "01004"
       expect(attributes[:lieu_actuel_edifice_nom]).to eq "chapelle des Allymes"
       expect(attributes[:lieu_actuel_edifice_ref]).to eq "PA00113792"
+      expect(attributes[:lieu_actuel_departement_code]).to eq "01"
     end
   end
 
@@ -70,6 +71,7 @@ RSpec.describe Synchronizer::Objets::Parser do
       expect(attributes[:lieu_actuel_code_insee]).to eq "01235"
       expect(attributes[:lieu_actuel_edifice_nom]).to eq "chapelle des Allymes"
       expect(attributes[:lieu_actuel_edifice_ref]).to eq "PA00113792"
+      expect(attributes[:lieu_actuel_departement_code]).to eq "01"
     end
   end
 
@@ -90,6 +92,7 @@ RSpec.describe Synchronizer::Objets::Parser do
       expect(attributes[:lieu_actuel_code_insee]).to eq "01235"
       expect(attributes[:lieu_actuel_edifice_nom]).to eq "église Saint-Martin"
       expect(attributes[:lieu_actuel_edifice_ref]).to eq nil
+      expect(attributes[:lieu_actuel_departement_code]).to eq "01"
       # important : lieu_actuel_edifice_ref ne doit pas prendre la valeur de palissy_REFA !
     end
   end
@@ -111,6 +114,7 @@ RSpec.describe Synchronizer::Objets::Parser do
       expect(attributes[:lieu_actuel_code_insee]).to eq "01235"
       expect(attributes[:lieu_actuel_edifice_nom]).to eq "église Saint-Martin"
       expect(attributes[:lieu_actuel_edifice_ref]).to eq "PA00934057"
+      expect(attributes[:lieu_actuel_departement_code]).to eq "01"
     end
   end
 end

--- a/spec/models/departement_spec.rb
+++ b/spec/models/departement_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Departement, type: :model do
+  describe "#parse_from_code_insee" do
+    subject { Departement.parse_from_code_insee(code_insee) }
+    context "Paris" do
+      let(:code_insee) { "75056" }
+      it { is_expected.to eq "75" }
+    end
+
+    context "martinique - fort de france" do
+      let(:code_insee) { "97209" }
+      it { is_expected.to eq "972" }
+    end
+
+    context "09 - Ariège" do
+      let(:code_insee) { "09001" }
+      it { is_expected.to eq "09" }
+    end
+
+    context "ajaccio" do
+      let(:code_insee) { "2A004" }
+      it { is_expected.to eq "2A" }
+    end
+  end
+end


### PR DESCRIPTION
Le champ `palissy_DPT` est peu utilisé dans l’app mais l’est plus sur metabase. Or, depuis qu’on importe les déplacements d’objets ce champ n’est plus le bon : il contient le code du département à date de protection.

On introduit donc un champ `lieu_actuel_departement_code` qui le parse depuis le code INSEE. 

## Logs données prod

Il y a environ ~50 objets dont le code INSEE n’arrive pas à être parsé en département. 6 contiennent `ETRANGER` . d’autres ont l’air juste erronnés genre 6 chiffres 🤷 