### PR TITLE
Migration de l'adresse émettrice des emails transactionnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ On retrouve ces termes encore dans le code, il faudrait idéalement les renommer
 La configuration des domaines en `.beta.gouv.fr` est gérée par l'équipe transverse de beta.gouv.fr,
 idem pour les domaines en `.incubateur.net`
 
-L'adresse `collectifobjets@beta.gouv.fr` est une liste de diffusion beta.gouv.fr, elle se gère depuis le mattermost
+L'adresse `contact@collectif-objets.beta.gouv.fr` est une liste de diffusion beta.gouv.fr, elle se gère depuis le mattermost
 de beta cf https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/outils/liste-de-diffusion-et-adresses-de-contact#la-commande-mattermost-emails
 
 L'adresse `support@collectif-objets.beta.gouv.fr` est gérée en délégation de service par l'incubateur du ministère de

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,4 +9,4 @@ We try never to lag behind a major update for more than 3 months.
 
 ## Reporting a Vulnerability
 
-If you think you have found a vulnerability or would like to question us on security, feel free to reach out to us at `collectifobjets@beta.gouv.fr`
+If you think you have found a vulnerability or would like to question us on security, feel free to reach out to us at `contact@collectif-objets.beta.gouv.fr`

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -10,7 +10,7 @@ class AdminMailer < ApplicationMailer
     @conservateur = conservateur
     @campaign = campaign
     @subject = "#{title_prefix} - Campagne planifiée par un conservateur dans le #{campaign.departement}"
-    mail to: "collectifobjets@beta.gouv.fr", subject: @subject
+    mail to: CONTACT_EMAIL, subject: @subject
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  FROM_EMAIL_ADDRESS = "contact@collectif-objets.beta.gouv.fr"
-  default from: email_address_with_name(FROM_EMAIL_ADDRESS, "Collectif Objets")
+  default from: email_address_with_name(CONTACT_EMAIL, "Collectif Objets")
   layout "application_mailer"
 
   # rubocop:disable Rails/OutputSafety

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  FROM_EMAIL_ADDRESS = "contact@collectifobjets.beta.gouv.fr"
+  FROM_EMAIL_ADDRESS = "contact@collectif-objets.beta.gouv.fr"
   default from: email_address_with_name(FROM_EMAIL_ADDRESS, "Collectif Objets")
   layout "application_mailer"
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: email_address_with_name("collectifobjets@beta.gouv.fr", "Collectif Objets")
+  FROM_EMAIL_ADDRESS = "contact@collectifobjets.beta.gouv.fr"
+  default from: email_address_with_name(FROM_EMAIL_ADDRESS, "Collectif Objets")
   layout "application_mailer"
 
   # rubocop:disable Rails/OutputSafety

--- a/app/mailers/campaign_v1_mailer.rb
+++ b/app/mailers/campaign_v1_mailer.rb
@@ -5,7 +5,7 @@ class CampaignV1Mailer < ApplicationMailer
   before_action :set_campaign_commune_and_user
   default \
     to: -> { @user.email },
