### PR TITLE
Facilite la connexion utilisateur

### DIFF
--- a/app/controllers/admin/session_codes_controller.rb
+++ b/app/controllers/admin/session_codes_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class SessionCodesController < BaseController
+    def index; end
+
+    private
+
+    def active_nav_links = %w[Admin]
+  end
+end

--- a/app/controllers/users/session_codes_controller.rb
+++ b/app/controllers/users/session_codes_controller.rb
@@ -26,7 +26,7 @@ module Users
       # bang method because there is no reason for this to fail and we want to know if it does
       session_code = SessionCode.create!(user:)
       UserMailer.with(session_code:).session_code_email.deliver_later
-      redirect_to new_user_session_path(email: params[:email])
+      redirect_to new_user_session_path(email: user.email)
     end
 
     protected

--- a/app/controllers/users/session_codes_controller.rb
+++ b/app/controllers/users/session_codes_controller.rb
@@ -23,8 +23,8 @@ module Users
           alert: "Erreur : l’email de la commune est incorrect"
       end
 
-      session_code = SessionCode.create!(user:, code: SessionCode.generate_random_code)
       # bang method because there is no reason for this to fail and we want to know if it does
+      session_code = SessionCode.create!(user:)
       UserMailer.with(session_code:).session_code_email.deliver_later
       redirect_to new_user_session_path(email: params[:email])
     end

--- a/app/controllers/users/session_codes_controller.rb
+++ b/app/controllers/users/session_codes_controller.rb
@@ -23,8 +23,7 @@ module Users
           alert: "Erreur : l’email de la commune est incorrect"
       end
 
-      # bang method because there is no reason for this to fail and we want to know if it does
-      session_code = SessionCode.create!(user:)
+      session_code = user.session_code || user.create_session_code!
       UserMailer.with(session_code:).session_code_email.deliver_later
       redirect_to new_user_session_path(email: user.email)
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -45,8 +45,11 @@ module Users
       @email = params[:email]
       return redirect_to new_user_session_code_path if @email.blank?
 
-      @user = User.find_by(email: params[:email])
-      return redirect_to new_user_session_code_path if @user.blank?
+      @user = User.find_by(email: @email)
+      if @user.blank?
+        return redirect_to new_user_session_code_path,
+                           alert: "Aucune commune associée à l'email #{@email}"
+      end
 
       @commune = @user.commune
     end

--- a/app/jobs/sanity/remove_old_session_codes_job.rb
+++ b/app/jobs/sanity/remove_old_session_codes_job.rb
@@ -3,9 +3,9 @@
 module Sanity
   class RemoveOldSessionCodesJob < ApplicationJob
     def perform
-      session_codes = SessionCode.where("created_at < ?", 1.month.ago)
+      session_codes = SessionCode.outdated
       GoodJob.logger.info "will delete #{session_codes.count} session_codes that are older than a month"
-      session_codes.each(&:destroy!)
+      session_codes.delete_all
       GoodJob.logger.info "done, there are now #{SessionCode.count} session_codes in the database"
     end
   end

--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -17,7 +17,7 @@ class SessionAuthentication
   end
 
   def authenticate(&sign_in_block)
-    sleep(rand(0.5..1)) if Rails.env.production? # To prevent timing attacks
+    prevent_timing_attacks
     return false unless valid?
 
     return false unless sign_in_block.call(user)
@@ -33,6 +33,10 @@ class SessionAuthentication
   def error_message = errors.map(&:message).to_sentence
 
   private
+
+  def prevent_timing_attacks
+    sleep(rand(0.5..1)) if Rails.env.production?
+  end
 
   attr_reader :email, :code
 

--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -39,16 +39,16 @@ class SessionAuthentication
   delegate :session_code, to: :user, allow_nil: true
 
   def cleaned_code
-    @cleaned_code ||= code.gsub(/\s+/, "")
+    @cleaned_code ||= code.gsub(/\D+/, "")
   end
 
   def validate_code_format
