### PR TITLE
Amélioration du responsive sur les pages presse

### DIFF
--- a/app/frontend/stylesheets/utilities.css
+++ b/app/frontend/stylesheets/utilities.css
@@ -161,6 +161,7 @@ html[data-fr-scheme="dark"] .co-background--white { background-color: #000; }
 .co-flex--shrink-0 { flex-shrink: 0; }
 
 @media only screen and (max-width: 768px) {
+  .co-flex-md-column { flex-direction: column; }
   .co-flex-md-reverse-order { order: -1; }
 }
 

--- a/app/views/presse/index.html.haml
+++ b/app/views/presse/index.html.haml
@@ -16,12 +16,11 @@
         %br
         = link_to "Retrouvez le reportage sur Canal 32", "https://www.canal32.fr/thematiques/culture/sujet/des-maires-participent-au-recensement-du-patrimoine-du-02-novembre-2022.html", target: "_blank", rel: "noopener", class: "fr-link co-text--muted fr-text--sm"
 
-  - @articles.each_slice(4) do |articles|
-    .fr-grid-row.fr-grid-row--gutters
-      - articles.each do |article|
-        .fr-col-6.fr-col-md-4.fr-col-lg-3
-          = render DsfrComponent::TileComponent.new title: article.title,
-            url: article_presse_path(article.id),
-            image_src: url_for(article.logo),
-            description: article.date,
-            heading_level: 2
+  .fr-grid-row.fr-grid-row--gutters
+    - @articles.each do |article|
+      .fr-col-12.fr-col-sm-6.fr-col-md-4.fr-col-lg-3
+        = render DsfrComponent::TileComponent.new title: article.title,
+          url: article_presse_path(article.id),
+          image_src: url_for(article.logo),
+          description: article.date,
+          heading_level: 2

--- a/app/views/presse/show.html.haml
+++ b/app/views/presse/show.html.haml
@@ -5,8 +5,8 @@
 
   %h1= @article.title
 
-  .co-flex.co-flex--align-items-center.co-flex--gap-1rem
-    = image_tag @article.logo, alt: "Logo #{@article.source}", class: "co-max-width-150px co-max-height-80px"
+  .co-flex.co-flex-md-column.co-flex--gap-1rem
+    = image_tag @article.logo, alt: "Logo #{@article.source}", class: "fr-responsive-img co-max-width-150px co-max-height-80px"
     %span.co-text--italic= @article.date
     = @article.source
 
@@ -16,7 +16,6 @@
   - if @article.video == "reportage_canal32"
     .fr-my-2w.co-max-width-40rem
       = render "shared/video_embed", title: "Reportage Canal 32", video_id: "114c5786-72a6-4c25-9638-cf4d87861963"
-
 
   .fr-mt-4w
     = link_to "Lire l'article complet", @article.url, class: "co-link", target: "_blank", rel: "noopener"


### PR DESCRIPTION
Une seule tuile par ligne sur petits écrans, pour éviter de n'avoir qu'un seul mot par ligne à cause de l'espacement horizontal du composant.

Sur les pages d'articles, le logo la date et le nom de l'auteur s'empilent sur mobile pour être plus lisibles.