### PR TITLE
Simplification de l'affichage du guide de recensement

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  PDFS = { "guide" => "Guidederecensement" }.freeze
   STATIC_FILES_HOST = "fichiers.collectif-objets.beta.gouv.fr"
 
   before_action :render_markdown, only: [
@@ -24,32 +23,21 @@ class PagesController < ApplicationController
   end
 
   def guide
-    params[:pdf] = "guide"
-    pdf_embed
-    render "pdf_embed"
-  end
+    respond_to do |format|
+      format.html
+      format.pdf do
+        filename = "Guidederecensement"
+        pdf_body = Rails.cache.fetch("pdfs/1.0/#{filename}.pdf", expires_in: 2.days) do
+          url = "https://#{STATIC_FILES_HOST}/#{filename}.pdf"
+          res = Net::HTTP.get_response(URI.parse(url))
+          raise unless res.code.starts_with?("2")
 
-  def pdf_embed
-    @pdf_name = params[:pdf]
-    raise unless PDFS.keys.include?(@pdf_name)
+          res.body
+        end
 
-    @breadcrumbs = @pdf_name.starts_with?("fiche") ? [["Fiches", fiches_url]] : []
-    @page = params[:page]&.to_i if params[:page]&.to_i&.positive?
-  end
-
-  def pdf_download
-    filename = PDFS[params[:pdf]]
-    raise if filename.blank?
-
-    pdf_body = Rails.cache.fetch("pdfs/1.0/#{filename}.pdf", expires_in: 2.days) do
-      url = "https://#{STATIC_FILES_HOST}/#{filename}.pdf"
-      res = Net::HTTP.get_response(URI.parse(url))
-      raise unless res.code.starts_with?("2")
-
-      res.body
+        send_data(pdf_body, content_type: "application/pdf", filename:, disposition: :inline)
+      end
     end
-
-    send_data(pdf_body, content_type: "application/pdf", filename:, disposition: :inline)
   end
 
   def campaigns_ics

--- a/app/views/pages/guide.haml
+++ b/app/views/pages/guide.haml
@@ -1,0 +1,9 @@
+- title = t("pages.pdf_embed.title.guide")
+- content_for(:head_title) { title }
+
+%main#contenu.fr-container.fr-pt-2w.fr-pb-8w
+  = render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: title
+  %h1= title
+  %p
+    = link_to "Télécharger", url_for(format: :pdf), class: "fr-link fr-link--icon-right fr-icon-file-download-line", download: "guide.pdf"
+  %embed.co-pdf-embed.co-height--60vh{src: "#{url_for(format: :pdf)}", title: title, type: "application/pdf", width: "100%" }

--- a/app/views/pages/pdf_embed.html.haml
+++ b/app/views/pages/pdf_embed.html.haml
@@ -1,9 +1,0 @@
-- title = t("pages.pdf_embed.title.#{@pdf_name}")
-- content_for(:head_title) { title }
-
-%main#contenu.fr-container.fr-pt-2w.fr-pb-8w
-  = render "shared/breadcrumbs", links: [["Accueil", root_path]] + @breadcrumbs, current_page_label: title
-  %h1= title
-  %p
-    = link_to "Télécharger", pdf_download_url(pdf: @pdf_name), class: "fr-link fr-link--icon-right fr-icon-file-download-line", download: "#{@pdf_name}.pdf"
-  %embed.co-pdf-embed.co-height--60vh{src: "#{pdf_download_url(pdf: @pdf_name)}", title: title, type: "application/pdf", width: "100%" }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
     get :confidentialite
     get "comment-ca-marche", action: :aide, as: :aide
     get "guide-de-recensement", action: :guide, as: :guide
-    get :pdf, action: :pdf_download, as: :pdf_download
+    get :pdf, to: redirect("guide-de-recensement")
     get :admin
     get :plan
     get :declaration_accessibilite


### PR DESCRIPTION
Les fiches ont été extraites de ce contrôleur dans le commit 1272a73c9186be7ff2085075e4ce279a211384ff.
Corrige l'erreur Sentry #52860 (825 occurrences).