### PR TITLE
correction de la synchro des édifices en cas de fusion

### DIFF
--- a/app/jobs/synchronizer/edifices/batch/base.rb
+++ b/app/jobs/synchronizer/edifices/batch/base.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Edifices
+    module Batch
+      class Base
+        include Parser
+
+        def initialize(csv_rows, logger: nil)
+          @csv_rows = csv_rows
+          @logger = logger
+        end
+
+        def revisions
+          @revisions ||=
+            csv_rows
+              .map { parse_row_to_edifice_attributes(_1) }
+              .map { Revision.new(_1, logger:) }
+        end
+
+        def synchronize
+          revisions.each do |revision|
+            revision.synchronize
+            yield if block_given?
+          end
+        end
+
+        private
+
+        attr_reader :csv_rows, :logger
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/edifices/parser.rb
+++ b/app/jobs/synchronizer/edifices/parser.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Synchronizer
+  module Edifices
+    module Parser
+      def parse_row_to_edifice_attributes(row)
+        # code_insee = row["code_insee_commune"]
+        {
+          merimee_REF: row["reference"],
+          nom: row["titre_editorial_de_la_notice"],
+          slug: Edifice.slug_for(row["titre_editorial_de_la_notice"]),
+          code_insee: parse_code_insee(row["cog_insee_lors_de_la_protection"])
+        }
+      end
+
+      def parse_code_insee(value)
+        if value.is_a?(String)
+          value.split(",")[0] # when from CSV
+        elsif value.is_a?(Array)
+          value[0] # when from API
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/synchronizer/edifices/revision.rb
+++ b/app/jobs/synchronizer/edifices/revision.rb
@@ -3,61 +3,69 @@
 module Synchronizer
   module Edifices
     class Revision
-      def initialize(row)
-        @row = row
+      include LogConcern
+
+      def initialize(edifice_attributes, logger: nil)
+        @edifice_attributes = edifice_attributes
+        @logger = logger
       end
 
       def synchronize
-        return unless row_valid?
+        @edifice = existing_edifice
 
-        find_edifice
-        return unless @edifice
+        return if !row_valid? || !@edifice
 
-        @edifice.assign_attributes(merimee_REF:, nom:, code_insee:, slug:)
-        return unless @edifice.changed?
+        merge_existing_edifices if two_existing_edifices?
 
-        Rails.logger.info "edifice #{@identified_by} changed : #{@edifice.changes}, saving..."
+        @edifice.assign_attributes(edifice_attributes)
+
+        return log(nil, counter: :unchanged) unless @edifice.changed?
+
+        return log_update_error unless @edifice.valid?
+
+        log "#{@edifice} changed : #{@edifice.changes}", counter: :update
         @edifice.save!
       end
 
       private
 
-      def merimee_REF = @row["reference"]
-      def nom = @row["titre_editorial_de_la_notice"]
-      def slug = Edifice.slug_for(@row["titre_editorial_de_la_notice"])
-
-      def code_insee
-        if @row["cog_insee_lors_de_la_protection"].is_a?(String)
-          @row["cog_insee_lors_de_la_protection"].split(",")[0] # when from CSV
-        elsif @row["cog_insee_lors_de_la_protection"].is_a?(Array)
-          @row["cog_insee_lors_de_la_protection"][0] # when from API
-        end
-      end
+      attr_reader :edifice_attributes
 
       def row_valid?
-        raise "missing merimee_REF in #{row.to_h}" if merimee_REF.blank? # maybe we should just skip
+        # maybe we should just skip
+        raise "missing merimee_REF in #{edifice_attributes}" if edifice_attributes[:merimee_REF].blank?
 
-        code_insee.present?
+        edifice_attributes[:code_insee].present?
       end
 
-      def find_edifice
-        @edifice, @identified_by = find_edifice_by_merimee_REF || find_edifice_by_slug_and_code_insee
+      def existing_edifice_by_ref
+        @existing_edifice_by_ref ||= Edifice.find_by(edifice_attributes.slice(:merimee_REF))
       end
 
-      def find_edifice_by_merimee_REF
-        edifice = Edifice.find_by(merimee_REF:)
-        return unless edifice
+      def existing_edifice_by_slug
+        return nil if edifice_attributes[:slug].blank? || edifice_attributes[:code_insee].blank?
 
-        [edifice, { merimee_REF: }]
+        @existing_edifice_by_slug ||= Edifice.find_by(**edifice_attributes.slice(:slug, :code_insee), merimee_REF: nil)
       end
 
-      def find_edifice_by_slug_and_code_insee
-        return if slug.blank? || code_insee.blank?
+      def existing_edifice
+        @existing_edifice ||= existing_edifice_by_ref || existing_edifice_by_slug
+      end
 
