### PR TITLE
Update @gouvfr/dsfr 1.11.0 -> 1.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@gouvfr/dsfr": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.11.0.tgz",
-      "integrity": "sha512-RD+kUk9iJJ4B7xFdAFCNQz0LRqYiMy9dajlKfgnmDPSrYHm+JCJpYCzXhNjYyp4FJggMafRd1ZqJJ6KW6aM0Jw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.11.2.tgz",
+      "integrity": "sha512-S7idT4rCCw6M1pqxJS8y4nUSq/Rus+Kucoifmv0CrZD/eoBA34HWqWYzR9GIxvtAX/TQ1XC7Hz+54THtVzMeqQ==",
       "engines": {
         "node": ">=18.16.1"
       }
@@ -2969,9 +2969,9 @@
       "optional": true
     },
     "@gouvfr/dsfr": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.11.0.tgz",
-      "integrity": "sha512-RD+kUk9iJJ4B7xFdAFCNQz0LRqYiMy9dajlKfgnmDPSrYHm+JCJpYCzXhNjYyp4FJggMafRd1ZqJJ6KW6aM0Jw=="
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@gouvfr/dsfr/-/dsfr-1.11.2.tgz",
+      "integrity": "sha512-S7idT4rCCw6M1pqxJS8y4nUSq/Rus+Kucoifmv0CrZD/eoBA34HWqWYzR9GIxvtAX/TQ1XC7Hz+54THtVzMeqQ=="
     },
     "@hotwired/stimulus": {
       "version": "3.2.2",


### PR DESCRIPTION
Corrige le focus invisible sur le logo.

J'ai vérifié, il ne devrait pas y avoir d'impact sur l'affichage car il n'y a que des correctifs (comme indiqué par le numéro de version).
[Voir tous les changements](https://github.com/GouvernementFR/dsfr/compare/v1.11.0...v1.11.2)