### PR TITLE
Corrige les recensements orphelins

### DIFF
--- a/app/controllers/communes/recensements_controller.rb
+++ b/app/controllers/communes/recensements_controller.rb
@@ -13,7 +13,10 @@ module Communes
     end
 
     def create
-      @recensement = Recensement.new(objet: @objet)
+      commune = Commune.find(params[:commune_id])
+      commune.start! if commune.inactive?
+
+      @recensement = Recensement.new(objet: @objet, dossier: commune.dossier)
       authorize(@recensement)
       if @recensement.save
         redirect_to edit_commune_objet_recensement_path(@recensement.commune, @objet, @recensement, step: 1)

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -20,8 +20,7 @@ class Commune < ApplicationRecord
     event :return_to_started, after: :aasm_after_return_to_started do
       transitions from: :completed, to: :started
     end
-
-    event :return_to_inactive do
+    event :return_to_inactive, after: :aasm_after_return_to_inactive do
       transitions from: :completed, to: :inactive
     end
   end
@@ -208,7 +207,7 @@ class Commune < ApplicationRecord
   end
 
   def aasm_before_start
-    raise AASM::InvalidTransition if dossier.present?
+    raise AASM::InvalidTransition, "Commune cannot start if it has a dossier" if dossier.present?
 
     create_dossier!
   end
@@ -218,7 +217,8 @@ class Commune < ApplicationRecord
   end
 
   def aasm_after_return_to_started
-    dossier.return_to_construction! unless dossier.construction?
+    dossier.archive!
+    create_dossier!
   end
 
   def completed_at

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -20,7 +20,7 @@ class Commune < ApplicationRecord
     event :return_to_started, after: :aasm_after_return_to_started do
       transitions from: :completed, to: :started
     end
-    event :return_to_inactive, after: :aasm_after_return_to_inactive do
+    event :return_to_inactive do
       transitions from: :completed, to: :inactive
     end
   end
@@ -217,8 +217,7 @@ class Commune < ApplicationRecord
   end
 
   def aasm_after_return_to_started
-    dossier.archive!
-    create_dossier!
+    dossier.return_to_construction! unless dossier.construction?
   end
 
   def completed_at

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -34,7 +34,7 @@ class Dossier < ApplicationRecord
 
   validates :conservateur, presence: true, if: :accepted?
   validates :visit, inclusion: { in: %w[souhaitable prioritaire] }, allow_nil: true
-  validates :commune_id, uniqueness: { conditions: -> { where.not(status: "archived") } }
+  validates :commune_id, uniqueness: true, unless: :archived?
 
   delegate :departement, to: :commune
 

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -74,7 +74,7 @@ class Objet < ApplicationRecord
   end
 
   def recensement
-    Recensement.where(objet: self).and(Recensement.where(dossier: commune.dossier).or(Recensement.draft)).first
+    Recensement.find_by(objet: self, dossier: commune.dossier)
   end
 
   def recensement? = recensement.present?

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -15,10 +15,10 @@ class Recensement < ApplicationRecord
     attachable.variant :medium, resize_to_limit: [800, 800], saver: { strip: true }
   end
 
-  delegate :commune, to: :dossier
-  delegate :departement, to: :dossier
 
   before_validation :set_dossier
+  delegate :commune, to: :objet, allow_nil: true
+  delegate :departement, to: :objet, allow_nil: true
 
   include AASM
   aasm column: :status, whiny_persistence: true, timestamps: true do

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -26,7 +26,7 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, before: :ensure_completable do
+    event :complete, before: :ensure_completable, after_commit: :notify_on_mattermost do
       transitions from: :draft, to: :completed
     end
     event :soft_delete, before_transaction: :aasm_before_soft_delete_transaction do
@@ -127,7 +127,7 @@ class Recensement < ApplicationRecord
   end
   ## fin du code qui semble mort
 
-  def aasm_after_commit_complete
+  def notify_on_mattermost
     SendMattermostNotificationJob.perform_later("recensement_created", { "recensement_id" => id })
   end
 

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -15,8 +15,6 @@ class Recensement < ApplicationRecord
     attachable.variant :medium, resize_to_limit: [800, 800], saver: { strip: true }
   end
 
-
-  before_validation :set_dossier
   delegate :commune, to: :objet, allow_nil: true
   delegate :departement, to: :objet, allow_nil: true
 
@@ -173,11 +171,6 @@ class Recensement < ApplicationRecord
   end
 
   private
