### PR TITLE
Configuration CORS en staging

### DIFF
--- a/scripts/s3buckets/cors-staging.json
+++ b/scripts/s3buckets/cors-staging.json
@@ -4,7 +4,7 @@
       "AllowedOrigins": [
         "https://staging.collectif-objets.incubateur.net",
         "https://staging.collectifobjets.org",
-        "https://collectif-objets-staging-pr701.osc-fr1.scalingo.io"
+        "https://collectif-objets-staging.osc-fr1.scalingo.io"
       ],
       "AllowedHeaders": [
         "*"


### PR DESCRIPTION
La configuration CORS ne prenait pas en compte l'URL de staging fournie par Scalingo, c'est désormais le cas.

À noter que l'URL https://staging.collectifobjets.org devra être retirée le jour où ce domaine n'est plus utilisé.