### PR TITLE
Corrige l'enregistrement du recensement pour un objet déplacé

### DIFF
--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -24,7 +24,8 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, before: :ensure_recensable, after: :aasm_after_complete, after_commit: :aasm_after_commit_complete do
+    event :complete, before: :ensure_recensable, after: :aasm_after_complete,
+                     after_commit: :aasm_after_commit_complete do
       transitions from: :draft, to: :completed
     end
     event :soft_delete, before_transaction: :aasm_before_soft_delete_transaction do
@@ -197,9 +198,9 @@ class Recensement < ApplicationRecord
     return unless recensable.nil?
 
     self.recensable = !localisation.in?([
-      Recensement::LOCALISATION_ABSENT,
-      Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE,
-      Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
-    ])
+                                          Recensement::LOCALISATION_ABSENT,
+                                          Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE,
+                                          Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
+                                        ])
   end
 end

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -24,7 +24,7 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, after: :aasm_after_complete, after_commit: :aasm_after_commit_complete do
+    event :complete, before: :ensure_recensable, after: :aasm_after_complete, after_commit: :aasm_after_commit_complete do
       transitions from: :draft, to: :completed
     end
     event :soft_delete, before_transaction: :aasm_before_soft_delete_transaction do
@@ -191,5 +191,15 @@ class Recensement < ApplicationRecord
       deleted_reason: reason,
       deleted_message: message.presence,
       deleted_objet_snapshot: objet_snapshot || objet.snapshot_attributes
+  end
+
+  def ensure_recensable
+    return unless recensable.nil?
+
+    self.recensable = !localisation.in?([
+      Recensement::LOCALISATION_ABSENT,
+      Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE,
+      Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
+    ])
   end
 end

--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -15,7 +15,8 @@ module RecensementWizard
       :securisation, :notes, :photos, :photo_attachments, :recensable?, :absent?,
       :edifice_initial?, :autre_commune_code_insee,
       :analyse_etat_sanitaire, :analyse_securisation, :persisted?,
-      :localisation=, :recensable=, :edifice_nom=, :autre_commune_code_insee=, :etat_sanitaire=, :securisation=, :notes=,
+      :localisation=, :recensable=, :edifice_nom=, :autre_commune_code_insee=,
+      :etat_sanitaire=, :securisation=, :notes=,
       to: :recensement
 
     delegate :title, :step_number, to: :class

--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RecensementWizard
-  STEPS = [1, 2, 3, 4, 5, 6, 7].freeze
+  STEPS = (1..7).to_a.freeze
   PHOTOS_STEP_NUMER = 4 # not ideal but a quick fix to know where to redirect in recensement photos controller
   class InvalidStep < StandardError; end
 
@@ -17,6 +17,11 @@ module RecensementWizard
       :analyse_etat_sanitaire, :analyse_securisation, :persisted?,
       to: :recensement
 
+    delegate :title, :step_number, to: :class
+
+    def self.title = self::TITLE
+    def self.step_number = name.demodulize[-1].to_i
+
     def initialize(recensement)
       @recensement = recensement
     end
@@ -27,8 +32,7 @@ module RecensementWizard
       "RecensementWizard::Step#{step}".constantize.new(recensement)
     end
 
-    def title = self.class::TITLE
-    def step_number = self.class::STEP_NUMBER
+    def step_number = self.class.name.demodulize[-1].to_i
 
     def next_step_number
       step_number + 1 if step_number < STEPS.last

--- a/app/models/recensement_wizard/base.rb
+++ b/app/models/recensement_wizard/base.rb
@@ -15,6 +15,7 @@ module RecensementWizard
       :securisation, :notes, :photos, :photo_attachments, :recensable?, :absent?,
       :edifice_initial?, :autre_commune_code_insee,
       :analyse_etat_sanitaire, :analyse_securisation, :persisted?,