-        edifice = Edifice.find_by(slug:, code_insee:, merimee_REF: nil)
-        return unless edifice
+      def two_existing_edifices? = existing_edifice_by_ref && existing_edifice_by_slug
 
-        [edifice, { slug:, code_insee: }]
+      def log_update_error
+        log "error when saving #{@edifice.changes} : #{@edifice.errors.full_messages}", counter: :update_error
+      end
+
+      def merge_existing_edifices
+        log "merging #{existing_edifice_by_slug} into #{existing_edifice_by_ref}", counter: :edifices_merged
+        Objet
+          .where(edifice: existing_edifice_by_slug)
+          .update_all(edifice_id: existing_edifice_by_ref.id)
+        existing_edifice_by_slug.destroy!
+        # at this point in time the objet may be associated to an edifice with a different code INSEE
+        # but it will be fixed in the edifice.save! call
       end
     end
   end

--- a/app/models/edifice.rb
+++ b/app/models/edifice.rb
@@ -41,4 +41,8 @@ class Edifice < ApplicationRecord
     s.sub(/-paroissiale$/, "")
     s
   end
+
+  def to_s
+    "Édifice #{nom} #{merimee_REF ? "(#{merimee_REF})" : '(sans référence Mérimée)'} - commune #{code_insee}"
+  end
 end

--- a/spec/jobs/synchronizer/edifices/revision_spec.rb
+++ b/spec/jobs/synchronizer/edifices/revision_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Synchronizer::Edifices::Revision do
+  subject { Synchronizer::Edifices::Revision.new(edifice_attributes).synchronize }
+
+  context "mise à jour du nom d’un édifice retrouvé par sa REF" do
+    let!(:edifice) { create(:edifice, merimee_REF: "PA00100001", nom: "Église Saint-Martin", code_insee: "01234") }
+    let(:edifice_attributes) do
+      {
+        merimee_REF: "PA00100001",
+        nom: "Église St Martin (ancien)",
+        code_insee: "01234"
+      }
+    end
+    it "should work" do
+      subject
+      expect(edifice.reload.nom).to eq("Église St Martin (ancien)")
+    end
+  end
+
+  context "mise à jour du nom et de la ref d’un édifice retrouvé par son slug" do
+    let!(:edifice) do
+      create(:edifice, merimee_REF: nil, slug: "eglise-saint-martin", nom: "Église Saint-Martin", code_insee: "01234")
+    end
+    let(:edifice_attributes) do
+      {
+        merimee_REF: "PA00100001",
+        nom: "Église Saint Martin", # tiret devient espace
+        code_insee: "01234",
+        slug: "eglise-saint-martin"
+      }
+    end
+    it "should work" do
+      subject
+      expect(edifice.reload.nom).to eq("Église Saint Martin")
+      expect(edifice.reload.merimee_REF).to eq("PA00100001")
+    end
+  end
+
+  context "deux édifices préexistants et la MàJ générerait un doublon" do
+    let!(:edifice_with_ref) do
+      create(
+        :edifice,
+        merimee_REF: "PA00100001",
+        slug: "eglise-saint-martin",
+        nom: "Église Saint-Martin",
+        code_insee: "01234"
+      )
+    end
+
+    let!(:edifice_with_slug) do
+      create(
+        :edifice,
+        merimee_REF: nil,
+        slug: "eglise-saint-martin",
+        nom: "Église Saint-Martin",
+        code_insee: "43210"
+      )
+    end
+
+    let(:edifice_attributes) do
+      {
+        merimee_REF: "PA00100001",
+        nom: "Église Saint Martin",
+        code_insee: "43210",
+        slug: "eglise-saint-martin"
+      }
+    end
+
+    it "should merge the two edifices" do
+      subject
+      expect(edifice_with_ref.reload.nom).to eq("Église Saint Martin")
+      expect(edifice_with_ref.reload.code_insee).to eq("43210")
+      expect { edifice_with_slug.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
Un cas bien particulier bloquait la synchro des édifices :

deux édifices existent déjà en DB
- edifice 1 : avec ref `PA01`
- edifice 2 : sans ref et code insee `01001` slug `immeuble`

et la ligne du csv qui nous dit : `{ref: 'PA01', code_insee: '01001', slug: 'immeuble'}` 

càd que l’édifice 1 doit être mis à jour mais que sa mise à jour causerait un doublon (même paire `code_insee , slug` )

cela explosait comme il faut jusque là.

Cette PR corrige ça en fusionnant l’édifice 2 vers l’édifice 1 lorsque ça se produit. J’ai aussi écrit un test pour ce cas.

Cavaliers applicatifs de cette PR :

- Refactos de `Synchronizer::Edifices::Revision` pour utiliser le logger comme les autres jobs 
- Refacto du module `Synchronizer::Edifices` pour s’aligner avec les autres : extraction d’une classe `Batch::Base` et d’un `Parser`