### PR TITLE
Améliorer le message d'erreur lorsqu'une commune essaie de se connecter avec un code expiré

### DIFF
--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -79,6 +79,7 @@ class SessionAuthentication
 
     return unless last_session_code.expired?
 
-    errors.add :code, :expired, message: "Code de connexion expiré"
+    errors.add :code, :expired, message: "Le code de connexion n'est plus valide, " \
+                                         "veuillez en redemander un en cliquant sur le bouton ci-dessous"
   end
 end

--- a/spec/models/session_authentication_spec.rb
+++ b/spec/models/session_authentication_spec.rb
@@ -105,7 +105,8 @@ RSpec.describe SessionAuthentication do
         subject
         error = session_authentication.errors.first
         expect(error).to have_attributes(attribute: :code, type: :expired)
-        expect(session_authentication.error_message).to eq "Code de connexion expiré"
+        expect(session_authentication.error_message).to eq "Le code de connexion n'est plus valide, veuillez en " \
+                                                           "redemander un en cliquant sur le bouton ci-dessous"
       end
     end
 


### PR DESCRIPTION
Actuellement, lorsqu'une commune essaie de se connecter avec un code expiré, elle voit ce message d'erreur :

![2024-04-08 Connexion commune code expiré · Collectif Objets](https://github.com/betagouv/collectif-objets/assets/1522772/7d961157-4b40-4be8-8745-bec5044b5bf2)

Elles contactent ensuite le support pour connaître la marche à suivre.
Dans un premier temps, nous clarifions le message pour qu'elles sachent qu'il est possible de redemander un code en cliquant sur le bouton adéquat. 