### PR TITLE
Améliore les tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,4 +64,5 @@ group :test do
   gem "axe-core-rspec", "~> 4.8"
   gem "capybara", "~> 3.39"
   gem "selenium-webdriver", "~> 4.16"
+  gem "webmock", "~> 3.23"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -204,6 +207,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    hashdiff (1.1.0)
     html-attributes-utils (1.0.0)
       activesupport (>= 6.1.4.4)
     html2haml (2.3.0)
@@ -465,6 +469,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.23.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.6)
@@ -532,6 +540,7 @@ DEPENDENCIES
   view_component (~> 2.83)
   vite_rails (~> 3.0)
   web-console (~> 4.2)
+  webmock (~> 3.23)
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,6 +16,10 @@ Rails.application.configure do
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 
+  # Disable logging to speed up tests
+  config.logger = Logger.new(nil)
+  config.log_level = :fatal
+
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.

--- a/spec/active_storage_safe_purge_spec.rb
+++ b/spec/active_storage_safe_purge_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe "Active Storage safe purge monkey patches" do
     end
   end
 
-  context "blob uses local service" do
+  context "when using local service" do
     let(:blob) { local_blob }
-    it "should delete the blob" do
+    it "the blob is deleted" do
       expect(blob.service).to receive(:delete)
       expect(blob.service).to receive(:delete_prefixed)
       res = blob.delete
@@ -30,9 +30,9 @@ RSpec.describe "Active Storage safe purge monkey patches" do
     end
   end
 
-  context "blob uses prod service" do
+  context "when using production service" do
     let(:blob) { local_blob.tap { _1.update!(service_name: "scaleway_production") } }
-    it "should not delete the blob" do
+    it "the blob is not deleted" do
       expect(blob.service).not_to receive(:delete)
       expect(blob.service).not_to receive(:delete_prefixed)
       res = blob.delete

--- a/spec/active_storage_safe_purge_spec.rb
+++ b/spec/active_storage_safe_purge_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Active Storage safe purge monkey patches" do
 
   context "when using production service" do
     let(:blob) { local_blob.tap { _1.update!(service_name: "scaleway_production") } }
+    before { stub_request(:any, /.*/).to_return(status: 200, body: "", headers: {}) }
     it "the blob is not deleted" do
       expect(blob.service).not_to receive(:delete)
       expect(blob.service).not_to receive(:delete_prefixed)

--- a/spec/active_storage_safe_purge_spec.rb
+++ b/spec/active_storage_safe_purge_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Active Storage safe purge monkey patches" do
-  let(:mock_service) { double("active_storage_service") }
   let(:local_blob) do
     ActiveStorage::Blob.create_and_upload!(
       io: Rails.root.join("spec/fixture_files/peinture1.jpg").open("rb"),

--- a/spec/features/public_pages_spec.rb
+++ b/spec/features/public_pages_spec.rb
@@ -66,7 +66,11 @@ feature "accessibility public pages", js: true do
   end
 
   describe "Guide du recensement" do
-    before { visit guide_path }
+    before do
+      url = Regexp.new(Regexp.escape(PagesController::STATIC_FILES_HOST))
+      stub_request(:any, url).to_return(status: 200, body: "", headers: {})
+      visit guide_path
+    end
     it { should be_axe_clean }
   end
 

--- a/spec/features/public_pages_spec.rb
+++ b/spec/features/public_pages_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 feature "accessibility public pages", js: true do
   subject { page }
 
+  describe "page d'accueil" do
+    before { visit root_path }
+    it { should be_axe_clean.excluding("iframe") }
+  end
+
   describe "communes#show" do
     let!(:commune) { create(:commune, :with_objets) }
     before { visit commune_path(commune) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,12 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers
   config.before(:suite) { require Rails.root.join("scripts/create_postgres_sequences_memoire_photos_numbers.rb") }
 
+  require "webmock/rspec"
+  WebMock.disable_net_connect!(allow_localhost: true)
+  config.before(type: :feature) do
+    stub_request(:any, /tube.numerique.gouv.fr/).to_return(status: 200, body: "", headers: {})
+  end
+
   config.after(type: :feature) do |example_group|
     next unless example_group.exception
 


### PR DESCRIPTION
Je sais qu'il y a de la feature à sortir, mais j'ai identifié quelques améliorations qui permettent de gagner du temps quand on fait tourner les tests. J'avais notamment remarqué que certains tests lançaient des requêtes HTTP, qui finissaient en timeout quand mon ordi n'avait pas de connexion Internet. Ce sont des choses faciles à bloquer avec un gain de performances non négligeable je pense.