### PR TITLE
Re recensement

### DIFF
--- a/app/controllers/communes/recensements_controller.rb
+++ b/app/controllers/communes/recensements_controller.rb
@@ -11,7 +11,8 @@ module Communes
     end
 
     def create
-      @recensement = Recensement.new(objet: @objet, status: "draft")
+      commune = Commune.find(params[:commune_id])
+      @recensement = commune.dossier.recensements.build(objet: @objet, status: "draft")
       authorize(@recensement)
       if @recensement.save
         redirect_to edit_commune_objet_recensement_path(@recensement.commune, @objet, @recensement, step: 1)

--- a/app/controllers/communes/recensements_controller.rb
+++ b/app/controllers/communes/recensements_controller.rb
@@ -15,9 +15,9 @@ module Communes
       @recensement = commune.dossier.recensements.build(objet: @objet, status: "draft")
       authorize(@recensement)
       if @recensement.save
-        redirect_to edit_commune_objet_recensement_path(@recensement.commune, @objet, @recensement, step: 1)
+        redirect_to edit_commune_objet_recensement_path(commune, @objet, @recensement, step: 1)
       else
-        redirect_to commune_objet_path(objet.commune, objet),
+        redirect_to commune_objet_path(@objet.commune, @objet),
                     alert: "Une erreur est survenue : #{@recensement.errors.full_messages.join}"
       end
     end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -65,6 +65,10 @@ class Commune < ApplicationRecord
   accepts_nested_attributes_for :users, allow_destroy: true
   validates_associated :users
 
+  after_create do
+    update!(dossier: Dossier.create!(commune: self))
+  end
+
   # Le "statut global" est une sorte de fusion des champs status de la commune, du dossier et de l'examen,
   # et permet l'affichage d'un statut unique dans les vues et un filtre facile via Ransack.
   #

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -32,7 +32,8 @@ class Commune < ApplicationRecord
     dependent: nil # leave the objets in the database when the commune is destroyed
   )
   has_many :recensements, through: :objets
-  has_many :past_dossiers, class_name: "Dossier", dependent: :restrict_with_error
+  has_many :past_dossiers, -> { where.not(id: dossier_id) },
+           class_name: "Dossier", inverse_of: "commune", dependent: :restrict_with_error
   belongs_to :dossier, optional: true
   has_many :campaign_recipients, dependent: :destroy
   has_many :admin_comments, dependent: :destroy, as: :resource

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -12,7 +12,7 @@ class Commune < ApplicationRecord
     state :started, display: "Recensement démarré"
     state :completed, display: "Recensement terminé"
 
-    event :start, before: :aasm_before_start do
+    event :start do
       transitions from: :inactive, to: :started
     end
     event :complete, after: :aasm_after_complete do
@@ -180,12 +180,6 @@ class Commune < ApplicationRecord
     parts << "conservateur" if role == :conservateur
     parts << inbound_email_token
     "#{parts.join('-')}@#{Rails.configuration.x.inbound_emails_domain}"
-  end
-
-  def aasm_before_start
-    raise AASM::InvalidTransition if dossier.present?
-
-    update!(dossier: Dossier.create!(commune: self))
   end
 
   def aasm_after_complete

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -32,8 +32,7 @@ class Commune < ApplicationRecord
     dependent: nil # leave the objets in the database when the commune is destroyed
   )
   has_many :recensements, through: :objets
-  has_many :past_dossiers, -> { where.not(id: dossier_id) },
-           class_name: "Dossier", inverse_of: "commune", dependent: :restrict_with_error
+  has_many :past_dossiers, class_name: "Dossier", dependent: :restrict_with_error
   belongs_to :dossier, optional: true
   has_many :campaign_recipients, dependent: :destroy
   has_many :admin_comments, dependent: :destroy, as: :resource

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -15,6 +15,10 @@ class Dossier < ApplicationRecord
     state :submitted, display: I18n.t("dossier.status_badge.submitted")
     state :accepted, display: I18n.t("dossier.status_badge.accepted")
 