-    from: -> { email_address_with_name(FROM_EMAIL_ADDRESS, @campaign.sender_name) },
+    from: -> { email_address_with_name(CONTACT_EMAIL, @campaign.sender_name) },
     reply_to: -> { @commune.support_email(role: :user) }
 
   MAIL_NAMES = (

--- a/app/mailers/campaign_v1_mailer.rb
+++ b/app/mailers/campaign_v1_mailer.rb
@@ -5,7 +5,7 @@ class CampaignV1Mailer < ApplicationMailer
   before_action :set_campaign_commune_and_user
   default \
     to: -> { @user.email },
-    from: -> { email_address_with_name("collectifobjets@beta.gouv.fr", @campaign.sender_name) },
+    from: -> { email_address_with_name(FROM_EMAIL_ADDRESS, @campaign.sender_name) },
     reply_to: -> { @commune.support_email(role: :user) }
 
   MAIL_NAMES = (

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -31,7 +31,7 @@ class UserMailer < ApplicationMailer
     @cta_url = commune_dossier_url(@commune)
     mail \
       subject: "Examen du recensement des objets protégés de #{@commune.nom}",
-      from: email_address_with_name("collectifobjets@beta.gouv.fr", @conservateur.to_s),
+      from: email_address_with_name(FROM_EMAIL_ADDRESS, @conservateur.to_s),
       reply_to: @conservateur.email
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -31,7 +31,7 @@ class UserMailer < ApplicationMailer
     @cta_url = commune_dossier_url(@commune)
     mail \
       subject: "Examen du recensement des objets protégés de #{@commune.nom}",
-      from: email_address_with_name(FROM_EMAIL_ADDRESS, @conservateur.to_s),
+      from: email_address_with_name(CONTACT_EMAIL, @conservateur.to_s),
       reply_to: @conservateur.email
   end
 

--- a/app/views/conservateurs/bordereaux/new.html.haml
+++ b/app/views/conservateurs/bordereaux/new.html.haml
@@ -7,7 +7,7 @@
         Vous pouvez générer des bordereaux de récolement pour les différents édifices de la commune. 
         Les champs seront préremplis avec les données de recensement que vous avez précédemment examinées et acceptées. 
         %br
-        En cas d’erreur pour les édifices, veuillez nous envoyer un mail à l’adresse : collectifobjets@beta.gouv.fr.
+        En cas d’erreur pour les édifices, veuillez nous envoyer un mail à l’adresse : #{CONTACT_EMAIL}.
     
     - if @edifices.empty?
       %p

--- a/app/views/pages/accueil_conservateurs.html.haml
+++ b/app/views/pages/accueil_conservateurs.html.haml
@@ -49,7 +49,7 @@
 
         Lancer une campagne de déploiement dans votre département est simple et rapide.
 
-      = link_to "Demander une démonstration", "mailto:collectifobjets@beta.gouv.fr", class: "fr-btn fr-mt-2w"
+      = link_to "Demander une démonstration", "mailto:#{CONTACT_EMAIL}", class: "fr-btn fr-mt-2w"
     .fr-col-md-6
       %h2 Infolettres
       Abonnez-vous pour recevoir des nouvelles environ tous les mois de l’actualité de Collectif Objets

--- a/app/views/pages/aide.html.haml
+++ b/app/views/pages/aide.html.haml
@@ -151,4 +151,4 @@
     %section.fr-py-8w.fr-mt-8w.co-text--center
       Vous avez une question qui n'est pas dans la liste ? N'hésitez pas à nous contacter.
       %div
-        = link_to "collectifobjets@beta.gouv.fr", "mailto:collectifobjets@beta.gouv.fr", class: "fr-link"
+        = link_to CONTACT_EMAIL, "mailto:#{CONTACT_EMAIL}", class: "fr-link"

--- a/app/views/pages/conditions.html.haml
+++ b/app/views/pages/conditions.html.haml
@@ -81,4 +81,4 @@
 
       ## Prise de contact
 
-      Tout utilisateur peut contacter Collectif Objet via l’adresse mail suivante : collectifobjets@beta.gouv.fr
+      Tout utilisateur peut contacter Collectif Objet via l’adresse mail suivante : #{CONTACT_EMAIL}

--- a/app/views/pages/confidentialite.html.haml
+++ b/app/views/pages/confidentialite.html.haml
@@ -47,7 +47,7 @@
       - Droit de rectification ;
       - Droit de suppression des données.
 
-      Pour les exercer, faites-nous parvenir une demande en précisant la date et lʼheure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à lʼadresse suivante : [collectifobjets@beta.gouv.fr](mailto:collectifobjets@beta.gouv.fr)
+      Pour les exercer, faites-nous parvenir une demande en précisant la date et lʼheure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à lʼadresse suivante : #{mail_to(CONTACT_EMAIL)}
 
       En raison de lʼobligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici :
 

--- a/app/views/pages/declaration_accessibilite.html.haml
+++ b/app/views/pages/declaration_accessibilite.html.haml
@@ -39,7 +39,7 @@
 
           Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de Collectif Objets pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
 
-          - E-mail : [collectifobjets@beta.gouv.fr](mailto:collectifobjets@beta.gouv.fr){:target="_blank" rel="noopener"}
+          - E-mail : [#{CONTACT_EMAIL}](mailto:#{CONTACT_EMAIL}){:target="_blank" rel="noopener"}
 
           ## Voie de recours
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -154,6 +154,6 @@
           - **Sybille de La Raudière** Chargée de déploiement
 
         %p
-          = link_to "collectifobjets@beta.gouv.fr", "mailto:collectifobjets@beta.gouv.fr", class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-mail-line fr-mt-2w"
+          = link_to CONTACT_EMAIL, "mailto:#{CONTACT_EMAIL}", class: "fr-btn fr-btn--secondary fr-btn--icon-right fr-icon-mail-line fr-mt-2w"
       .fr-col-md-6.fr-px-6w
         = render 'shared/picture_tag', filename_without_extension: "equipe",  img_class: "co--width-max-100", alt: "Équipe de Collectif Objets"

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -16,7 +16,7 @@
     .fr-footer__bottom
       %ul.fr-footer__bottom-list
         %li.fr-footer__bottom-item.co-white-space-nowrap
-          = link_to "mailto:#{current_user&.commune&.support_email(role: :user) || "collectifobjets@beta.gouv.fr"}", class: "fr-footer__bottom-link fr-link--icon-left fr-icon-mail-line" do
+          = link_to "mailto:#{current_user&.commune&.support_email(role: :user) || CONTACT_EMAIL}", class: "fr-footer__bottom-link fr-link--icon-left fr-icon-mail-line" do
             Contact
         %li.fr-footer__bottom-item.co-white-space-nowrap
           = link_to fiches_path, class: "fr-footer__bottom-link fr-link--icon-left fr-icon-file-line" do

--- a/app/views/shared/campaigns/_form.html.haml
+++ b/app/views/shared/campaigns/_form.html.haml
@@ -20,7 +20,7 @@
           = t("activerecord.attributes.campaign.sender_name")
           %span.fr-hint-text
             C'est ce nom qui sera affiché dans les mails reçus par les communes.
-            Les mails seront toujours envoyés avec l'adresse collectifobjets@beta.gouv.fr.
+            Les mails seront toujours envoyés avec l'adresse contact@collectifobjets.beta.gouv.fr.
             Les réponses par mail arriveront dans la messagerie et vous recevrez des notifications.
         = f.text_field :sender_name, placeholder: "Jeanne Dupont"
       .fr-input-group

--- a/app/views/shared/campaigns/_form.html.haml
+++ b/app/views/shared/campaigns/_form.html.haml
@@ -20,7 +20,7 @@
           = t("activerecord.attributes.campaign.sender_name")
           %span.fr-hint-text
             C'est ce nom qui sera affiché dans les mails reçus par les communes.
-            Les mails seront toujours envoyés avec l'adresse contact@collectifobjets.beta.gouv.fr.
+            Les mails seront toujours envoyés avec l'adresse #{CONTACT_EMAIL}.
             Les réponses par mail arriveront dans la messagerie et vous recevrez des notifications.
         = f.text_field :sender_name, placeholder: "Jeanne Dupont"
       .fr-input-group

--- a/config/initializers/contact_email.rb
+++ b/config/initializers/contact_email.rb
@@ -1,0 +1,1 @@
+CONTACT_EMAIL="contact@collectif-objets.beta.gouv.fr"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'collectifobjets@beta.gouv.fr'
+  config.mailer_sender = 'contact@collectifobjets.beta.gouv.fr'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'CustomDeviseMailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'contact@collectifobjets.beta.gouv.fr'
+  config.mailer_sender = 'contact@collectif-objets.beta.gouv.fr'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'CustomDeviseMailer'

--- a/contenus/content_blobs/documentation_conservateur.md
+++ b/contenus/content_blobs/documentation_conservateur.md
@@ -41,7 +41,7 @@ Plus de 90% des informations transmises par les communes sont validées sans cor
 
 ## Si vous souhaitez déployer une campagne dans votre département
 
-C’est simple : contactez-nous à l’adresse [collectifobjets@beta.gouv.fr](mailto:collectifobjets@beta.gouv.fr) pour prendre rendez-vous avec notre équipe de déploiement.
+C’est simple : contactez-nous à l’adresse [contact@collectif-objets.beta.gouv.fr](mailto:contact@collectif-objets.beta.gouv.fr) pour prendre rendez-vous avec notre équipe de déploiement.
 
 Collectif Objets est un service destiné aux conservateurs des Monuments Historiques et conservateurs des Antiquités et Objets d’Art.
 
@@ -250,7 +250,7 @@ Si des informations semblent prescrites ou erronnées sur Collectif Objets, nous
 
 **Si un objet est attribué à une commune autre que celle qui l’abrite :**
 
-Si vous détectez une différence entre la localisation réelle d’un objet et la commune indiquée sur sa notice Palissy en amont d’une campagne, vous pouvez nous l’indiquer par mél à : [collectifobjets@beta.gouv.fr](mailto:collectifobjets@beta.gouv.fr) .
+Si vous détectez une différence entre la localisation réelle d’un objet et la commune indiquée sur sa notice Palissy en amont d’une campagne, vous pouvez nous l’indiquer par mél à : [contact@collectif-objets.beta.gouv.fr](mailto:contact@collectif-objets.beta.gouv.fr) .
 
 Si le changement de localisation de l’objet n’est pas détecté en amont de la campagne, c’est la commune indiquée sur la notice Palissy de l’objet qui recevra la demande de recensement. 
 
@@ -262,7 +262,7 @@ Le compte de chaque conservateur dans Collectif Objets est lié à une adresse e
 
 Dans de rares cas, certains systèmes informatiques (de type "pare-feu" ou "anti-spam") bloquent la transmission des e-mails provenant de la plateforme Collectif Objets. Par exemple, le système de pare-feu utilisé par le service informatique d'une région peut considérer que les e-mails envoyés par la plateforme sont des "spams" et ainsi empêcher les adresses e-mails des employés de la région de recevoir les e-mails provenant de Collectif Objets. 
 
-Si vous êtes dans cette situation, prenez contact avec les gérants du système informatique en question et demandez-leur de faire en sorte que les emails envoyés par la plateforme Collectif Objets (via l'adresse : collectifobjets@beta.gouv.fr ) ne soient plus considérés comme indésirables.
+Si vous êtes dans cette situation, prenez contact avec les gérants du système informatique en question et demandez-leur de faire en sorte que les emails envoyés par la plateforme Collectif Objets (via l'adresse : contact@collectif-objets.beta.gouv.fr) ne soient plus considérés comme indésirables.
 
 # Autres
 

--- a/contenus/content_blobs/documentation_conservateur.md
+++ b/contenus/content_blobs/documentation_conservateur.md
@@ -260,9 +260,9 @@ Pour information, les notices Palissy indiquent généralement la commune qui ab
 
 Le compte de chaque conservateur dans Collectif Objets est lié à une adresse e-mail qui sert d'identifiant pour se connecter à Collectif Objets. Cette adresse sert aussi à prévenir le conservateur lorsqu'une commune lui écrit dans la messagerie intégrée à Collectif Objets, ainsi qu'à créer / réinitialiser son mot de passe pour se connecter à la plateforme. 
 
-D﻿ans de rares cas, certains systèmes informatiques (de type "pare-feu" ou "anti-spam") bloquent la transmission des e-mails provenant de la plateforme Collectif Objets. Par exemple, le système de pare-feu utilisé par le service informatique d'une région peut considérer que les e-mails envoyés par la plateforme sont des "spams" et ainsi empêcher les adresses e-mails des employés de la région de recevoir les e-mails provenant de Collectif Objets. 
+Dans de rares cas, certains systèmes informatiques (de type "pare-feu" ou "anti-spam") bloquent la transmission des e-mails provenant de la plateforme Collectif Objets. Par exemple, le système de pare-feu utilisé par le service informatique d'une région peut considérer que les e-mails envoyés par la plateforme sont des "spams" et ainsi empêcher les adresses e-mails des employés de la région de recevoir les e-mails provenant de Collectif Objets. 
 
-S﻿i vous êtes dans cette situation, prenez contact avec les gérants du système informatique en question et demandez-leur de faire en sorte que les emails envoyés par la plateforme Collectif Objets (via l'adresse : collectifobjets@beta.gouv.fr ) ne soient plus considérés comme indésirables.
+Si vous êtes dans cette situation, prenez contact avec les gérants du système informatique en question et demandez-leur de faire en sorte que les emails envoyés par la plateforme Collectif Objets (via l'adresse : collectifobjets@beta.gouv.fr ) ne soient plus considérés comme indésirables.
 
 # Autres
 

--- a/scripts/send_test_mail.rb
+++ b/scripts/send_test_mail.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 puts ActionMailer::Base.mail(
-  from: ApplicationMailer::FROM_EMAIL_ADDRESS,
+  from: CONTACT_EMAIL,
   to: "wazaa@lol.fr",
   subject: "Envoi #{Time.zone.now.to_i} d'un dossier Collectif Objets",
   content_type: "text/html",

--- a/scripts/send_test_mail.rb
+++ b/scripts/send_test_mail.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 puts ActionMailer::Base.mail(
-  from: "collectifobjets@beta.gouv.fr",
+  from: ApplicationMailer::FROM_EMAIL_ADDRESS,
   to: "wazaa@lol.fr",
   subject: "Envoi #{Time.zone.now.to_i} d'un dossier Collectif Objets",
   content_type: "text/html",

--- a/spec/lib/co/send_in_blue_client_spec.rb
+++ b/spec/lib/co/send_in_blue_client_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Co::SendInBlueClient do
                 "event": "delivered",
                 "tag": "",
                 "ip": "212.146.222.15",
-                "from": "collectifobjets@beta.gouv.fr"
+                "from": "contact@collectif-objets.beta.gouv.fr"
               },
               {
                 "email": "adrien@dipasquale.fr",
@@ -35,7 +35,7 @@ RSpec.describe Co::SendInBlueClient do
                 "event": "requests",
                 "tag": "",
                 "ip": "212.146.222.15",
-                "from": "collectifobjets@beta.gouv.fr"
+                "from": "contact@collectif-objets.beta.gouv.fr"
               }
             ]
           }
@@ -73,7 +73,7 @@ RSpec.describe Co::SendInBlueClient do
                 "reason": "Unable to find MX of domain lol.fr",
                 "tag": "",
                 "ip": "212.146.222.15",
-                "from": "collectifobjets@beta.gouv.fr"
+                "from": "contact@collectif-objets.beta.gouv.fr"
               },
               {
                 "email": "wazaa@lol.fr",
@@ -83,7 +83,7 @@ RSpec.describe Co::SendInBlueClient do
                 "event": "requests",
                 "tag": "",
                 "ip": "212.146.222.15",
-                "from": "collectifobjets@beta.gouv.fr"
+                "from": "contact@collectif-objets.beta.gouv.fr"
               }
             ]
           }

--- a/spec/mailers/campaign_v1_mailer_spec.rb
+++ b/spec/mailers/campaign_v1_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples "campaign email commons" do
     # it "recipient is users' email" do
     expect(mail.to).to eq(["jean@mairie.fr"])
     # it "sender is collectif objets" do
-    expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+    expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
   end
 
   describe "contains the campaign signature" do

--- a/spec/mailers/campaign_v1_mailer_spec.rb
+++ b/spec/mailers/campaign_v1_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples "campaign email commons" do
     # it "recipient is users' email" do
     expect(mail.to).to eq(["jean@mairie.fr"])
     # it "sender is collectif objets" do
-    expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+    expect(mail.from).to eq([CONTACT_EMAIL])
   end
 
   describe "contains the campaign signature" do

--- a/spec/mailers/conservateur_mailer_spec.rb
+++ b/spec/mailers/conservateur_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ConservateurMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille vous a envoyé un message"
       expect(mail.to).to eq(["nadia.riza@drac.gouv.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 end

--- a/spec/mailers/conservateur_mailer_spec.rb
+++ b/spec/mailers/conservateur_mailer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ConservateurMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille vous a envoyé un message"
       expect(mail.to).to eq(["nadia.riza@drac.gouv.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Code de connexion"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille, merci dʼavoir contribué à Collectif Objets"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Examen du recensement des objets protégés de Marseille"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Vos recensements d'objets ont été transmis aux conservateurs"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 
@@ -92,7 +92,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Nadia Riza vous a envoyé un message sur Collectif Objets"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
+      expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Code de connexion"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille, merci dʼavoir contribué à Collectif Objets"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Examen du recensement des objets protégés de Marseille"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Vos recensements d'objets ont été transmis aux conservateurs"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 
@@ -92,7 +92,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Nadia Riza vous a envoyé un message sur Collectif Objets"
       expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq(["collectifobjets@beta.gouv.fr"])
+      expect(mail.from).to eq([ApplicationMailer::FROM_EMAIL_ADDRESS])
     end
   end
 end


### PR DESCRIPTION
Beta Gouv nous demande de ne plus envoyer nos emails avec une adresse "De:" en collectifobjets@beta.gouv.fr.

À la place, on utilise contact@collectifobjets.beta.gouv.fr.