-    return if errors.any? || cleaned_code.match(SessionCode::FORMAT_REGEX)
+    return if errors.any? || SessionCode.valid_format?(cleaned_code)
 
     errors.add(
       :code,
       :invalid_format,
-      message: "Le code de connexion est composé de 6 chiffres exactement. " \
+      message: "Le code de connexion est composé de #{SessionCode::LENGTH} chiffres exactement. " \
                "Vérifiez que vous n’avez pas copié deux fois le même chiffre."
     )
   end

--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -12,8 +12,8 @@ class SessionAuthentication
   validate :validate_code_format, :validate_codes_match, :validate_code_not_expired, :validate_code_not_used
 
   def initialize(email, code)
-    @email = email
-    @code = code
+    @email = email.to_s.strip
+    @code = code.gsub(/\D+/, "")
   end
 
   def authenticate(&sign_in_block)
@@ -42,12 +42,8 @@ class SessionAuthentication
 
   delegate :session_code, to: :user, allow_nil: true
 
-  def cleaned_code
-    @cleaned_code ||= code.gsub(/\D+/, "")
-  end
-
   def validate_code_format
-    return if errors.any? || SessionCode.valid_format?(cleaned_code)
+    return if errors.any? || SessionCode.valid_format?(code)
 
     errors.add(
       :code,
@@ -60,7 +56,7 @@ class SessionAuthentication
   def validate_codes_match
     return if errors.any?
 
-    return if session_code.present? && session_code.code == cleaned_code
+    return if session_code.present? && session_code.code == code
 
     errors.add(
       :code,

--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -22,7 +22,7 @@ class SessionAuthentication
 
     return false unless sign_in_block.call(user)
 
-    last_session_code.mark_used!
+    session_code.mark_used!
     true
   end
 
@@ -36,7 +36,7 @@ class SessionAuthentication
 
   attr_reader :email, :code
 
-  delegate :last_session_code, to: :user, allow_nil: true
+  delegate :session_code, to: :user, allow_nil: true
 
   def cleaned_code
     @cleaned_code ||= code.gsub(/\s+/, "")
@@ -56,7 +56,7 @@ class SessionAuthentication
   def validate_codes_match
     return if errors.any?
 
-    return if last_session_code.present? && last_session_code.code == cleaned_code
+    return if session_code.present? && session_code.code == cleaned_code
 
     errors.add(
       :code,
@@ -69,7 +69,7 @@ class SessionAuthentication
   def validate_code_not_used
     return if errors.any?
 
-    return unless last_session_code.used?
+    return unless session_code.used?
 
     errors.add :code, :used, message: "Code de connexion déjà utilisé"
   end
@@ -77,7 +77,7 @@ class SessionAuthentication
   def validate_code_not_expired
     return if errors.any?
 
-    return unless last_session_code.expired?
+    return unless session_code.expired?
 
     errors.add :code, :expired, message: "Le code de connexion n'est plus valide, " \
                                          "veuillez en redemander un en cliquant sur le bouton ci-dessous"

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -18,6 +18,10 @@ class SessionCode < ApplicationRecord
     rand((10.pow(LENGTH - 1))...(10.pow(LENGTH))).to_s
   end
 
+  def self.valid_format?(code)
+    /^\d{#{LENGTH}}$/.match? code.to_s.strip
+  end
+
   def expired?
     created_at < Time.zone.now - EXPIRE_AFTER
   end

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -9,6 +9,8 @@ class SessionCode < ApplicationRecord
   scope :used, -> { where.not(used_at: nil) }
   scope :unused, -> { where(used_at: nil) }
   scope :valid, -> { unused.where(created_at: EXPIRE_AFTER.ago..) }
+  scope :expired, -> { where(created_at: ..EXPIRE_AFTER.ago) }
+  scope :outdated, -> { where(created_at: ..1.month.ago) }
 
   before_create :generate_code
 

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
-class SessionCodeGenerationError < StandardError; end
-
 class SessionCode < ApplicationRecord
-  LENGTH = 6
-  FORMAT_REGEX = /^\d{#{LENGTH}}$/
   EXPIRE_AFTER = 60.minutes.freeze
 
   belongs_to :user
 
   def self.generate_random_code
-    code = LENGTH.times.map { rand(0..9) }.join
-    raise SessionCodeGenerationError, code unless code.match(FORMAT_REGEX)
-
-    code
+    length = 6
+    rand(10.pow(length - 1)...10.pow(length)).to_s
   end
 
   def expired?

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -5,6 +5,10 @@ class SessionCode < ApplicationRecord
 
   belongs_to :user
 
+  before_create :generate_code
+
+  delegate :random_code, to: :class
+
   def self.random_code
     length = 6
     rand(10.pow(length - 1)...10.pow(length)).to_s
@@ -19,4 +23,8 @@ class SessionCode < ApplicationRecord
   def used? = used_at.present?
 
   def mark_used! = update!(used_at: Time.zone.now)
+
+  private
+
+  def generate_code = self.code = random_code
 end

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -5,6 +5,7 @@ class SessionCode < ApplicationRecord
   EXPIRE_AFTER = 1.day.freeze
 
   belongs_to :user
+  has_one :commune, through: :user
 
   scope :used, -> { where.not(used_at: nil) }
   scope :unused, -> { where(used_at: nil) }

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -5,7 +5,7 @@ class SessionCode < ApplicationRecord
 
   belongs_to :user
 
-  def self.generate_random_code
+  def self.random_code
     length = 6
     rand(10.pow(length - 1)...10.pow(length)).to_s
   end

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionCode < ApplicationRecord
-  EXPIRE_AFTER = 60.minutes.freeze
+  EXPIRE_AFTER = 1.day.freeze
 
   belongs_to :user
 
@@ -13,6 +13,8 @@ class SessionCode < ApplicationRecord
   def expired?
     created_at < Time.zone.now - EXPIRE_AFTER
   end
+
+  def valid_until = (created_at || Time.zone.now) + EXPIRE_AFTER
 
   def used? = used_at.present?
 

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class SessionCode < ApplicationRecord
+  LENGTH = 6
   EXPIRE_AFTER = 1.day.freeze
 
   belongs_to :user
@@ -14,8 +15,7 @@ class SessionCode < ApplicationRecord
   delegate :random_code, to: :class
 
   def self.random_code
-    length = 6
-    rand(10.pow(length - 1)...10.pow(length)).to_s
+    rand((10.pow(LENGTH - 1))...(10.pow(LENGTH))).to_s
   end
 
   def expired?

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -5,6 +5,10 @@ class SessionCode < ApplicationRecord
 
   belongs_to :user
 
+  scope :used, -> { where.not(used_at: nil) }
+  scope :unused, -> { where(used_at: nil) }
+  scope :valid, -> { unused.where(created_at: EXPIRE_AFTER.ago..) }
+
   before_create :generate_code
 
   delegate :random_code, to: :class

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :commune
 
-  has_one :session_code, -> { valid }, dependent: :destroy
+  has_one :session_code, -> { valid.order(created_at: :desc) }, dependent: :destroy, inverse_of: :user
 
   attr_accessor :impersonating
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :commune
 
-  has_many :session_codes, dependent: :destroy
+  has_one :session_code, -> { valid }, dependent: :destroy
 
   attr_accessor :impersonating
 
@@ -17,6 +17,4 @@ class User < ApplicationRecord
 
   def safe_email? = SAFE_DOMAINS.include?(email.split("@").last)
   def to_s = email.split("@")[0]
-
-  def last_session_code = session_codes.order(created_at: :desc).first
 end

--- a/app/views/admin/session_codes/index.html.haml
+++ b/app/views/admin/session_codes/index.html.haml
@@ -1,0 +1,54 @@
+- title = "Codes de connexion"
+- content_for(:head_title) { title }
+
+%main#contenu.fr-container.fr-pt-2w.fr-pb-4w
+  = render "shared/breadcrumbs", links: [["Admin", admin_path]], current_page_label: title
+  %h1= title
+
+  .fr-grid-row.fr-grid-row--gutters
+    .fr-col-md-4
+      %h2 Statistiques
+      - total = SessionCode.count.to_f
+      .fr-table
+        %table
+          %thead
+            %tr
+              %th
+              %th Nombre
+              %th Pourcentage
+          %tbody
+            %tr
+              %th Codes valides
+              %td.text-end= total_valid = SessionCode.valid.count
+              %td.text-end= "#{(total_valid / total * 100).to_i}&nbsp;%".html_safe
+            %tr
+              %th Codes utilisés
+              %td.text-end= total_used = SessionCode.used.count
+              %td.text-end= "#{(total_used / total * 100).to_i}&nbsp;%".html_safe
+            %tr
+              %th Codes expirés
+              %td.text-end= total_expired = SessionCode.expired.count
+              %td.text-end= "#{(total_expired / total * 100).to_i}&nbsp;%".html_safe
+            %tr
+              %th Total des codes
+              %td.text-end= total.to_i
+              %td.text-end 100 %
+    .fr-col-md-8
+      %h2 Derniers codes générés
+      .fr-table
+        %table
+          %thead
+            %tr
+              %th Commune
+              %th Email
+              %th Code
+              %th Utilisé&nbsp;?
+              %th Valide jusqu'au
+          %tbody
+            - SessionCode.last(10).each do |session_code|
+              %tr
+                %th= link_to session_code.commune.nom, admin_commune_path(session_code.commune)
+                %td= session_code.user.email
+                %td.text-center= session_code.code
+                %td.text-center= session_code.used? ? "Oui" : "Non"
+                %td.text-end= l session_code.valid_until, format: :long

--- a/app/views/pages/admin.html.haml
+++ b/app/views/pages/admin.html.haml
@@ -24,4 +24,5 @@
           - else
             %li= link_to "Prévisualisation des emails", mail_previews_path
           %li= link_to "Suivi des tâches asynchrones (GoodJob)", "/good_job"
+          %li= link_to "Codes de connexion", admin_session_codes_path
           %li= link_to "Exports pour POP", admin_exports_path

--- a/app/views/user_mailer/session_code_email.mjml
+++ b/app/views/user_mailer/session_code_email.mjml
@@ -7,7 +7,7 @@
       <%= @session_code.code %>
     </mj-text>
     <mj-text>
-      <%= I18n.t("user_mailer.session_code.one_hour") %>
+      <%= I18n.t("user_mailer.session_code.valid_until", date: l(@session_code.valid_until, format: :long)) %>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/app/views/user_mailer/session_code_email.text.erb
+++ b/app/views/user_mailer/session_code_email.text.erb
@@ -2,4 +2,4 @@
 
 <%= @session_code.code %>
 
-<%= I18n.t("user_mailer.session_code.one_hour") %>
+<%= I18n.t("user_mailer.session_code.valid_until", date: l(@session_code.valid_until, format: :long)) %>

--- a/app/views/users/session_codes/new.html.haml
+++ b/app/views/users/session_codes/new.html.haml
@@ -65,7 +65,8 @@
                 = f.submit "Recevoir un code de connexion"
                 = link_to "Saisir mon code de connexion",
                   new_user_session_path(email: @commune_user.email),
-                  class: "fr-btn fr-btn--tertiary"
+                  class: "fr-btn fr-btn--tertiary",
+                  data: { turbo_frame: "_top" }
 
         .fr-mt-6w
           = render "users/sessions/faq"

--- a/app/views/users/session_codes/new.html.haml
+++ b/app/views/users/session_codes/new.html.haml
@@ -59,14 +59,13 @@
             = form_with(url: user_session_codes_path, builder: FormBuilderDsfr, data: { turbo_frame: "_top" }) do |f|
               = f.hidden_field :email, value: @commune_user.email
               = dsfr_alert type: :info, size: :sm do
-                L’email auquel sera envoyé le code de connexion est
+                Le code de connexion sera envoyé par email à
                 %b= @commune_user.email
               .fr-btns-group.fr-mt-4w
                 = f.submit "Recevoir un code de connexion"
                 = link_to "Saisir mon code de connexion",
                   new_user_session_path(email: @commune_user.email),
-                  class: "fr-btn fr-btn--tertiary",
-                  data: { turbo_action: "advance" }
+                  class: "fr-btn fr-btn--tertiary"
 
         .fr-mt-6w
           = render "users/sessions/faq"

--- a/app/views/users/session_codes/new.html.haml
+++ b/app/views/users/session_codes/new.html.haml
@@ -26,6 +26,7 @@
               {include_blank: "Sélectionnez un département"},
               required: true,
               autocomplete: "off",
+              autofocus: @departement.nil?,
               disabled: @departement.present?,
               data: { action: "user-session-form#submitCommuneForm",
                 user_session_form_target: "departementSelect" })
@@ -44,6 +45,7 @@
               {include_blank: true},
               required: true,
               autocomplete: "off",
+              autofocus: @departement.present?,
               disabled: @departement.blank?,
               data: { action: "user-session-form#submitCommuneForm" })
 

--- a/app/views/users/session_codes/new.html.haml
+++ b/app/views/users/session_codes/new.html.haml
@@ -63,6 +63,10 @@
                 %b= @commune_user.email
               .fr-btns-group.fr-mt-4w
                 = f.submit "Recevoir un code de connexion"
+                = link_to "Saisir mon code de connexion",
+                  new_user_session_path(email: @commune_user.email),
+                  class: "fr-btn fr-btn--tertiary",
+                  data: { turbo_action: "advance" }
 
         .fr-mt-6w
           = render "users/sessions/faq"

--- a/app/views/users/sessions/_faq.html.haml
+++ b/app/views/users/sessions/_faq.html.haml
@@ -37,5 +37,5 @@
         Les comptes des mairies ont été créés en utilisant les données publiées sur l'annuaire du service public.
         %br
         Si cet email est erroné ou que vous n'y avez pas accès, retrouvez la mairie de votre commune sur
-        = link_to "l’annuaire du service public", url_annuaire, target: :_blank, rel: :noopener
+        = link_to "l’annuaire du service public", url, target: :_blank, rel: :noopener
         puis cliquez sur "Mettre cette page à jour".

--- a/app/views/users/sessions/_faq.html.haml
+++ b/app/views/users/sessions/_faq.html.haml
@@ -34,7 +34,7 @@
           Mauvais email / Je n'y ai pas accès
       #faq-mauvais-email.fr-collapse
         - url = @commune ? "https://www.service-public.fr/particuliers/recherche?keyword=mairie+#{@commune.nom}+#{@commune.departement.nom}" : url_annuaire
-        = "Les comptes des mairies ont été créés en utilisant les données publiées sur #{link_to "service-public.fr", url_annuaire, target: :_blank, rel: :noopener}."
+        Les comptes des mairies ont été créés en utilisant les données publiées sur l'annuaire du service public.
         %br
         Si cet email est erroné ou que vous n'y avez pas accès, retrouvez la mairie de votre commune sur
         = link_to "l’annuaire du service public", url_annuaire, target: :_blank, rel: :noopener

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -25,7 +25,7 @@
               = @error
         .fr-input-group.fr-btns-group
           = f.submit "Connexion"
-          = link_to "Redemander un code de connexion …",
+          = link_to "Demander un nouveau code de connexion",
             new_user_session_code_path(code_insee: @commune.code_insee),
             type: "button",
             class: "fr-btn fr-btn--tertiary",

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -6,7 +6,7 @@
     .fr-col-md-5
       %h1.fr-h2 Connexion à Collectif Objets
       %h2.fr-h3 Rentrez le code de connexion pour #{@commune.nom}
-      - if @user.last_session_code.present?
+      - if @user.session_code.present?
         .fr-mb-2w
           Le code de connexion a été envoyé à #{@user.email}
       = form_with(url: user_session_path, builder: FormBuilderDsfr, data: { turbo_frame: "_top" }) do |f|

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -17,6 +17,7 @@
             value: params[:code],
             required: true,
             autocomplete: "off",
+            autofocus: true,
             class: ("fr-input--error" if @error),
             **(@error ? { aria: { describedby: "error-message" } }  : {})
           - if @error

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -27,9 +27,7 @@
           = f.submit "Connexion"
           = link_to "Demander un nouveau code de connexion",
             new_user_session_code_path(code_insee: @commune.code_insee),
-            type: "button",
-            class: "fr-btn fr-btn--tertiary",
-            data: { turbo_action: "advance" }
+            class: "fr-btn fr-btn--tertiary"
 
       .fr-mt-10w
         = render "users/sessions/faq"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -661,7 +661,7 @@ fr:
     session_code:
       lien: "Voici votre code de connexion à Collectif Objets :"
       cta: Connexion
-      one_hour: Ce code est valide une heure.
+      valid_until: "Ce code est valide jusqu'à %{date}."
     message_received:
       bonjour: Bonjour %{nom_commune},
       from_conservateur: "%{author}, conservateur de votre département, vous a envoyé un message sur Collectif Objets le %{date} :"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
         post :toggle_impersonate_mode
       end
     end
+    get :session_codes, to: "session_codes#index", as: :session_codes
     resources :campaigns do
       get :edit_recipients
       patch :update_recipients

--- a/spec/models/session_authentication_spec.rb
+++ b/spec/models/session_authentication_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SessionAuthentication do
   let!(:session_code) { instance_double(SessionCode, code: "123456", expired?: expired, used?: used) }
   let(:expired) { false }
   let(:used) { false }
-  before { allow(user).to receive(:last_session_code).and_return(session_code) }
+  before { allow(user).to receive(:session_code).and_return(session_code) }
 
   subject { session_authentication.authenticate }
 

--- a/spec/models/session_code_spec.rb
+++ b/spec/models/session_code_spec.rb
@@ -10,6 +10,18 @@ describe SessionCode, type: :service do
     end
   end
 
+  describe ".valid_format?" do
+    subject { SessionCode.valid_format?(code) }
+    context "when code is valid" do
+      let(:code) { SessionCode.random_code }
+      it { should eq true }
+    end
+    context "when code is invalid" do
+      let(:code) { "abcd" }
+      it { should eq false }
+    end
+  end
+
   describe "#expired?" do
     let(:session_code) { build(:session_code, created_at:) }
     subject { session_code.expired? }

--- a/spec/models/session_code_spec.rb
+++ b/spec/models/session_code_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 describe SessionCode, type: :service do
-  describe "#generate_session_code" do
+  describe ".random_code" do
     it "should generate a 6-digit code" do
-      code = SessionCode.generate_random_code
+      code = SessionCode.random_code
       expect(code).to match(/^\d{6}$/)
     end
   end

--- a/spec/models/session_code_spec.rb
+++ b/spec/models/session_code_spec.rb
@@ -17,8 +17,8 @@ describe SessionCode, type: :service do
       let(:created_at) { 3.minutes.ago }
       it { should eq false }
     end
-    context "sent 3 hours ago" do
-      let(:created_at) { 3.hours.ago }
+    context "sent 3 days ago" do
+      let(:created_at) { 3.days.ago }
       it { should eq true }
     end
   end


### PR DESCRIPTION
- [x] Ajouter l'autofocus sur les champs de saisie
- [x] Supprimer le lien en double vers service public
- [x] Ajuster le texte du lien pour redemander un code de connexion
- [x] Ajouter un lien vers la page de saisie du code de connexion
- [x] Allonger la durée de validité des codes de connexion
- [x] Renvoyer le code actif s'il en existe un.
- [x] Afficher la date et heure de fin de validité du code plutôt que sa durée, pour éviter de devoir calculer.