### PR TITLE
Refactoring de la classe RecensementWizard::Base

### DIFF
--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -12,6 +12,11 @@ module RecensementWizard
 
     delegate *Recensement.attribute_names, :objet, :commune, :persisted?, to: :recensement # rubocop:disable Lint/AmbiguousOperator
 
+    def recensement_params = raise NotImplementedError
+    def wizard_params = []
+
+    def permitted_params = recensement_params + wizard_params
+
     def initialize(recensement)
       @recensement = recensement
     end
@@ -61,8 +66,6 @@ module RecensementWizard
 
       recensement.save
     end
-
-    def permitted_params = raise NotImplementedError
 
     def after_success_path
       to_step = confirmation_modal? ? step_number : next_step_number

--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -81,8 +81,7 @@ module RecensementWizard
 
     def assign_attributes(attributes)
       attrs_recensement = attributes.to_h.clone.symbolize_keys
-      attrs_wizard = attrs_recensement.slice! \
-        :localisation, :recensable, :edifice_nom, :autre_commune_code_insee, :etat_sanitaire, :securisation, :notes
+      attrs_wizard = attrs_recensement.slice!(*recensement_params)
       recensement.assign_attributes(attrs_recensement)
       super(attrs_wizard)
     end

--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -10,12 +10,7 @@ module RecensementWizard
     include ActiveModel::Model
     attr_reader :recensement
 
-    delegate \
-      :objet, :commune, :localisation, :recensable, :edifice_nom, :etat_sanitaire,
-      :securisation, :notes, :photos, :photo_attachments, :recensable?, :absent?,
-      :edifice_initial?, :autre_commune_code_insee,
-      :analyse_etat_sanitaire, :analyse_securisation, :persisted?,
-      to: :recensement
+    delegate *Recensement.attribute_names, :objet, :commune, :persisted?, to: :recensement # rubocop:disable Lint/AmbiguousOperator
 
     def initialize(recensement)
       @recensement = recensement
@@ -110,9 +105,9 @@ module RecensementWizard
     def skipped_steps
       # return [] if step_number <= 5 # can we comment this line ?
       s = []
-      s += [2, 3, 4, 5] if absent?
-      s += [4, 5] unless recensable?
-      s += [2] if edifice_initial?
+      s += [2, 3, 4, 5] if recensement.absent?
+      s += [4, 5] unless recensement.recensable?
+      s += [2] if recensement.edifice_initial?
       s
     end
   end

--- a/app/models/recensement_wizard/step1.rb
+++ b/app/models/recensement_wizard/step1.rb
@@ -7,6 +7,9 @@ module RecensementWizard
 
     attr_accessor :confirmation_introuvable
 
+    def recensement_params = %i[localisation]
+    def wizard_params = %i[confirmation_introuvable]
+
     validates :localisation, presence: { message: "Veuillez préciser où se trouve l’objet" }
 
     validates :localisation,
@@ -20,8 +23,6 @@ module RecensementWizard
       super
       self.confirmation_introuvable = recensement.absent? ? "true" : "false"
     end
-
-    def permitted_params = %i[localisation confirmation_introuvable]
 
     def next_step_number
       if localisation == Recensement::LOCALISATION_ABSENT

--- a/app/models/recensement_wizard/step2.rb
+++ b/app/models/recensement_wizard/step2.rb
@@ -5,6 +5,8 @@ module RecensementWizard
     STEP_NUMBER = 2
     TITLE = "Précisions sur la localisation"
 
+    def recensement_params = %i[edifice_nom autre_commune_code_insee]
+
     validates \
       :edifice_nom,
       presence: {
@@ -13,7 +15,5 @@ module RecensementWizard
 
     validates :autre_commune_code_insee,
               presence: { message: "Veuillez préciser le code INSEE de la commune dans laquelle l'objet a été déplacé" }
-
-    def permitted_params = %i[edifice_nom autre_commune_code_insee]
   end
 end

--- a/app/models/recensement_wizard/step3.rb
+++ b/app/models/recensement_wizard/step3.rb
@@ -21,7 +21,8 @@ module RecensementWizard
       self.confirmation_not_recensable = recensement.recensable_was == false ? "true" : "false"
     end
 
-    def permitted_params = %i[recensable confirmation_not_recensable]
+    def recensement_params = %i[recensable]
+    def wizard_params = %i[confirmation_not_recensable]
 
     def confirmation_modal_path_params
       return if recensable != false || confirmation_not_recensable

--- a/app/models/recensement_wizard/step4.rb
+++ b/app/models/recensement_wizard/step4.rb
@@ -11,6 +11,10 @@ module RecensementWizard
 
     delegate :photos, :photo_attachments, to: :recensement
 
+    def recensement_params = %i[photos]
+
+    def wizard_params = %i[confirmation_no_photos]
+
     validates(
       :photos,
       content_type: %w[image/jpg image/jpeg image/png],
@@ -21,8 +25,6 @@ module RecensementWizard
       super
       self.confirmation_no_photos = "false"
     end
-
-    def permitted_params = %i[confirmation_no_photos photos]
 
     # rubocop:disable Style/GuardClause
     def assign_attributes(parsed_params)

--- a/app/models/recensement_wizard/step4.rb
+++ b/app/models/recensement_wizard/step4.rb
@@ -9,6 +9,8 @@ module RecensementWizard
 
     attr_accessor :confirmation_no_photos
 
+    delegate :photos, :photo_attachments, to: :recensement
+
     validates(
       :photos,
       content_type: %w[image/jpg image/jpeg image/png],

--- a/app/models/recensement_wizard/step5.rb
+++ b/app/models/recensement_wizard/step5.rb
@@ -5,6 +5,8 @@ module RecensementWizard
     STEP_NUMBER = 5
     TITLE = "Objet"
 
+    def recensement_params = %i[etat_sanitaire securisation]
+
     validates \
       :etat_sanitaire,
       presence: { message: "Veuillez préciser l’état de l’objet" }
@@ -28,7 +30,5 @@ module RecensementWizard
         message: "La sécurisation de l’objet n’est pas valide"
       },
       if: -> { securisation.present? }
-
-    def permitted_params = %i[etat_sanitaire securisation]
   end
 end

--- a/app/models/recensement_wizard/step6.rb
+++ b/app/models/recensement_wizard/step6.rb
@@ -5,6 +5,6 @@ module RecensementWizard
     STEP_NUMBER = 6
     TITLE = "Commentaires"
 
-    def permitted_params = %i[notes]
+    def recensement_params = %i[notes]
   end
 end


### PR DESCRIPTION
 Dans la classe `RecensementWizard::Base`, on liste à plusieurs reprises les attributs de l'objet `Recensement`, notamment dans la méthode `assign_attributes` et le `delegate`.

On retrouve aussi les booléens comme `recensable` ou les `confirmation_` dans la méthode `parse_params`.

L'idée est de les reporter sur les classes filles `RecensementWizard::StepN`, afin de ne pas modifier la classe `Base` lorsqu'on ajoute ou modifie une étape.