### PR TITLE
Corrige l'affichage des objets incomplets

### DIFF
--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -100,6 +100,7 @@ class Objet < ApplicationRecord
   end
 
   def to_s = palissy_TICO
+  def nom = super || [palissy_DENO || categorie || palissy_REF, crafted_at].compact_blank.join(", ").upcase_first
   def déplacé? = palissy_WEB.present? && palissy_DEPL.present?
   def code_insee_a_changé? = palissy_WEB.present? && palissy_DEPL.blank?
 

--- a/app/views/shared/_objet_attributes.html.haml
+++ b/app/views/shared/_objet_attributes.html.haml
@@ -21,12 +21,12 @@
 %p
   %b Époque
   %br
-  = objet.crafted_at || "N/A"
+  = objet.crafted_at || "Inconnue"
 
 %p
   %b Protection
   %br
-  = objet.palissy_DPRO || "N/A"
+  = objet.palissy_DPRO || "Inconnue"
 
 - if objet.déplacé?
   %p
@@ -45,7 +45,7 @@
   %b Récolement
   %br
   Dernier récolement :
-  = objet.last_recolement_at || "N/A"
+  = objet.last_recolement_at || "inconnu"
 
 %p
   %b Références

--- a/app/views/shared/_objet_attributes.html.haml
+++ b/app/views/shared/_objet_attributes.html.haml
@@ -3,8 +3,11 @@
 %p
   %b Emplacement
   %br
-  Se situe dans l'édifice
-  %b= objet.edifice_nom
+  - if objet.edifice_nom
+    Se situe dans l'édifice
+    %b= objet.edifice_nom
+  - else
+    Inconnu
   %br
   %i= objet.emplacement
 

--- a/app/views/shared/_objet_attributes.html.haml
+++ b/app/views/shared/_objet_attributes.html.haml
@@ -11,12 +11,12 @@
 %p
   %b Dénomination
   %br
-  = objet.palissy_DENO
+  = objet.palissy_DENO || "Inconnue"
 
 %p
   %b Catégorie
   %br
-  = objet.categorie
+  = objet.categorie || "Inconnue"
 
 %p
   %b Époque


### PR DESCRIPTION
Certains objets n'ont pas beaucoup d'informations, ce qui provoque un affichage incomplet. Je propose de générer un nom à partir des données présentes si nécessaire.
En remplaçant "N/A" par "Inconnu" on évite un problème d'accessibilité (abréviation non identifiée), tout en étant plus explicite.