### PR TITLE
Migration des photos Mémoire vers OVH

### DIFF
--- a/app/jobs/synchronizer/photos/synchronize_all_job.rb
+++ b/app/jobs/synchronizer/photos/synchronize_all_job.rb
@@ -3,8 +3,6 @@
 module Synchronizer
   module Photos
     class SynchronizeAllJob < ApplicationJob
-      MEMOIRE_PHOTOS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"
-
       def perform(params = {})
         @limit = params.with_indifferent_access[:limit]
         @dry_run = params.with_indifferent_access[:dry_run]

--- a/app/presenters/photo_presenter.rb
+++ b/app/presenters/photo_presenter.rb
@@ -6,7 +6,7 @@ class PhotoPresenter
   attr_accessor :lightbox_path_params, :lightbox_path
 
   def initialize(url:, description: nil, credit: nil, thumb_url: nil, download_url: nil, id: nil)
-    @url = rewrite_photo_url(url)
+    @url = url
     @thumb_url = thumb_url || url
     @description = description
     @download_url = download_url || url
@@ -28,15 +28,11 @@ class PhotoPresenter
 
   def self.from_palissy_photo(palissy_photo, index)
     new(
-      url: palissy_photo["url"],
+      url: palissy_photo["url"].sub(MEMOIRE_PHOTOS_AWS_BASE_URL, MEMOIRE_PHOTOS_BASE_URL),
       description: palissy_photo["name"],
       credit: palissy_photo["credit"],
       id: index
     )
-  end
-
-  def rewrite_photo_url(url)
-    url.sub(MEMOIRE_PHOTOS_AWS_BASE_URL, MEMOIRE_PHOTOS_BASE_URL)
   end
 
   def alt = [description, credit].map(&:presence).compact.join(" - ")

--- a/app/presenters/photo_presenter.rb
+++ b/app/presenters/photo_presenter.rb
@@ -6,7 +6,7 @@ class PhotoPresenter
   attr_accessor :lightbox_path_params, :lightbox_path
 
   def initialize(url:, description: nil, credit: nil, thumb_url: nil, download_url: nil, id: nil)
-    @url = url
+    @url = rewrite_photo_url(url)
     @thumb_url = thumb_url || url
     @description = description
     @download_url = download_url || url
@@ -33,6 +33,10 @@ class PhotoPresenter
       credit: palissy_photo["credit"],
       id: index
     )
+  end
+
+  def rewrite_photo_url(url)
+    url.sub(MEMOIRE_PHOTOS_AWS_BASE_URL, MEMOIRE_PHOTOS_BASE_URL)
   end
 
   def alt = [description, credit].map(&:presence).compact.join(" - ")

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -19,6 +19,7 @@ Rails.application.configure do
       *s3_uris1,
       *s3_uris2,
       "https://s3.eu-west-3.amazonaws.com/pop-phototeque/",
+      "https://pop-perf-assets.s3.gra.io.cloud.ovh.net/",
       "https://collectif-objets.beta.gouv.fr/", # for mail previews
       "https://stats.beta.gouv.fr"
 

--- a/config/initializers/memoire_db.rb
+++ b/config/initializers/memoire_db.rb
@@ -1,0 +1,3 @@
+# Photos from the Memoire database were previously hosted on AWS
+MEMOIRE_PHOTOS_AWS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"
+MEMOIRE_PHOTOS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"

--- a/config/initializers/memoire_db.rb
+++ b/config/initializers/memoire_db.rb
@@ -1,3 +1,3 @@
 # Photos from the Memoire database were previously hosted on AWS
 MEMOIRE_PHOTOS_AWS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"
-MEMOIRE_PHOTOS_BASE_URL = "https://s3.eu-west-3.amazonaws.com/pop-phototeque"
+MEMOIRE_PHOTOS_BASE_URL = "https://pop-perf-assets.s3.gra.io.cloud.ovh.net"

--- a/db/migrate/20240624161724_replace_palissy_photos_url.rb
+++ b/db/migrate/20240624161724_replace_palissy_photos_url.rb
@@ -1,0 +1,23 @@
+class ReplacePalissyPhotosUrl < ActiveRecord::Migration[7.1]
+  def up
+    ReplacePalissyPhotosUrl.replace_palissy_photos_url(MEMOIRE_PHOTOS_AWS_BASE_URL, MEMOIRE_PHOTOS_BASE_URL)
+  end
+
+  def down
+    ReplacePalissyPhotosUrl.replace_palissy_photos_url(MEMOIRE_PHOTOS_BASE_URL, MEMOIRE_PHOTOS_AWS_BASE_URL)
+  end
+
+  private
+    def self.replace_palissy_photos_url(from_base_url, to_base_url)
+      progress_bar = ProgressBar.create(title: "Avancement de la migration", total: Objet.count, format: "%t: |%W|")
+      Objet.find_each do |objet|
+        progress_bar.increment
+        next if objet.palissy_photos.empty?
+
+        objet.palissy_photos.each do |palissy_photo|
+          palissy_photo["url"] = palissy_photo["url"].sub(from_base_url, to_base_url)
+        end
+        objet.save
+      end
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_123719) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_161724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"


### PR DESCRIPTION
Les photos importées de la base Mémoire vont migrer d'AWS vers OVH.

Actuellement nous stockons l'URL complète de la photo dans le champ JSON `palissy_photos` de la table `objets`, comme par exemple : https://s3.eu-west-3.amazonaws.com/pop-phototeque/memoire/OA052_065200001/OA052_065200001.jpg

Suite à la migration, seule la racine `s3.eu-west-3.amazonaws.com` va changer.

Plusieurs options possibles pour s'adapter côté Collectif Objets : 
- Remplacer la racine à la volée au moment de l'affichage de la photo
  - Avantage : simple à faire, pas de migration de la base
  - Inconvénient : laisse des URLs avec la racine AWS en base
- Migrer la base avec les nouvelles URLs
  - Avantage : base de données cohérente
  - Inconvénient : migration lente (on remplace des données dans un champ JSON)
- Migrer la base en ne laissant que le chemin relatif de la photo. L'URL est reconstituée à l'affichage avec la nouvelle racine
  - Avantage : la base ne dépend plus de la racine de l'URL, qui pourra encore changer
  - Inconvénient : migration lente, nom de variable "url" devient incohérent (plutôt à renommer en relative_path)
  
  Nous avons choisi les options 1 et 2 ensemble, de manière à assurer une transition sans downtime.