### PR TITLE
nouveau CRON Job de synchronisation de tous les modèles

### DIFF
--- a/app/jobs/synchronizer/api_client_opendatasoft_concern.rb
+++ b/app/jobs/synchronizer/api_client_opendatasoft_concern.rb
@@ -48,7 +48,7 @@ module Synchronizer
 
     def csv_path
       # useful to iterate, make sure to download the csv with ?with_bom=false
-      return ENV["USE_LOCAL_FILE"] if ENV["USE_LOCAL_FILE"].present?
+      return "#{ENV['CSV_DIR']}/#{@dataset_name}.csv" if ENV["CSV_DIR"].present?
 
       @csv_path ||= begin
         download_csv_to_temp_file

--- a/app/jobs/synchronizer/communes/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/communes/synchronize_all_job.rb
@@ -3,9 +3,11 @@
 module Synchronizer
   module Communes
     class SynchronizeAllJob < ApplicationJob
+      include EnqueueNextJobConcern
+
       BATCH_SIZE = 1000
 
-      def perform
+      def perform(enqueue_next_job_after_success: false)
         Rails.logger.info("starting iteration by batch of #{BATCH_SIZE}...")
         create_progressbar
         # La synchronisation des communes nécessite trois parcours consécutifs du CSV :
@@ -13,6 +15,7 @@ module Synchronizer
         cycle_2_destroy_users_with_disappeared_email
         cycle_3_upsert_all
         logger.close
+        enqueue_next_job if enqueue_next_job_after_success
       end
 
       private

--- a/app/jobs/synchronizer/edifices/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/edifices/synchronize_all_job.rb
@@ -3,12 +3,15 @@
 module Synchronizer
   module Edifices
     class SynchronizeAllJob < ApplicationJob
-      def perform
+      include EnqueueNextJobConcern
+
+      def perform(enqueue_next_job_after_success: false)
         @progressbar = ProgressBar.create(total: client.count_all, format: "%t: |%B| %p%% %e %c/%u")
         client.each do |row|
           Revision.new(row).synchronize
           @progressbar.increment
         end
+        enqueue_next_job if enqueue_next_job_after_success
       end
 
       private

--- a/app/jobs/synchronizer/enqueue_next_job_concern.rb
+++ b/app/jobs/synchronizer/enqueue_next_job_concern.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Synchronizer
+  module EnqueueNextJobConcern
+    extend ActiveSupport::Concern
+
+    ENQUEUE_ORDER = %w[
+      Synchronizer::Objets::SynchronizeAllJob
+      Synchronizer::Communes::SynchronizeAllJob
+      Synchronizer::Edifices::SynchronizeAllJob
+      Synchronizer::Photos::SynchronizeAllJob
+    ].freeze
+
+    def enqueue_next_job
+      next_job_class = ENQUEUE_ORDER[ENQUEUE_ORDER.index(self.class.name) + 1]
+      return if next_job_class.nil?
+
+      next_job_class.constantize.perform_later(enqueue_next_job_after_success: true)
+    end
+  end
+end

--- a/app/jobs/synchronizer/objets/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/objets/synchronize_all_job.rb
@@ -3,12 +3,15 @@
 module Synchronizer
   module Objets
     class SynchronizeAllJob < ApplicationJob
+      include EnqueueNextJobConcern
+
       BATCH_SIZE = 1000
 
-      def perform
+      def perform(enqueue_next_job_after_success: false)
         @progressbar = ProgressBar.create(total: client.count_all, format: "%t: |%B| %p%% %e %c/%u")
         client.each_slice(BATCH_SIZE) { synchronize_batch(_1) }
         logger.close
+        enqueue_next_job if enqueue_next_job_after_success
       end
 
       private

--- a/app/jobs/synchronizer/photos/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/photos/synchronize_all_job.rb
@@ -3,6 +3,8 @@
 module Synchronizer
   module Photos
     class SynchronizeAllJob < ApplicationJob
+      include EnqueueNextJobConcern
+
       MEMOIRE_PHOTOS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"
 
       def perform(params = {})
@@ -16,6 +18,7 @@ module Synchronizer
             unstack
           end
         update_objet(@stack) if @limit.nil? && @stack.count >= 1 # last PM
+        enqueue_next_job if params[:enqueue_next_job_after_success]
       end
 
       private

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -26,6 +26,11 @@ Rails.application.configure do
     purge_unattached_blobs: {
       cron: "0 2 * * *",
       class: "PurgeUnattachedBlobsJob"
+    },
+    synchronize_all: {
+      cron: "0 4 * * 0", # every sunday at 4am
+      class: "Synchronizer::Objets::SynchronizeAllJob",
+      kwargs: { enqueue_next_job_after_success: true }
     }
   }
 end


### PR DESCRIPTION
cf https://www.notion.so/atelier-numerique/automatiser-rendre-r-gulier-l-import-c36dcd917ae64e8eb467720752572973

les jobs doivent être exécutés dans un certain ordre

1. Objets
2. Communes
3. Edifices
4. Photos

(3 et 4 pourraient éventuellement être executés en parallèle)

On pourrait tout simplement les mettre en CRON à une heure d’intervalle

Ici je le fais dans le code, on lance le job de synchro 1 et à la fin de ce job, en cas de succès, on enqueue le job suivant et ainsi de suite

L’avantage est d’enqueue un seul job et d’avoir dans un fichier la logique contenue de l’ordre de synchro des modèles

## Détail 

le refacto de la variable d’env `CSV_DIR` permet d’utiliser les 3 csvs des différents jobs plutôt qu’un seul