+      :localisation=, :recensable=, :edifice_nom=, :autre_commune_code_insee=, :etat_sanitaire=, :securisation=, :notes=,
       to: :recensement
 
     delegate :title, :step_number, to: :class
@@ -88,14 +89,6 @@ module RecensementWizard
       to_step = confirmation_modal? ? step_number : next_step_number
       edit_commune_objet_recensement_path \
         commune, objet, recensement, step: to_step, **confirmation_modal_path_params.to_h
-    end
-
-    def assign_attributes(attributes)
-      attrs_recensement = attributes.to_h.clone.symbolize_keys
-      attrs_wizard = attrs_recensement.slice! \
-        :localisation, :recensable, :edifice_nom, :autre_commune_code_insee, :etat_sanitaire, :securisation, :notes
-      recensement.assign_attributes(attrs_recensement)
-      super(attrs_wizard)
     end
 
     # Cette méthode est à re définir dans les sous-classes pour remettre à zéro les données de recensement

--- a/app/models/recensement_wizard/step1.rb
+++ b/app/models/recensement_wizard/step1.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step1 < Base
-    STEP_NUMBER = 1
     TITLE = "Localisation"
 
     attr_accessor :confirmation_introuvable

--- a/app/models/recensement_wizard/step2.rb
+++ b/app/models/recensement_wizard/step2.rb
@@ -9,7 +9,7 @@ module RecensementWizard
 
     validates :edifice_nom_existant,
               presence: { message: "Veuillez sélectionner un édifice. \
-                S’il n'est pas dans la liste, choisir \"Autre édificie\"." },
+                S’il n'est pas dans la liste, choisir \"Autre édifice\"." },
               unless: lambda {
                 localisation != Recensement::LOCALISATION_AUTRE_EDIFICE ||
                   (localisation == Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE && autre_edifice_checked)

--- a/app/models/recensement_wizard/step2.rb
+++ b/app/models/recensement_wizard/step2.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step2 < Base
-    STEP_NUMBER = 2
     TITLE = "Précisions sur la localisation"
 
     attr_accessor :edifice_nom_existant, :autre_edifice_checked

--- a/app/models/recensement_wizard/step3.rb
+++ b/app/models/recensement_wizard/step3.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step3 < Base
-    STEP_NUMBER = 3
     TITLE = "Accessibilité"
 
     include ActiveStorageValidations

--- a/app/models/recensement_wizard/step4.rb
+++ b/app/models/recensement_wizard/step4.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step4 < Base
-    STEP_NUMBER = 4
     TITLE = "Photos de l’objet"
 
     include ActiveStorageValidations

--- a/app/models/recensement_wizard/step5.rb
+++ b/app/models/recensement_wizard/step5.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step5 < Base
-    STEP_NUMBER = 5
     TITLE = "Objet"
 
     validates \

--- a/app/models/recensement_wizard/step6.rb
+++ b/app/models/recensement_wizard/step6.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step6 < Base
-    STEP_NUMBER = 6
     TITLE = "Commentaires"
 
     def permitted_params = %i[notes]

--- a/app/models/recensement_wizard/step7.rb
+++ b/app/models/recensement_wizard/step7.rb
@@ -2,7 +2,6 @@
 
 module RecensementWizard
   class Step7 < Base
-    STEP_NUMBER = 7
     TITLE = "Récapitulatif"
 
     def update(_params)

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Recensement, type: :model do
   describe "#complete!" do
     subject(:do_complete!) { recensement.complete! }
 
-    describe "#complete! pour une commune inactive" do
+    context "pour une commune inactive" do
       let!(:commune) { create(:commune, status: "inactive") }
       let!(:objet) { create(:objet, commune:) }
       let(:recensement) { create(:recensement, objet:, status: "draft", dossier: nil) }
@@ -183,7 +183,7 @@ RSpec.describe Recensement, type: :model do
       end
     end
 
-    describe "#complete! pour une commune started" do
+    context "pour une commune started" do
       let!(:commune) { create(:commune, status: "started") }
       let!(:dossier) { create(:dossier, status: "construction", commune:) }
       before { commune.update!(dossier:) }
@@ -203,7 +203,7 @@ RSpec.describe Recensement, type: :model do
       end
     end
 
-    describe "#complete! pour une commune inactive mais une erreur se produit" do
+    context "pour une commune inactive mais une erreur se produit" do
       let!(:commune) { create(:commune, status: "inactive") }
       let!(:objet) { create(:objet, commune:) }
       let(:recensement) { create(:recensement, objet:, status: "draft", dossier: nil) }

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -171,10 +171,14 @@ RSpec.describe Recensement, type: :model do
       let(:etat_sanitaire) { Recensement::ETAT_BON }
       let(:securisation) { Recensement::SECURISATION_CORRECTE }
       let(:localisation) { Recensement::LOCALISATION_EDIFICE_INITIAL }
-      let(:recensement) { create(:recensement, status: :draft, recensable:, localisation:, etat_sanitaire:, securisation:) }
+      let(:recensement) do
+        create(:recensement, status: :draft, recensable:, localisation:, etat_sanitaire:, securisation:)
+      end
 
       context "false" do
-        let(:recensement) { create(:recensement, status: :draft, localisation:, recensable:, etat_sanitaire: nil, securisation: nil) }
+        let(:recensement) do
+          create(:recensement, status: :draft, localisation:, recensable:, etat_sanitaire: nil, securisation: nil)
+        end
         let(:recensable) { false }
         it "reste false" do
           do_complete!
@@ -211,7 +215,7 @@ RSpec.describe Recensement, type: :model do
             let(:etat_sanitaire) { nil }
             let(:securisation) { nil }
             it "devient false" do
-              recensement.autre_commune_code_insee = 12345
+              recensement.autre_commune_code_insee = 12_345
               recensement.edifice_nom = "autre édifice"
               do_complete!
               expect(recensement.reload.recensable).to eq false

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -167,6 +167,78 @@ RSpec.describe Recensement, type: :model do
   describe "#complete!" do
     subject(:do_complete!) { recensement.complete! }
 
+    context "quand recensable est" do
+      let(:etat_sanitaire) { Recensement::ETAT_BON }
+      let(:securisation) { Recensement::SECURISATION_CORRECTE }
+      let(:localisation) { Recensement::LOCALISATION_EDIFICE_INITIAL }
+      let(:recensement) { create(:recensement, status: :draft, recensable:, localisation:, etat_sanitaire:, securisation:) }
+
+      context "false" do
+        let(:recensement) { create(:recensement, status: :draft, localisation:, recensable:, etat_sanitaire: nil, securisation: nil) }
+        let(:recensable) { false }
+        it "reste false" do
+          do_complete!
+          expect(recensement.reload.recensable).to eq recensable
+        end
+      end
+      context "true" do
+        let(:recensable) { true }
+        it "reste true" do
+          do_complete!
+          expect(recensement.reload.recensable).to eq recensable
+        end
+      end
+      context "vide" do
+        let(:recensable) { nil }
+        context "et localisation est" do
+          context "LOCALISATION_EDIFICE_INITIAL" do
+            let(:localisation) { Recensement::LOCALISATION_EDIFICE_INITIAL }
+            it "devient true" do
+              do_complete!
+              expect(recensement.reload.recensable).to eq true
+            end
+          end
+          context "LOCALISATION_AUTRE_EDIFICE" do
+            let(:localisation) { Recensement::LOCALISATION_AUTRE_EDIFICE }
+            it "devient true" do
+              recensement.edifice_nom = "autre édifice"
+              do_complete!
+              expect(recensement.reload.recensable).to eq true
+            end
+          end
+          context "LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE" do
+            let(:localisation) { Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE }
+            let(:etat_sanitaire) { nil }
+            let(:securisation) { nil }
+            it "devient false" do
+              recensement.autre_commune_code_insee = 12345
+              recensement.edifice_nom = "autre édifice"
+              do_complete!
+              expect(recensement.reload.recensable).to eq false
+            end
+          end
+          context "LOCALISATION_DEPLACEMENT_TEMPORAIRE" do
+            let(:localisation) { Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE }
+            let(:etat_sanitaire) { nil }
+            let(:securisation) { nil }
+            it "devient false" do
+              do_complete!
+              expect(recensement.reload.recensable).to eq false
+            end
+          end
+          context "LOCALISATION_ABSENT" do
+            let(:localisation) { Recensement::LOCALISATION_ABSENT }
+            let(:etat_sanitaire) { nil }
+            let(:securisation) { nil }
+            it "devient false" do
+              do_complete!
+              expect(recensement.reload.recensable).to eq false
+            end
+          end
+        end
+      end
+    end
+
     context "pour une commune inactive" do
       let!(:commune) { create(:commune, status: "inactive") }
       let!(:objet) { create(:objet, commune:) }

--- a/spec/requests/recensement_wizard_spec.rb
+++ b/spec/requests/recensement_wizard_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Communes::RecensementsController, type: :request do
+  let(:commune) { create(:commune, :with_user) }
+  let(:objet) { create(:objet, commune:) }
+  let(:user) { commune.users.first }
+  let(:params) { {} }
+
+  before(:each) { login_as(user, scope: :user) }
+
+  subject(:perform_request) { send(method, path, params:) }
+
+  context "POST communes/1/objets/1/recensements" do
+    let(:method) { :post }
+    let(:path) { commune_objet_recensements_path(commune_id: commune.id, objet_id: objet.id) }
+
+    context "si l'objet n'a pas de recensement" do
+      let(:recensement) { objet.recensements.last }
+      it "crée un nouveau recensement" do
+        expect { perform_request }.to change(Recensement, :count).by(1)
+        expect(recensement.draft?).to eq true
+      end
+    end
+    context "quand l'utilisateur n'appartient pas à la commune" do
+      # Rediriger vers le login semblerait plus logique, non ?
+      it "redirige vers la page d'accueil" do
+        user = create(:user)
+        login_as(user, scope: :user)
+        expect { perform_request }.to change(Recensement, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+    context "quand l'objet a déjà un recensement" do
+      # Si un recensement existe, l'autorisation est refusée. Rediriger vers le recensement en cours plutôt ?
+      it "redirige vers la page d'accueil" do
+        create(:recensement, objet:)
+        expect { perform_request }.to change(Recensement, :count).by(0)
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  context "PATCH communes/1/objets/1/recensements/1&step=" do
+    let(:recensement) { create(:recensement, objet:, status: :draft) }
+    let(:path) { commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id, step:) }
+    let(:method) { :patch }
+    let(:next_step) { edit_commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id, step: next_step_number) }
+
+    context "Étape 1" do
+      let(:step) { 1 }
+      let(:params) { { wizard: { localisation: } } }
+      context "si l'objet se trouve dans l'édifice" do
+        let(:localisation) { Recensement::LOCALISATION_EDIFICE_INITIAL }
+        let(:next_step_number) { 3 }
+        it "enregistre et redirige vers l'étape 3" do
+          perform_request
+          expect(recensement.reload.localisation).to eq localisation
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet se trouve dans un autre édifice" do
+        let(:localisation) { Recensement::LOCALISATION_AUTRE_EDIFICE }
+        let(:next_step_number) { 2 }
+        it "enregistre et redirige vers l'étape 2" do
+          perform_request
+          expect(recensement.reload.localisation).to eq localisation
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet se trouve dans une autre commune" do
+        let(:localisation) { Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE }
+        let(:next_step_number) { 2 }
+        it "enregistre et redirige vers l'étape 2" do
+          perform_request
+          expect(recensement.reload.localisation).to eq localisation
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet est temporairement déplacé" do
+        let(:localisation) { Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE }
+        let(:next_step_number) { 6 }
+        it "enregistre et redirige vers l'étape 6" do
+          perform_request
+          expect(recensement.reload.localisation).to eq localisation
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet est introuvable" do
+        let(:localisation) { Recensement::LOCALISATION_ABSENT }
+        let(:next_step_number) { 6 }
+        it "enregistre et redirige vers l'étape 6" do
+          perform_request
+          expect(recensement.reload.localisation).to eq localisation
+          expect(response).to redirect_to next_step
+        end
+      end
+    end
+
+    context "Étape 2" do
+      let(:step) { 2 }
+      context "si l'objet se trouve dans un édifice existant" do
+        let(:edifice_nom_existant) { create(:edifice, commune:).nom }
+        let(:params) { { wizard: { edifice_nom_existant: } } }
+        let(:next_step_number) { 3 }
+        it "enregistre et redirige vers l'étape 3" do
+          perform_request
+          expect(recensement.reload.edifice_nom).to eq edifice_nom_existant
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet se trouve dans un édifice non listé" do
+        let(:params) { { wizard: { edifice_nom_existant: "0", edifice_nom: "Édifice non listé"} } }
+        let(:next_step_number) { 3 }
+        it "enregistre et redirige vers l'étape 3" do
+          perform_request
+          expect(recensement.reload.edifice_nom).to eq "Édifice non listé"
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet se trouve dans une autre commune" do
+        let(:autre_commune_code_insee) { create(:commune).code_insee }
+        let(:params) { { wizard: { autre_commune_code_insee:, edifice_nom: "Édifice d'une autre commune" } } }
+        let(:next_step_number) { 3 }
+        it "enregistre et redirige vers l'étape 3" do
+          perform_request
+          expect(recensement.reload.autre_commune_code_insee).to eq autre_commune_code_insee
+          expect(recensement.edifice_nom).to eq "Édifice d'une autre commune"
+          expect(response).to redirect_to next_step
+        end
+      end
+    end
+
+    context "Étape 3" do
+      let(:step) { 3 }
+      context "si l'objet est recensable" do
+        let(:params) { { wizard: { recensable: true } } }
+        let(:next_step_number) { 4 }
+        it "enregistre et redirige vers l'étape 4" do
+          perform_request
+          expect(recensement.reload.recensable).to eq true
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'objet n'est pas recensable" do
+        let(:params) { { wizard: { recensable: false } } }
+        let(:next_step_number) { 6 }
+        it "enregistre et redirige vers l'étape 6" do
+          perform_request
+          expect(recensement.reload.recensable).to eq false
+          expect(response).to redirect_to next_step
+        end
+      end
+    end
+
+    context "Étape 4" do
+      let(:step) { 4 }
+      context "si aucune photo n'est fournie" do
+        let(:params) { { wizard: { confirmation_no_photos: true } } }
+        let(:next_step_number) { 5 }
+        it "enregistre et redirige vers l'étape 5" do
+          perform_request
+          expect(response).to redirect_to next_step
+        end
+      end
+    end
+
+    context "Étape 5" do
+      let(:step) { 5 }
+      context "si l'objet est en bon état et en sécurité" do
+        let(:params) { { wizard: { etat_sanitaire: Recensement::ETAT_BON, securisation: Recensement::SECURISATION_CORRECTE } } }
+        let(:next_step_number) { 6 }
+        it "enregistre et redirige vers l'étape 6" do
+          perform_request
+          expect(recensement.reload.etat_sanitaire).to eq Recensement::ETAT_BON
+          expect(recensement.securisation).to eq Recensement::SECURISATION_CORRECTE
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si l'état et la sécurisation de l'objet ne sont pas indiqués" do
+        let(:params) { { wizard: { etat_sanitaire: "", securisation: "" } } }
+        let(:next_step_number) { 5 }
+        it "enregistre et redirige vers l'étape 5" do
+          perform_request
+          expect(response).to have_http_status :unprocessable_entity
+        end
+      end
+    end
+
+    context "Étape 6" do
+      let(:step) { 6 }
+      context "si des notes sont fournies" do
+        let(:params) { { wizard: { notes: "Notes" } } }
+        let(:next_step_number) { 7 }
+        it "enregistre et redirige vers l'étape 7" do
+          perform_request
+          expect(recensement.reload.notes).to eq "Notes"
+          expect(response).to redirect_to next_step
+        end
+      end
+      context "si le champ notes reste vide" do
+        let(:params) { { wizard: { notes: "" } } }
+        let(:next_step_number) { 7 }
+        it "enregistre et redirige vers l'étape 7" do
+          perform_request
+          expect(recensement.reload.notes).to eq ""
+          expect(response).to redirect_to next_step
+        end
+      end
+    end
+
+    context "Étape 7" do
+      let(:step) { 7 }
+      it "clôture le recensement" do
+        perform_request
+        expect(recensement.reload.completed?).to eq true
+        expect(response).to redirect_to commune_objets_path(commune, objet_id: objet.id, recensement_saved: true)
+      end
+    end
+  end
+
+  context "DELETE communes/1/objets/1/recensements/1" do
+    let(:recensement) { create(:recensement, objet:, status: :completed) }
+    let(:method) { :delete }
+    let(:path) { commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id) }
+
+    context "si le recensement peut être supprimé" do
+      it "supprime le recensement" do
+        recensement
+        expect { perform_request }.to change(Recensement, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/requests/recensement_wizard_spec.rb
+++ b/spec/requests/recensement_wizard_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe Communes::RecensementsController, type: :request do
     let(:recensement) { create(:recensement, objet:, status: :draft) }
     let(:path) { commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id, step:) }
     let(:method) { :patch }
