### PR TITLE
correction synchro communes lorsque l’email est déjà utilisé

### DIFF
--- a/app/jobs/synchronizer/api_client_opendatasoft_concern.rb
+++ b/app/jobs/synchronizer/api_client_opendatasoft_concern.rb
@@ -48,7 +48,7 @@ module Synchronizer
 
     def csv_path
       # useful to iterate, make sure to download the csv with ?with_bom=false
-      return ENV["USE_LOCAL_FILE"] if ENV["USE_LOCAL_FILE"].present?
+      return "#{ENV['CSV_DIR']}/#{@dataset_name}.csv" if ENV["CSV_DIR"].present?
 
       @csv_path ||= begin
         download_csv_to_temp_file

--- a/app/jobs/synchronizer/communes/revision.rb
+++ b/app/jobs/synchronizer/communes/revision.rb
@@ -81,7 +81,7 @@ module Synchronizer
       def check_valid
         return true if commune.valid?
 
-        log "commune synchro rejected : #{commune_attributes[:code_insee]} #{commune_attributes[:nom]} : " \
+        log "error | commune synchro rejected : #{commune_attributes[:code_insee]} #{commune_attributes[:nom]} : " \
             "#{commune.errors.full_messages.to_sentence} - #{all_attributes}",
             counter: :error
         false
@@ -89,17 +89,18 @@ module Synchronizer
 
       def log_changes
         if action_commune == :create
-          log "creating commune #{commune_attributes[:code_insee]} with #{all_attributes}", counter: :create_commune
+          log "#{action_commune} | creating commune #{commune_attributes[:code_insee]} with #{all_attributes}",
+              counter: :create_commune
         elsif action_commune == :update
-          log "saving changes to commune #{commune_attributes[:code_insee]} #{commune.changes}",
+          log "#{action_commune} | saving changes to commune #{commune_attributes[:code_insee]} #{commune.changes}",
               counter: :update_commune
         end
 
         if action_user == :update_email
-          log "saving email change #{persisted_user.email} -> #{user_attributes[:email]}",
+          log "#{action_user} | saving email change #{persisted_user.email} -> #{user_attributes[:email]}",
               counter: :user_update_email
         elsif action_user == :destroy
-          log "destroying user #{persisted_user.email} for commune #{commune_attributes[:code_insee]}",
+          log "#{action_user} | destroying user #{persisted_user.email} for commune #{commune_attributes[:code_insee]}",
               counter: :user_destroyed
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
 
   attr_accessor :impersonating
 
+  validates :email, presence: true, uniqueness: true
+
   def safe_email? = SAFE_DOMAINS.include?(email.split("@").last)
   def to_s = email.split("@")[0]
 

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -279,4 +279,28 @@ RSpec.describe Commune, type: :model do
       end
     end
   end
+
+  describe "validate" do
+    subject { commune.valid? }
+    context "valid commune without user attributes" do
+      let!(:departement) { create(:departement, code: "51") }
+      let(:commune) { Commune.new(nom: "Châlons", code_insee: "51023", departement:) }
+      it { should be_truthy }
+    end
+    context "valid commune with new user attributes" do
+      let!(:departement) { create(:departement, code: "51") }
+      let(:commune) do
+        Commune.new(nom: "Châlons", code_insee: "51023", departement:, users_attributes: [{ email: "jean@lol.fr" }])
+      end
+      it { should be_truthy }
+
+      context "email is taken" do
+        let!(:user) { create(:user, email: "jean@lol.fr") }
+        it "should have email taken error" do
+          expect(commune.valid?).to eq false
+          expect(commune.errors.first).to have_attributes(attribute: :"users.email", type: :taken)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
je suis surpris j’étais sûr que ça fonctionnait correctement 🤔 

ce qu’il manquait c’est la validation de l’unicité de l’email au niveau ActiveRecord - ce n’était fait qu’au niveau de postgres avec l’index unique.

j’ai rajouté un test au niveau de commune qui vérifie l’invalidité d’une commune avec un user attribute avec un email déjà utilisé

cavaliers applicatifs de cette PR : 

- simplification de la méthode pour passer les CSVs déjà téléchargés en local
- petit refacto des logs de la synchro pour les rendre plus lisibles 
- correction de l’incrémentation de la progressbar qui débordait un peu
