### PR TITLE
Refactoring sur le reset de data de recensement

### DIFF
--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -24,7 +24,7 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, before: :ensure_correct_data, after: :aasm_after_complete,
+    event :complete, before: :ensure_completable, after: :aasm_after_complete,
                      after_commit: :aasm_after_commit_complete do
       transitions from: :draft, to: :completed
     end
@@ -194,7 +194,7 @@ class Recensement < ApplicationRecord
       deleted_objet_snapshot: objet_snapshot || objet.snapshot_attributes
   end
 
-  def ensure_correct_data
+  def ensure_completable
     return unless recensable.nil?
 
     self.recensable = !localisation.in?([

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -24,7 +24,7 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, before: :ensure_recensable, after: :aasm_after_complete,
+    event :complete, before: :ensure_correct_data, after: :aasm_after_complete,
                      after_commit: :aasm_after_commit_complete do
       transitions from: :draft, to: :completed
     end
@@ -194,7 +194,7 @@ class Recensement < ApplicationRecord
       deleted_objet_snapshot: objet_snapshot || objet.snapshot_attributes
   end
 
-  def ensure_recensable
+  def ensure_correct_data
     return unless recensable.nil?
 
     self.recensable = !localisation.in?([
@@ -202,5 +202,14 @@ class Recensement < ApplicationRecord
                                           Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE,
                                           Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
                                         ])
+
+    return unless (recensable == false && (localisation == Recensement::LOCALISATION_ABSENT)) ||
+                  localisation == Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE ||
+                  localisation == Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
+
+    self.etat_sanitaire = nil
+    self.securisation = nil
+    self.photos = []
+    self.photos_count = 0
   end
 end

--- a/app/models/recensement_wizard/step1.rb
+++ b/app/models/recensement_wizard/step1.rb
@@ -45,16 +45,6 @@ module RecensementWizard
         recensement.edifice_nom = nil
         recensement.autre_commune_code_insee = nil
       end
-
-      return unless (localisation == Recensement::LOCALISATION_ABSENT && confirmation_introuvable) ||
-                    localisation == Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE ||
-                    localisation == Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
-
-      recensement.recensable = false
-      recensement.etat_sanitaire = nil
-      recensement.securisation = nil
-      recensement.photos = []
-      recensement.photos_count = 0
     end
   end
 end

--- a/app/models/recensement_wizard/step1.rb
+++ b/app/models/recensement_wizard/step1.rb
@@ -41,10 +41,10 @@ module RecensementWizard
     end
 
     def reset_recensement_data_for_next_steps
-      if recensement.localisation_changed?
-        recensement.edifice_nom = nil
-        recensement.autre_commune_code_insee = nil
-      end
+      return unless recensement.localisation_changed?
+
+      recensement.edifice_nom = nil
+      recensement.autre_commune_code_insee = nil
     end
   end
 end

--- a/app/models/recensement_wizard/step1.rb
+++ b/app/models/recensement_wizard/step1.rb
@@ -47,7 +47,8 @@ module RecensementWizard
       end
 
       return unless (localisation == Recensement::LOCALISATION_ABSENT && confirmation_introuvable) ||
-                    localisation == Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE
+                    localisation == Recensement::LOCALISATION_DEPLACEMENT_TEMPORAIRE ||
+                    localisation == Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE
 
       recensement.recensable = false
       recensement.etat_sanitaire = nil

--- a/app/models/recensement_wizard/step3.rb
+++ b/app/models/recensement_wizard/step3.rb
@@ -32,15 +32,5 @@ module RecensementWizard
     def next_step_number
       recensable == false ? 6 : super
     end
-
-    def reset_recensement_data_for_next_steps
-      return unless recensable == false && confirmation_not_recensable
-
-      recensement.etat_sanitaire = nil
-      recensement.securisation = nil
-      recensement.photos = []
-      # TODO : voir s'il est plus judicieux d'utiliser un counter_cache
-      recensement.photos_count = 0
-    end
   end
 end


### PR DESCRIPTION
Suite à la détection d'un bug lorsqu’une commune finalise le recensement d’un objet déclaré comme déplacé dans une autre commune, il nous a semblé judicieux d'intégrer la méthode `RecensementWizard::Base#reset_recensement_data_for_next_steps`dans la classe `Recensement`.