+    event :start do
+      transitions from: :empty, to: :construction
+    end
+
     event :submit, after: :aasm_after_submit do
       transitions from: :construction, to: :submitted
     end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -10,7 +10,7 @@ class Dossier < ApplicationRecord
 
   include AASM
   aasm column: :status, timestamps: true, whiny_persistence: true do
-    state :empty, initial: true, display: I18n.t("dossier.status_badge.vide")
+    state :empty, initial: true, display: I18n.t("dossier.status_badge.empty")
     state :construction, display: I18n.t("dossier.status_badge.construction")
     state :submitted, display: I18n.t("dossier.status_badge.submitted")
     state :accepted, display: I18n.t("dossier.status_badge.accepted")

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -10,9 +10,11 @@ class Dossier < ApplicationRecord
 
   include AASM
   aasm column: :status, timestamps: true, whiny_persistence: true do
+    state :initial
     state :construction, initial: true, display: I18n.t("dossier.status_badge.construction")
     state :submitted, display: I18n.t("dossier.status_badge.submitted")
     state :accepted, display: I18n.t("dossier.status_badge.accepted")
+    state :closed
 
     event :submit, after: :aasm_after_submit do
       transitions from: :construction, to: :submitted

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -10,11 +10,10 @@ class Dossier < ApplicationRecord
 
   include AASM
   aasm column: :status, timestamps: true, whiny_persistence: true do
-    state :initial
-    state :construction, initial: true, display: I18n.t("dossier.status_badge.construction")
+    state :empty, initial: true, display: I18n.t("dossier.status_badge.vide")
+    state :construction, display: I18n.t("dossier.status_badge.construction")
     state :submitted, display: I18n.t("dossier.status_badge.submitted")
     state :accepted, display: I18n.t("dossier.status_badge.accepted")
-    state :closed
 
     event :submit, after: :aasm_after_submit do
       transitions from: :construction, to: :submitted

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -120,12 +120,7 @@ class Recensement < ApplicationRecord
 
   def aasm_after_complete
     commune.start! if commune.inactive?
-
-    if !commune.dossier&.persisted? || !commune.dossier&.valid?
-      raise ActiveRecord::RecordInvalid, "cannot complete recensement before dossier is created"
-    end
-
-    update(dossier: commune.dossier)
+    dossier.start! if dossier.empty?
   end
 
   def aasm_after_commit_complete

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -92,10 +92,10 @@ fr:
       en_danger: Facile à voler
   dossier:
     status_badge:
+      empty: Non Recensé
       construction: Partiellement recensé
       submitted: Non examiné
       accepted: Examiné
-      none: Non recensé
     rapport:
       recensement:
         notes: Commentaires de la commune

--- a/db/migrate/20240506145400_create_empty_dossier_for_communes_without_dossier.rb
+++ b/db/migrate/20240506145400_create_empty_dossier_for_communes_without_dossier.rb
@@ -1,0 +1,14 @@
+class CreateEmptyDossierForCommunesWithoutDossier < ActiveRecord::Migration[7.1]
+  def up
+    Commune.where(dossier_id: nil).find_each do |commune|
+      dossier = commune.create_dossier(status: :empty, commune_id: commune.id)
+      commune.update(dossier:)
+    end
+  end
+
+  def down
+    dossier_ids = Dossier.empty.ids
+    Dossier.empty.delete_all
+    Commune.where(dossier_id: dossier_ids).update_all(dossier_id: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_124218) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_06_145400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :dossier do
     association :commune
-    status { "construction" }
 
     trait :submitted do
       status { "submitted" }


### PR DESCRIPTION
L'idée ici était d'aborder le sujet du re-recensement en ayant obligatoirement un dossier en base pour chaque commune. On supprimait ainsi les callbacks du type `aasm_before_start` qui créait le dossier pour la commune.

Nous avons mis ça de côté pour le moment