### PR TITLE
Utilisation de la timezone Paris

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module CollectifObjets
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Europe/Paris"
 
     config.autoload_lib(ignore: %w[assets tasks])
 


### PR DESCRIPTION
Suite à un constat de mauvais affichage de l'heure sur les emails de codes de session et des messages dans la messagerie, je me suis aperçu que la timezone n'était pas configurée.

Après un tour dans le code pour vérifier où on utilisait des `Time.zone.now` ou `Time.zone.today`, cela ne devrait pas avoir d'impact sur les jobs.