### PR TITLE
db: bump the connection pool size

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: RAILS_MAX_THREADS=5 bundle exec puma -C config/puma.rb
-worker: RAILS_MAX_THREADS=5 bundle exec good_job start
+worker: GOOD_JOB_MAX_THREADS=5 bundle exec good_job start
 postdeploy: ./scripts/postdeploy.sh

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,5 +17,5 @@ test:
 production:
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i + 2 + ENV.fetch("GOOD_JOB_MAX_THREADS", 5).to_i %>
   url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
The production worker is unable to run jobs:

ActiveRecord::ConnectionTimeoutError:
  could not obtain a connection from the pool within 5.000 seconds

This makes sense because the pool size is currently 5, and both Good Job and Rails are being told to use 5 threads. Assuming the web server is busy or keeps DB connections alive, it means the worker is starving on the side.

Bump the pool size to the recommended calculation[1].

[1]: https://github.com/bensheldon/good_job/issues/669#issuecomment-1188022040