### PR TITLE
Enregistre le statut des tests (en dev uniquement)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore saved spec results
+spec/examples.txt
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+     config.example_status_persistence_file_path = "spec/examples.txt" unless ENV["CI"].present?
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:


### PR DESCRIPTION
Permet de gagner du temps en ne relançant que les tests en erreur avec la commande `rspec --only-failures`.