### PR TITLE
Correctif de l'export Mémoire

### DIFF
--- a/app/jobs/export_memoire_csv_job.rb
+++ b/app/jobs/export_memoire_csv_job.rb
@@ -13,17 +13,6 @@ class ExportMemoireCsvJob < ApplicationJob
 
   private
 
-  def palissy_data
-    @palissy_data ||= Synchronizer::ApiClientJson.objets(
-      params: {
-        REF__in: recensements_memoire.map(&:objet).map(&:palissy_REF).join(","),
-        _col: %w[REF TICO CATE DATE SCLE AUTR INSEE ADRS LIEU],
-        _json: %w[CATE DATE SCLE AUTR]
-      },
-      logger: Rails.logger, limit: 1000
-    ).to_a
-  end
-
   def io
     StringIO.new(
       CSV.generate(force_quotes: true) do |csv|
@@ -36,7 +25,7 @@ class ExportMemoireCsvJob < ApplicationJob
   end
 
   def recensement_photos
-    @recensement_photos ||= MemoireExportPhoto.from_recensements(recensements_memoire, palissy_data:)
+    @recensement_photos ||= MemoireExportPhoto.from_recensements(recensements_memoire)
   end
 
   def recensements_memoire

--- a/spec/models/memoire_export_photo_spec.rb
+++ b/spec/models/memoire_export_photo_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MemoireExportPhoto, type: :model do
+  let!(:departement) { create(:departement, code: "52") }
+  let!(:commune) { create(:commune, nom: "Anglefort", departement:) }
+  let!(:edifice) { create(:edifice, nom: "Notre Dame", code_insee: commune.code_insee) }
+  let!(:objet) do
+    create(:objet, palissy_REF: "PM12345678", palissy_TICO: "La Sainte-Famille", palissy_CATE: "Peinture",
+                   palissy_SCLE: "16e siècle", palissy_INSEE: "01010", commune:, edifice:)
+  end
+  let!(:recensement) { create(:recensement, :with_photo, objet:) }
+
+  it "should be valid" do
+    attachment = recensement.photos.first
+    attachment.memoire_number = 1
+    memoire_export_photo = MemoireExportPhoto.new(attachment:, recensement:)
+    current_year = Time.zone.today.year
+    expect(memoire_export_photo.memoire_LBASE).to eq("PM12345678")
+    expect(memoire_export_photo.memoire_NUMP).to eq("#{current_year}052000001")
+    expect(memoire_export_photo.memoire_REF).to eq("MHCO052_#{memoire_export_photo.memoire_NUMP}")
+    expect(memoire_export_photo.memoire_REFIMG).to eq("#{memoire_export_photo.memoire_REF}.jpg")
+    expect(memoire_export_photo.memoire_DATPV).to eq(current_year)
+    expect(memoire_export_photo.memoire_COULEUR).to eq("Oui")
+    expect(memoire_export_photo.memoire_OBS).to eq("Photographie fournie lors du recensement " \
+                                                   "réalisé par Collectif Objets")
+    expect(memoire_export_photo.memoire_COM).to eq("Anglefort")
+    expect(memoire_export_photo.memoire_EDIF).to eq("Notre Dame")
+    expect(memoire_export_photo.memoire_COPY).to eq("© Ministère de la Culture (France), Collectif Objets " \
+                                                    "– Tous droits réservés")
+    expect(memoire_export_photo.memoire_TYPDOC).to eq("Image numérique native")
+    expect(memoire_export_photo.memoire_IDPROD).to eq("MHCO008")
+    expect(memoire_export_photo.memoire_LIEUCOR).to eq("Collectif Objets")
+    expect(memoire_export_photo.memoire_LEG).to eq("La Sainte-Famille")
+    expect(memoire_export_photo.memoire_TECHOR).to eq("Peinture")
+    expect(memoire_export_photo.memoire_SCLE).to eq("16e siècle")
+    expect(memoire_export_photo.memoire_INSEE).to eq("01010")
+  end
+end


### PR DESCRIPTION
## Constat

Depuis l’admin “Export pour POP”, lorsqu’on génère un export des photos (à destination de la MPP), le CSV ne se génère jamais.

## Investigation

Après avoir creusé dans la tâche responsable de la génération de l’export `ExportMemoireCsvJob` plante avec l’erreur suivante :

`NameError: uninitialized constant Synchronizer::ApiClientJson`

En fait, pendant l’export on va ré importer certains champs de Palissy qui ne sont pas dans notre base. Mais cet import ne fonctionne pas car il se base sur l’ancienne méthode qui n’est plus disponible (on est censés passer uniquement par le portail Open Data du ministère de la Culture).

Les champs en question sont DATE, AUTR, ADRS et LIEU, respectivement utilisés pour remplir les champs Mémoire DATEOEU, AUTOEU, ADRESSE, LIEU.

## Résolution
La MPP est d'accord pour omettre ces champs lors de l’export.
On peut donc ne plus les importer et les retirer de l'export.