### PR TITLE
Fix/puma config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ruby:3.2-slim
+FROM ruby:3.3-slim
 
 EXPOSE 3000
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -43,13 +43,3 @@ pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-
-# when using good_job in async mode locally, we need to shutdown the good_job process manually
-# cf https://github.com/bensheldon/good_job/tree/main#execute-jobs-async--in-process
-if ENV.fetch("WEB_CONCURRENCY", 0).positive?
-  before_fork { GoodJob.shutdown }
-  on_worker_boot { GoodJob.restart }
-  on_worker_shutdown { GoodJob.shutdown }
-  MAIN_PID = Process.pid
-  at_exit { GoodJob.shutdown if Process.pid == MAIN_PID }
-end


### PR DESCRIPTION
Il y a des erreurs de boot de l'application en production qui plante avec :

```
2024-03-12 12:41:52.748706429 +0100 CET [web-1] #<Thread:0x00007fd92aa46a68 /app/vendor/ruby-3.3.0/lib/ruby/3.3.0/open3.rb:664 run> terminated with exception (report_on_exception is true):
2024-03-12 12:41:52.748710381 +0100 CET [web-1] /app/vendor/ruby-3.3.0/lib/ruby/3.3.0/open3.rb:664:in `read': stream closed in another thread (IOError)
```

Pour des raisons que la raison ignore, le serveur ne pouvait redémarrer qu'avec le worker éteint, ce qui veut dire que la synchronisation entre les deux posait problème (en tout cas la mention de `thread` indique quelque chose comme ça).

De toute façon, en production ce code n'est pas nécessaire puisque `good_job` se lance dans son propre worker. Pas besoin de rajouter cette complexité, voir https://github.com/betagouv/collectif-objets/pull/1204/commits/7ebe8361ecf78741fd45778e98220eade54f8959.

