### PR TITLE
Évite l'affichage d'un message de déprécation causé par Devise

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = '4bbaa3207495a0fbc27ab6ba9a80c1be373845b0789115e18506d81814ba1f4aef683425e7087bb95646686a56e8ba3c5af286ba50f144705665f50cf8563fc2'
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
Lors du démarrage de l'application, Devise cherche la clé `secrets_key_base` dans `Rails.application.secrets`, ce qui déclenche le message de déprécation suivant :

> WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2.

En attendant que Devise corriger le problème, il suffit d'indiquer où trouver cette clé explicitement.

[Issue sur Devise](https://github.com/heartcombo/devise/issues/5644)