-
-  def set_dossier
-    commune.start! if commune.inactive?
-    self.dossier = commune.dossier
-  end
 
   def aasm_before_soft_delete_transaction(reason:, message: nil, objet_snapshot: nil)
     assign_attributes \

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -5,7 +5,7 @@ class Recensement < ApplicationRecord
   include Recensements::BooleansConcern
 
   belongs_to :objet, optional: true
-  belongs_to :dossier, optional: true
+  belongs_to :dossier
   belongs_to :pop_export_memoire, class_name: "PopExport", inverse_of: :recensements_memoire, optional: true
   belongs_to :pop_export_palissy, class_name: "PopExport", inverse_of: :recensements_palissy, optional: true
   # À terme, avoir une association de ce genre :
@@ -15,8 +15,10 @@ class Recensement < ApplicationRecord
     attachable.variant :medium, resize_to_limit: [800, 800], saver: { strip: true }
   end
 
-  delegate :commune, to: :objet, allow_nil: true
-  delegate :departement, to: :objet, allow_nil: true
+  delegate :commune, to: :dossier
+  delegate :departement, to: :dossier
+
+  before_validation :set_dossier
 
   include AASM
   aasm column: :status, whiny_persistence: true, timestamps: true do
@@ -24,8 +26,7 @@ class Recensement < ApplicationRecord
     state :completed, display: "Complet et validé"
     state :deleted, display: "Archivé"
 
-    event :complete, before: :ensure_completable, after: :aasm_after_complete,
-                     after_commit: :aasm_after_commit_complete do
+    event :complete, before: :ensure_completable do
       transitions from: :draft, to: :completed
     end
     event :soft_delete, before_transaction: :aasm_before_soft_delete_transaction do
@@ -126,16 +127,6 @@ class Recensement < ApplicationRecord
   end
   ## fin du code qui semble mort
 
-  def aasm_after_complete
-    commune.start! if commune.inactive?
-
-    if !commune.dossier&.persisted? || !commune.dossier&.valid?
-      raise ActiveRecord::RecordInvalid, "cannot complete recensement before dossier is created"
-    end
-
-    update(dossier: commune.dossier)
-  end
-
   def aasm_after_commit_complete
     SendMattermostNotificationJob.perform_later("recensement_created", { "recensement_id" => id })
   end
@@ -182,6 +173,11 @@ class Recensement < ApplicationRecord
   end
 
   private
+
+  def set_dossier
+    commune.start! if commune.inactive?
+    self.dossier = commune.dossier
+  end
 
   def aasm_before_soft_delete_transaction(reason:, message: nil, objet_snapshot: nil)
     assign_attributes \

--- a/app/policies/communes/recensement_policy.rb
+++ b/app/policies/communes/recensement_policy.rb
@@ -4,7 +4,7 @@ module Communes
   class RecensementPolicy < BasePolicy
     def new?
       user_commune? &&
-        (objet.recensement.nil? || objet.recensement.new_record?) &&
+        objet.recensement.nil? &&
         commune_can_edit?
     end
 

--- a/db/migrate/20240710131820_link_draft_recensements_with_dossier.rb
+++ b/db/migrate/20240710131820_link_draft_recensements_with_dossier.rb
@@ -1,0 +1,10 @@
+class LinkDraftRecensementsWithDossier < ActiveRecord::Migration[7.1]
+  # Les recensements en brouillon doivent désormais être associés à un dossier, que l'on crée s'il n'existe pas
+  def up
+    Recensement.draft.where(dossier: nil).find_each do |recensement|
+      commune = recensement.objet.commune
+      commune.start! if commune.inactive?
+      recensement.update(dossier: commune.dossier)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_081527) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_10_131820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"

--- a/spec/factories/commune.rb
+++ b/spec/factories/commune.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
 
     trait :examinée do
       status { "completed" }
-      dossier { association(:dossier_examiné, :submitted, commune: instance) }
+      dossier { association(:dossier_examiné, commune: instance) }
     end
 
     factory :commune_with_user, traits: [:with_user]

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -27,10 +27,9 @@ FactoryBot.define do
     end
 
     trait :archived do
-      accepted
       conservateur
       archived_at { 1.day.ago }
-      status { :archived }
+      status { "archived" }
     end
 
     factory :dossier_en_cours_dexamen, traits: [:submitted, :with_recensement_examiné]

--- a/spec/models/campaign_recipient_spec.rb
+++ b/spec/models/campaign_recipient_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CampaignRecipient, type: :model do
 
     context "seconde relance pour une commune ayant recensé il y a plus de 5 jours" do
       let(:step) { "relance2" }
