### PR TITLE
migration: remove useless recensements.user_id

### DIFF
--- a/app/controllers/communes/recensements_controller.rb
+++ b/app/controllers/communes/recensements_controller.rb
@@ -11,7 +11,7 @@ module Communes
     end
 
     def create
-      @recensement = Recensement.new(objet: @objet, user: current_user, status: "draft")
+      @recensement = Recensement.new(objet: @objet, status: "draft")
       authorize(@recensement)
       if @recensement.save
         redirect_to edit_commune_objet_recensement_path(@recensement.commune, @objet, @recensement, step: 1)

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -5,7 +5,6 @@ class Recensement < ApplicationRecord
   include Recensements::BooleansConcern
 
   belongs_to :objet, optional: true
-  belongs_to :user, optional: true
   belongs_to :dossier, optional: true
   belongs_to :pop_export_memoire, class_name: "PopExport", inverse_of: :recensements_memoire, optional: true
   belongs_to :pop_export_palissy, class_name: "PopExport", inverse_of: :recensements_palissy, optional: true
@@ -169,7 +168,6 @@ class Recensement < ApplicationRecord
   def aasm_before_soft_delete_transaction(reason:, message: nil, objet_snapshot: nil)
     assign_attributes \
       objet_id: nil,
-      user_id: nil,
       deleted_reason: reason,
       deleted_message: message.presence,
       deleted_objet_snapshot: objet_snapshot || objet.snapshot_attributes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :commune
 
-  has_many :recensements, dependent: :nullify
   has_many :session_codes, dependent: :destroy
 
   attr_accessor :impersonating

--- a/db/migrate/20240228143918_remove_user_id_from_recensements.rb
+++ b/db/migrate/20240228143918_remove_user_id_from_recensements.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromRecensements < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :recensements, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_26_171422) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_143918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -366,7 +366,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_26_171422) do
     t.string "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
     t.string "analyse_etat_sanitaire"
     t.string "analyse_etat_sanitaire_edifice"
     t.string "analyse_securisation"
@@ -388,7 +387,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_26_171422) do
     t.index ["deleted_at"], name: "index_recensements_on_deleted_at"
     t.index ["dossier_id"], name: "index_recensements_on_dossier_id"
     t.index ["objet_id"], name: "index_recensements_on_objet_id", unique: true
-    t.index ["user_id"], name: "index_recensements_on_user_id"
   end
 
   create_table "session_codes", force: :cascade do |t|
@@ -435,7 +433,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_26_171422) do
   add_foreign_key "dossiers", "communes"
   add_foreign_key "messages", "communes"
   add_foreign_key "recensements", "objets"
-  add_foreign_key "recensements", "users"
   add_foreign_key "session_codes", "users"
   add_foreign_key "users", "communes"
 end

--- a/spec/factories/recensement.rb
+++ b/spec/factories/recensement.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :recensement do
     association :objet
-    association :user
     association :dossier
     confirmation_sur_place { true }
     localisation { Recensement::LOCALISATION_EDIFICE_INITIAL }

--- a/spec/features/communes/read_rapport_spec.rb
+++ b/spec/features/communes/read_rapport_spec.rb
@@ -24,7 +24,8 @@ RSpec.feature "Communes - Read rapport", type: :feature, js: true do
   let!(:recensement_bouquet) do
     create(
       :recensement,
-      objet: objet_bouquet, user:, dossier:,
+      objet: objet_bouquet,
+      dossier:,
       etat_sanitaire: Recensement::ETAT_BON,
       analyse_etat_sanitaire: Recensement::ETAT_PERIL,
       securisation: Recensement::SECURISATION_CORRECTE,
@@ -38,7 +39,8 @@ RSpec.feature "Communes - Read rapport", type: :feature, js: true do
   let!(:recensement_ciboire) do
     create(
       :recensement,
-      objet: objet_ciboire, user:, dossier:,
+      objet: objet_ciboire,
+      dossier:,
       etat_sanitaire: Recensement::ETAT_BON,
       securisation: Recensement::SECURISATION_CORRECTE,
       notes: nil,

--- a/spec/features/conservateurs/accept_dossier_spec.rb
+++ b/spec/features/conservateurs/accept_dossier_spec.rb
@@ -18,7 +18,8 @@ RSpec.feature "Conservateurs - Accept Dossier", type: :feature, js: true do
       :recensement,
       :with_photos,
       photos_count: 3,
-      objet: objet_bouquet, user:, dossier:,
+      objet: objet_bouquet,
+      dossier:,
       etat_sanitaire: Recensement::ETAT_BON,
       securisation: Recensement::SECURISATION_CORRECTE,
       notes: "objet très doux"
@@ -28,7 +29,8 @@ RSpec.feature "Conservateurs - Accept Dossier", type: :feature, js: true do
   let!(:recensement_ciboire) do
     create(
       :recensement,
-      objet: objet_ciboire, user:, dossier:,
+      objet: objet_ciboire,
+      dossier:,
       etat_sanitaire: Recensement::ETAT_PERIL,
       securisation: Recensement::SECURISATION_CORRECTE,
       notes: nil

--- a/spec/models/bordereau/pdf_spec.rb
+++ b/spec/models/bordereau/pdf_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe "Bordereau::Pdf" do
     let!(:recensement_bouquet) do
       create(
         :recensement,
-        objet: objet_bouquet, user:, dossier:,
+        objet: objet_bouquet,
+        dossier:,
         etat_sanitaire: Recensement::ETAT_BON,
         analyse_etat_sanitaire: Recensement::ETAT_PERIL,
         securisation: Recensement::SECURISATION_CORRECTE,
@@ -40,7 +41,8 @@ RSpec.describe "Bordereau::Pdf" do
     let!(:recensement_ciboire) do
       create(
         :recensement,
-        objet: objet_ciboire, user:, dossier:,
+        objet: objet_ciboire,
+        dossier:,
         etat_sanitaire: Recensement::ETAT_BON,
         securisation: Recensement::SECURISATION_CORRECTE,
         notes: nil,

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -260,14 +260,13 @@ RSpec.describe Recensement, type: :model do
     let(:message) { "gros problème de sous-dossier" }
 
     context "recensement completed" do
-      let(:recensement) { create(:recensement, objet:, user:) }
+      let(:recensement) { create(:recensement, objet:) }
       it "soft deletes and stores reason and message" do
         expect(recensement.reload.deleted_at).to be_nil
         subject
         expect(recensement.reload.deleted_at).to be_within(1.second).of(Time.current)
         expect(recensement.reload.deleted_reason).to eq "objet-devenu-hors-scope"
         expect(recensement.reload.deleted_message).to eq "gros problème de sous-dossier"
-        expect(recensement.reload.user_id).to be_nil
         expect(recensement.reload.deleted_objet_snapshot["palissy_REF"]).to eq "PM02000023"
         expect(recensement.reload.deleted_objet_snapshot["palissy_TICO"]).to eq "grande peinture à l'huile"
         expect(recensement.reload.deleted_objet_snapshot["lieu_actuel_code_insee"]).to eq "01002"


### PR DESCRIPTION
cette colonne est inutile. On pourrait d’ailleurs aussi supprimer dossiers.user_id

il faudra merger cette PR si des recensements soft deleted se retrouvent avec des user_id pour une raison inconnue

```rb
Recensement.only_deleted.where.not(user_id: nil)
```

j’ai fait un test du happy path complet en local recensement commune examen conservateur je n’ai pas vu d’erreurs