-    let(:next_step) { edit_commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id, step: next_step_number) }
+    let(:next_step) do
+      edit_commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id,
+                                          step: next_step_number)
+    end
 
     context "Étape 1" do
       let(:step) { 1 }
@@ -111,7 +114,7 @@ RSpec.describe Communes::RecensementsController, type: :request do
         end
       end
       context "si l'objet se trouve dans un édifice non listé" do
-        let(:params) { { wizard: { edifice_nom_existant: "0", edifice_nom: "Édifice non listé"} } }
+        let(:params) { { wizard: { edifice_nom_existant: "0", edifice_nom: "Édifice non listé" } } }
         let(:next_step_number) { 3 }
         it "enregistre et redirige vers l'étape 3" do
           perform_request
@@ -169,7 +172,9 @@ RSpec.describe Communes::RecensementsController, type: :request do
     context "Étape 5" do
       let(:step) { 5 }
       context "si l'objet est en bon état et en sécurité" do
-        let(:params) { { wizard: { etat_sanitaire: Recensement::ETAT_BON, securisation: Recensement::SECURISATION_CORRECTE } } }
+        let(:params) do
+          { wizard: { etat_sanitaire: Recensement::ETAT_BON, securisation: Recensement::SECURISATION_CORRECTE } }
+        end
         let(:next_step_number) { 6 }
         it "enregistre et redirige vers l'étape 6" do
           perform_request


### PR DESCRIPTION
Quand un objet est déplacé dans une autre commune, on ne demande pas s'il est recensable, et l'attribut `recensable` reste à `nil` ce qui empêche de valider le recensement ([erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/100891/)).

Le commit f05e468c4eb398f34be0d2abc1cfe799046c08c8 enregistre automatiquement une valeur inférée de la localisation de l'objet si `recensable` est à nil au moment où le référencement est complété.

J'ai ajouté des tests pour être sûr que cette modification n'a pas d'effets de bords, corrigé une coquille et amélioré la lisibilité du code et des tests au passage.