### PR TITLE
Utilisation d'une association entre Objet et Recensement

### DIFF
--- a/app/controllers/communes/completions_controller.rb
+++ b/app/controllers/communes/completions_controller.rb
@@ -31,7 +31,7 @@ module Communes
 
     def set_objets
       @objets = @dossier.objets
-        .includes(:commune, recensements: %i[photos_attachments photos_blobs])
+        .includes(:commune, recensement: %i[photos_attachments photos_blobs])
     end
 
     def set_missing_photos

--- a/app/controllers/conservateurs/communes_controller.rb
+++ b/app/controllers/conservateurs/communes_controller.rb
@@ -8,10 +8,7 @@ module Conservateurs
     def show
       return show_analyse_saved if params[:analyse_saved].present?
 
-      @edifices = Edifice.where(code_insee: @commune.code_insee)
-        .with_objets
-        .ordered_by_nom
-        .includes(objets: { recensements: { photos_attachments: :blob } })
+      @edifices = Edifice.where(code_insee: @commune.code_insee).preloaded
     end
 
     def autocomplete
@@ -26,7 +23,7 @@ module Conservateurs
     def show_analyse_saved
       @objets = @commune
         .objets
-        .includes(:edifice, recensements: %i[photos_attachments photos_blobs])
+        .includes(:edifice, recensement: %i[photos_attachments photos_blobs])
         .a_examiner
         .order_by_recensement_priorite
       render "show_analyse_saved"

--- a/app/jobs/synchronizer/objets/revision/destroy_concern.rb
+++ b/app/jobs/synchronizer/objets/revision/destroy_concern.rb
@@ -32,7 +32,7 @@ module Synchronizer
         end
 
         def existing_recensement
-          @existing_recensement ||= persisted_objet.recensements.first
+          @existing_recensement ||= persisted_objet.recensement
         end
 
         def log_message

--- a/app/jobs/synchronizer/objets/revision/update_concern.rb
+++ b/app/jobs/synchronizer/objets/revision/update_concern.rb
@@ -49,7 +49,7 @@ module Synchronizer
         end
 
         def existing_recensement
-          @existing_recensement ||= persisted_objet.recensements.first
+          @existing_recensement ||= persisted_objet.recensement
         end
 
         def commune_after_update = @eager_loaded_records.commune

--- a/app/lib/co/communes/objets_list.rb
+++ b/app/lib/co/communes/objets_list.rb
@@ -19,7 +19,7 @@ module Co
         @edifices ||= commune
           .edifices
           .with_objets
-          .includes(objets: { recensements: %i[photos_attachments photos_blobs] })
+          .includes(objets: { recensement: %i[photos_attachments photos_blobs] })
           .ordered_by_nom
       end
 
@@ -27,7 +27,7 @@ module Co
         @objets ||= begin
           objets = scoped_objets
             .where(commune: @commune)
-            .includes(:commune, recensements: %i[photos_attachments photos_blobs])
+            .includes(:commune, recensement: %i[photos_attachments photos_blobs])
           objets = objets.without_completed_recensements if @exclude_recensed
           objets = objets.where.not(id: @exclude_ids) if @exclude_ids.any?
           objets = objets.where(edifice: @edifice) if @edifice.present?

--- a/app/models/edifice.rb
+++ b/app/models/edifice.rb
@@ -20,7 +20,7 @@ class Edifice < ApplicationRecord
 
   scope :preloaded, lambda {
     with_objets.ordered_by_nom.includes(
-      objets: [:commune, :recensements, { recensements: [:photos_attachments, :photos_blobs] }]
+      objets: [:commune, { recensement: [:photos_attachments, :photos_blobs] }]
     )
   }
 

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -9,12 +9,17 @@ class Objet < ApplicationRecord
   belongs_to :edifice, optional: true
   has_many :recensements, dependent: :restrict_with_exception
 
+  has_one :recensement, -> {
+    left_outer_joins(objet: { commune: :dossier })
+    .where("recensements.dossier_id = dossiers.id OR recensements.status = 'draft'")
+  }, dependent: :nullify, inverse_of: :objet
+
   accepts_nested_attributes_for :edifice
 
   scope :order_by_recensement_priorite, lambda {
     left_outer_joins(commune: :dossier)
-    .left_outer_joins(:recensements)
-    .where("recensements.dossier_id = dossiers.id")
+    .joins("LEFT JOIN recensements ON recensements.objet_id = objets.id AND recensements.deleted_at IS NULL \
+              AND (recensements.dossier_id = dossiers.id OR recensements.status = 'draft')")
     .order(Arel.sql(Recensement::SQL_ORDER_PRIORITE))
     .order("recensements.analysed_at DESC")
   }
@@ -71,10 +76,6 @@ class Objet < ApplicationRecord
 
   def nom_with_ref_pop
     truncate("#{palissy_REF} #{nom}", length: 40)
-  end
-
-  def recensement
-    Recensement.where(objet: self).and(Recensement.where(dossier: commune.dossier).or(Recensement.draft)).first
   end
 
   def recensement? = recensement.present?

--- a/app/views/conservateurs/communes/show.html.haml
+++ b/app/views/conservateurs/communes/show.html.haml
@@ -27,7 +27,7 @@
 
 
   = render "edifices/list", edifices: @edifices
-  - @edifices.each_with_index do |edifice, index|
+  - @edifices.each do |edifice|
     = render "edifices/title", edifice:
     = render layout: "shared/grid_layout" do
       - reordered = @dossier ? edifice.objets.order_by_recensement_priorite : edifice.objets

--- a/spec/jobs/synchronizer/objets/revision/base_spec.rb
+++ b/spec/jobs/synchronizer/objets/revision/base_spec.rb
@@ -310,9 +310,9 @@ RSpec.describe Synchronizer::Objets::Revision::Base do
     end
 
     context "changement de commune + objet déjà recensé" do
-      let!(:commune_before_update) { create(:commune, code_insee: "01004", status: :started) }
-      let!(:recensement) { create(:recensement, objet: persisted_objet) }
-      let!(:commune_after_update) { create(:commune, code_insee: "01999", status: :inactive) }
+      let!(:commune_before_update) { create(:commune_en_cours_de_recensement, code_insee: "01004") }
+      let!(:recensement) { create(:recensement, objet: persisted_objet, dossier: commune_before_update.dossier) }
+      let!(:commune_after_update) { create(:commune_en_cours_de_recensement, code_insee: "01999") }
       before do
         objet_attributes.merge!(
           palissy_INSEE: "01999",

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Objet, type: :model do
   end
 
   it ".order_by_recensement_priorite" do
-    commune = create(:commune_en_cours_de_recensement)
+    commune = create(:commune, :en_cours_de_recensement)
     dossier = commune.dossier
     objet_recensé_vert = create(:objet, commune:)
     create(:recensement, objet: objet_recensé_vert, dossier:)


### PR DESCRIPTION
Actuellement on récupère le recensement en cours d'un objet via une méthode `def recensement [...] end`.

On va privilégier une association `has_one :recensement`, de manière à être plus proche des standards Rails et pouvoir bénéficier du `includes(:recensement)` pour éviter certaines requêtes N+1. 
NB : l'includes ne fonctionne pas pour la page `conservateur/communes/:id/`, ce qui est fort dommage. Peut-être parce qu'on passe l'objet à un `ObjetCardComponent`.