-      let!(:commune) { create(:commune_with_user, status: "started") }
+      let!(:commune) { create(:commune, :with_user, :en_cours_de_recensement) }
       let!(:campaign) { create(:campaign) }
       let!(:objet) { create(:objet, commune:) }
       let!(:recensement) do

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Objet, type: :model do
     create(:recensement, :en_peril, objet: objet_recensé_prioritaire, dossier:)
     objet_examiné = create(:objet, commune:)
     create(:recensement_examiné, objet: objet_examiné, dossier:)
-    dossier_archivé = create(:dossier, :archived)
+    dossier_archivé = create(:dossier, :archived, commune:)
     create(:recensement_examiné, objet: objet_examiné, dossier: dossier_archivé)
 
     objets_ordered_by_priorite = Objet.order_by_recensement_priorite

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe Objet, type: :model do
   end
 
   it ".order_by_recensement_priorite" do
-    dossier = create(:dossier)
-    commune = dossier.commune
+    commune = create(:commune_en_cours_de_recensement)
+    dossier = commune.dossier
     objet_recensé_vert = create(:objet, commune:)
     create(:recensement, objet: objet_recensé_vert, dossier:)
     objet_recensé_prioritaire = create(:objet, commune:)
@@ -110,12 +110,12 @@ RSpec.describe Objet, type: :model do
   end
 
   it ".without_completed_recensements" do
-    dossier = create(:dossier)
-    create(:objet, commune: dossier.commune)
-    objet_recensé_brouillon = create(:objet, commune: dossier.commune)
+    commune = create(:commune, :en_cours_de_recensement)
+    dossier = commune.dossier
+    create(:objet, commune:)
+    objet_recensé_brouillon = create(:objet, commune:)
     create(:recensement, status: :draft, objet: objet_recensé_brouillon, dossier:)
-    create(:recensement, :supprimé, dossier:)
-    objet_recensé = create(:objet, commune: dossier.commune)
+    objet_recensé = create(:objet, commune:)
     create(:recensement, objet: objet_recensé, dossier:)
 
     expect(Objet.without_completed_recensements.count).to eq 2

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -92,13 +92,14 @@ RSpec.describe Objet, type: :model do
 
   it ".order_by_recensement_priorite" do
     dossier = create(:dossier)
-    objet_recensé_vert = create(:objet, commune: dossier.commune)
+    commune = dossier.commune
+    objet_recensé_vert = create(:objet, commune:)
     create(:recensement, objet: objet_recensé_vert, dossier:)
-    objet_recensé_prioritaire = create(:objet, commune: dossier.commune)
+    objet_recensé_prioritaire = create(:objet, commune:)
     create(:recensement, :en_peril, objet: objet_recensé_prioritaire, dossier:)
-    objet_examiné = create(:objet, commune: dossier.commune)
+    objet_examiné = create(:objet, commune:)
     create(:recensement_examiné, objet: objet_examiné, dossier:)
-    dossier_archivé = create(:dossier, :archived)
+    dossier_archivé = create(:dossier, :archived, commune:)
     create(:recensement_examiné, objet: objet_examiné, dossier: dossier_archivé)
 
     objets_ordered_by_priorite = Objet.order_by_recensement_priorite

--- a/spec/models/objet_spec.rb
+++ b/spec/models/objet_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Objet, type: :model do
     create(:recensement, :en_peril, objet: objet_recensé_prioritaire, dossier:)
     objet_examiné = create(:objet, commune:)
     create(:recensement_examiné, objet: objet_examiné, dossier:)
-    dossier_archivé = create(:dossier, :archived, commune:)
+    dossier_archivé = create(:dossier, :archived)
     create(:recensement_examiné, objet: objet_examiné, dossier: dossier_archivé)
 
     objets_ordered_by_priorite = Objet.order_by_recensement_priorite

--- a/spec/models/recensement_spec.rb
+++ b/spec/models/recensement_spec.rb
@@ -237,11 +237,9 @@ RSpec.describe Recensement, type: :model do
     end
 
     context "pour une commune started" do
-      let!(:commune) { create(:commune, status: "started") }
-      let!(:dossier) { create(:dossier, status: "construction", commune:) }
-      before { commune.update!(dossier:) }
+      let!(:commune) { create(:commune, :en_cours_de_recensement) }
       let!(:objet) { create(:objet, commune:) }
-      let(:recensement) { create(:recensement, objet:, status: "draft", dossier: nil) }
+      let(:recensement) { create(:recensement, objet:, status: "draft", dossier: commune.dossier) }
       it "change le statut du recensement et réutilise le dossier existant" do
         expect(SendMattermostNotificationJob).to \
           receive(:perform_later).with("recensement_created", { "recensement_id" => an_instance_of(Integer) })

