### PR TITLE
Corrige l'affichage de la page statistiques

### DIFF
--- a/app/views/pages/stats.html.haml
+++ b/app/views/pages/stats.html.haml
@@ -4,7 +4,7 @@
 %main.fr-container.fr-pb-8w
   = render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: title
 
-  %h1= title
+  %h1.co-text--blue= title
 
   %iframe#metabase-iframe.co-width--100.co-height--100vh{src: "https://collectif-objets-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/33cf5b50-b2e8-41c4-9bcd-ed7fe5b994d0",
     frameborder: "0",

--- a/app/views/pages/stats.html.haml
+++ b/app/views/pages/stats.html.haml
@@ -1,7 +1,10 @@
-- content_for(:head_title) { "Statistiques" }
+- title = "Statistiques"
+- content_for(:head_title) { title }
 
 %main.fr-container.fr-pb-8w
-  = render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: "Statistiques"
+  = render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: title
+
+  %h1= title
 
   %iframe#metabase-iframe.co-width--100.co-height--100vh{src: "https://collectif-objets-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/33cf5b50-b2e8-41c4-9bcd-ed7fe5b994d0",
     frameborder: "0",

--- a/app/views/pages/stats.html.haml
+++ b/app/views/pages/stats.html.haml
@@ -1,9 +1,9 @@
 - content_for(:head_title) { "Statistiques" }
 
 %main.fr-container.fr-pb-8w
-= render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: "Statistiques"
+  = render "shared/breadcrumbs", links: [["Accueil", root_path]], current_page_label: "Statistiques"
 
-%iframe#metabase-iframe.co-width--100.co-height--100vh{src: "https://collectif-objets-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/33cf5b50-b2e8-41c4-9bcd-ed7fe5b994d0",
-  frameborder: "0",
-  allowtransparency: true
-}
+  %iframe#metabase-iframe.co-width--100.co-height--100vh{src: "https://collectif-objets-metabase.osc-secnum-fr1.scalingo.io/public/dashboard/33cf5b50-b2e8-41c4-9bcd-ed7fe5b994d0",
+    frameborder: "0",
+    allowtransparency: true
+  }


### PR DESCRIPTION
À cause de l'indentation, le contenu n'était pas inclus dans le conteneur, et s'étalait en pleine largeur. Sur écran large, c'était particulièrement gênant.