### PR TITLE
Correctif du bouton Télécharger une photo dans la galerie

### DIFF
--- a/app/presenters/photo_presenter.rb
+++ b/app/presenters/photo_presenter.rb
@@ -18,7 +18,9 @@ class PhotoPresenter
     new(
       url: Rails.application.routes.url_helpers.url_for(attachment),
       thumb_url: Rails.application.routes.url_helpers.url_for(attachment.variant(:medium)),
-      download_url: Rails.application.routes.url_helpers.rails_blob_path(attachment, disposition: "attachment"),
+      download_url: Rails.application.routes.url_helpers.rails_blob_path(attachment,
+                                                                         disposition: "attachment",
+                                                                         only_path: true),
       credit: "© Licence ouverte",
       id: attachment.id
     )


### PR DESCRIPTION
Actuellement le bouton Télécharger de la galerie renvoie vers une page d'erreur 404

![2024-03-20 bouton télécharger une photo](https://github.com/betagouv/collectif-objets/assets/1522772/bf171391-378e-4340-920a-94190c81853d)

Ce problème n'apparait à priori qu'en production.
Il manquait le préfixe `/rails` dans l'URL du reverse proxy, qui est ajouté uniquement avec l'option `only_path: true` dans le helper `rails_blob_path`