### PR TITLE
Abandon des notifications Mattermost en cas d'erreur

### DIFF
--- a/app/jobs/send_mattermost_notification_job.rb
+++ b/app/jobs/send_mattermost_notification_job.rb
@@ -3,6 +3,12 @@
 class MattermostApiError < StandardError; end
 
 class SendMattermostNotificationJob < ApplicationJob
+  # The extension must be included before other extensions
+  include GoodJob::ActiveJobExtensions::InterruptErrors
+  # Discard the job if it is interrupted
+  # This avoids having jobs that are in the Running queue indefinitely
+  discard_on GoodJob::InterruptError
+
   HOOKS_URL = "https://mattermost.incubateur.net/hooks/#{Rails.application.credentials.mattermost&.hook_id}".freeze
   HANDLED_EVENTS = %w[commune_completed recensement_created dossier_auto_submitted message_created].freeze
 


### PR DESCRIPTION
Les jobs `SendMattermostNotificationJob` restent parfois bloqués dans la file Running de GoodJob, avec une erreur `GoodJob::InterruptError`.

Cela engendre à priori des redémarrages intempestifs du worker de GoodJob.

Pour éviter ça on dit à GoodJob d'abandonner la tâche dans le cas où on a cette erreur.