--- a/spec/policies/communes/recensement_policy_spec.rb
+++ b/spec/policies/communes/recensement_policy_spec.rb
@@ -9,15 +9,15 @@ describe Communes::RecensementPolicy do
     context "objet n'a pas de recensement + commune inactive" do
       let(:commune) { build(:commune, status: :inactive) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune:) }
       it { should permit(user, recensement) }
     end
 
     context "objet n'a pas de recensement + commune inactive MAIS autre commune" do
-      let(:commune) { build(:commune, status: :inactive) }
+      let(:commune) { build(:commune, :en_cours_de_recensement) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune: build(:commune)) }
       it { should_not permit(user, recensement) }
     end
@@ -32,9 +32,9 @@ describe Communes::RecensementPolicy do
 
     context "objet n'a pas de recensement + commune completed" do
       # this is a rare case where an object is created after the commune is completed
-      let(:commune) { build(:commune, status: :completed) }
+      let(:commune) { build(:commune, :completed) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune:) }
       it { should permit(user, recensement) }
     end
@@ -42,40 +42,36 @@ describe Communes::RecensementPolicy do
 
   permissions :edit?, :update?, :destroy? do
     context "commune started" do
-      let(:commune) { build(:commune, status: :started) }
+      let(:commune) { build(:commune, :en_cours_de_recensement) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune:) }
 
       it { should permit(user, recensement) }
     end
 
     context "commune started MAIS autre commune" do
-      let(:commune) { build(:commune, status: :started) }
+      let(:commune) { build(:commune, :en_cours_de_recensement) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune: build(:commune)) }
 
       it { should_not permit(user, recensement) }
     end
 
     context "commune completed + dossier submitted" do
-      let(:commune) { build(:commune, status: :completed) }
-      let(:dossier) { build(:dossier, status: :submitted, commune:) }
-      before { commune.dossier = dossier }
+      let(:commune) { build(:commune, :completed) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune:) }
 
       it { should permit(user, recensement) }
     end
 
     context "commune completed + dossier accepted" do
-      let(:commune) { build(:commune, status: :completed) }
-      let(:dossier) { build(:dossier, status: :accepted, commune:) }
-      before { commune.dossier = dossier }
+      let(:commune) { build(:commune, :examinée) }
       let(:objet) { build(:objet, commune:) }
-      let(:recensement) { build(:recensement, objet:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
       let(:user) { build(:user, commune:) }
 
       it { should_not permit(user, recensement) }

--- a/spec/policies/communes/recensement_policy_spec.rb
+++ b/spec/policies/communes/recensement_policy_spec.rb
@@ -22,6 +22,14 @@ describe Communes::RecensementPolicy do
       it { should_not permit(user, recensement) }
     end
 
+    context "objet n'a pas de recensement + commune started" do
+      let(:commune) { build(:commune, :en_cours_de_recensement) }
+      let(:objet) { build(:objet, commune:) }
+      let(:recensement) { build(:recensement, objet:, dossier: commune.dossier) }
+      let(:user) { build(:user, commune:) }
+      it { should permit(user, recensement) }
+    end
+
     context "objet n'a pas de recensement + commune completed" do
       # this is a rare case where an object is created after the commune is completed
       let(:commune) { build(:commune, status: :completed) }

--- a/spec/requests/recensement_wizard_spec.rb
+++ b/spec/requests/recensement_wizard_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe Communes::RecensementsController, type: :request do
   end
 
   context "PATCH communes/1/objets/1/recensements/1&step=" do
-    let(:recensement) { create(:recensement, objet:, status: :draft) }
+    before { commune.start! }
+    let(:recensement) { create(:recensement, objet:, status: :draft, dossier: commune.dossier) }
     let(:path) { commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id, step:) }
     let(:method) { :patch }
     let(:next_step) do
@@ -227,7 +228,8 @@ RSpec.describe Communes::RecensementsController, type: :request do
   end
 
   context "DELETE communes/1/objets/1/recensements/1" do
-    let(:recensement) { create(:recensement, objet:, status: :completed) }
+    before { commune.start! }
+    let(:recensement) { create(:recensement, objet:, status: :completed, dossier: commune.dossier) }
     let(:method) { :delete }
     let(:path) { commune_objet_recensement_path(commune_id: commune.id, objet_id: objet.id, id: recensement.id) }
 


### PR DESCRIPTION
Dans le re-recensement, une commune peut désormais avoir plusieurs dossiers.
À la création du tout premier recensement de la commune, s'il reste en brouillon il n'est pas associé au dossier de la commune (qui n'a pas encore été créé). Il devient donc impossible de retrouver le recensement, et d'en créer un nouveau pour cet objet (Erreur "Objet n'est pas disponible" liée à la contrainte d'unicité).