### PR TITLE
Demande le nom du recenseur et met à jour les mentions légales

### DIFF
--- a/app/controllers/communes/completions_controller.rb
+++ b/app/controllers/communes/completions_controller.rb
@@ -39,7 +39,7 @@ module Communes
     end
 
     def dossier_completion_params
-      params.require(:dossier_completion).permit(:notes_commune).to_h.symbolize_keys
+      params.require(:dossier_completion).permit(:notes_commune, :recenseur).to_h.symbolize_keys
         .merge(user: current_user)
     end
 

--- a/app/jobs/remove_personal_information_job.rb
+++ b/app/jobs/remove_personal_information_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemovePersonalInformationJob < ApplicationJob
+  queue_as :default
+  discard_on ActiveRecord::RecordNotFound
+
+  def perform(dossier_id)
+    @dossier = Dossier.find(dossier_id)
+    # On utilise update_columns pour éviter les validations qui pourraient faire échouer la tâche
+    @dossier.update_columns(recenseur: nil, updated_at: Time.zone.now)
+  end
+end

--- a/app/jobs/schedule_remove_personal_information_job.rb
+++ b/app/jobs/schedule_remove_personal_information_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ScheduleRemovePersonalInformationJob < ApplicationJob
+  queue_as :default
+
+  class << self
+    def dossiers
+      Dossier.where(created_at: ..6.years.ago)
+             .where.not(recenseur: [nil, ""])
+    end
+  end
+
+  delegate :dossiers, to: :class
+
+  def perform
+    dossiers.pluck(:id).each { RemovePersonalInformationJob.perform_later(_1) }
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -92,6 +92,7 @@ class Dossier < ApplicationRecord
 
   def aasm_after_submit(updates = {}, **_kwargs)
     update(notes_commune: updates[:notes_commune]) if updates.key?(:notes_commune)
+    update(recenseur: updates[:recenseur]) if updates.key?(:recenseur)
     commune.complete! unless commune.completed?
   end
 

--- a/app/models/dossier_completion.rb
+++ b/app/models/dossier_completion.rb
@@ -3,14 +3,14 @@
 class DossierCompletion
   attr_reader :dossier
 
-  delegate :commune, :notes_commune, to: :dossier
+  delegate :commune, :notes_commune, :recenseur, to: :dossier
 
   def initialize(dossier:)
     @dossier = dossier
   end
 
-  def create!(user:, notes_commune:)
-    return false unless dossier.submit!(notes_commune:)
+  def create!(user:, notes_commune:, recenseur:)
+    return false unless dossier.submit!(notes_commune:, recenseur:)
 
     SendMattermostNotificationJob.perform_later("commune_completed", { "commune_id" => commune.id })
     UserMailer.with(user:, commune:).commune_completed_email.deliver_later

--- a/app/views/communes/completions/new.html.haml
+++ b/app/views/communes/completions/new.html.haml
@@ -19,16 +19,23 @@
         Veuillez vérifier la complétion et l'exactitude de vos recensements avant de les transmettre aux conservateurs de votre département.
 
   = render "communes/completions/summary", objets: @objets
-  .fr-grid-row
-    .fr-col-md-6
-      = form_for @dossier_completion,
-        as: :dossier_completion,
-        url: commune_completion_path(@commune),
-        method: "POST",
-        builder: FormBuilderDsfr,
-        data: (@missing_photos ? { turbo_confirm: "Un recensement d'objet sans photo vous sera probablement renvoyé par les conservateurs. Êtes-vous sûr de vouloir valider votre recensement en l'état ?" } : {}) do |f|
+
+  = form_for @dossier_completion,
+    as: :dossier_completion,
+    url: commune_completion_path(@commune),
+    method: "POST",
+    builder: FormBuilderDsfr,
+    data: (@missing_photos ? { turbo_confirm: "Un recensement d'objet sans photo vous sera probablement renvoyé par les conservateurs. Êtes-vous sûr de vouloir valider votre recensement en l'état ?" } : {}) do |f|
+    .fr-grid-row.fr-grid-row--gutters
+      .fr-col-md-6.fr-mb-2w
         .fr-input-group
           = f.label :notes_commune, t("activerecord.attributes.dossier.interface_communes.notes_commune")
           = f.text_area :notes_commune
-        .actions
-          = f.submit "Je valide le recensement des objets de ma commune"
+      .fr-col-md-6.fr-mb-2w
+        .fr-input-group
+          = f.label :recenseur do
+            = t("activerecord.attributes.dossier.recenseur")
+            %span.fr-hint-text= t("activerecord.attributes.dossier.recenseur_hint_html", confidentialite_path:)
+          = f.text_area :recenseur
+    .actions
+      = f.submit "Je valide le recensement des objets de ma commune"

--- a/app/views/communes/completions/new.html.haml
+++ b/app/views/communes/completions/new.html.haml
@@ -2,6 +2,7 @@
 %main#contenu.fr-container.fr-pb-8w
   = render"shared/breadcrumbs",
     links: [["Accueil", root_path], ["Objets de #{@commune.nom}", commune_objets_path(@commune)]], current_page_label: "Finalisation"
+
   - if @commune.errors.any?
     .fr-grid-row
       .fr-col-md-6
@@ -11,12 +12,12 @@
           %ul
             - @commune.errors.attribute_names.each do |attribute|
               %li= @commune.errors.messages_for(attribute).first
-  .fr-grid-row
-    .fr-col-md-6
-      %h1
-        Finalisation du recensement de #{@commune.nom}
-      %p
-        Veuillez vérifier la complétion et l'exactitude de vos recensements avant de les transmettre aux conservateurs de votre département.
+
+  %h1 Finalisation du recensement de #{@commune.nom}
+
+  .co-readable
+    %p
+      Veuillez vérifier la complétion et l'exactitude de vos recensements avant de les transmettre aux conservateurs de votre département.
 
   = render "communes/completions/summary", objets: @objets
 

--- a/app/views/communes/completions/show.html.haml
+++ b/app/views/communes/completions/show.html.haml
@@ -1,11 +1,12 @@
 - content_for(:head_title) { "Recensements de #{@commune.nom}" }
 %main#contenu.fr-container.fr-pt-2w.fr-pb-8w
   = render "shared/breadcrumbs",  links: [["Accueil", root_path], ["Objets de #{@commune.nom}", commune_objets_path(@commune)]],  current_page_label: "Données envoyées"
-  %h1
-    Recensements de #{@commune.nom}
-  .fr-grid-row
-    .fr-col-md-6
-      %p Merci d'avoir participé et validé le recensement des objets de votre commune ! Un conservateur a été prévenu et reviendra vers vous.
+
+  %h1 Recensements de #{@commune.nom}
+
+  .co-readable
+    %p Merci d'avoir participé et validé le recensement des objets de votre commune ! Un conservateur a été prévenu et reviendra vers vous.
+
   = render "communes/completions/summary", objets: @objets
 
   .fr-grid-row.fr-grid-row--gutters

--- a/app/views/communes/completions/show.html.haml
+++ b/app/views/communes/completions/show.html.haml
@@ -7,8 +7,15 @@
     .fr-col-md-6
       %p Merci d'avoir participé et validé le recensement des objets de votre commune ! Un conservateur a été prévenu et reviendra vers vous.
   = render "communes/completions/summary", objets: @objets
-  - if @dossier.notes_commune.present?
-    %p= t("activerecord.attributes.dossier.interface_communes.notes_commune")
-    = blockquote(@dossier.notes_commune)
-  - else
-    %p.co-text--italic Aucun commentaire à destination des conservateurs
+
+  .fr-grid-row.fr-grid-row--gutters
+    .fr-col-md-6.fr-mb-4w
+      - if @dossier.notes_commune.present?
+        = t("activerecord.attributes.dossier.notes_commune")
+        = blockquote(@dossier.notes_commune)
+      - else
+        %p.co-text--italic Aucun commentaire à destination des conservateurs
+    - if @dossier.recenseur.present?
+      .fr-col-md-6.fr-mb-4w
+        = t("activerecord.attributes.dossier.recenseur")
+        = blockquote(@dossier.recenseur)

--- a/app/views/conservateurs/communes/show.html.haml
+++ b/app/views/conservateurs/communes/show.html.haml
@@ -19,11 +19,16 @@
         Examinez l’ensemble des objets en péril ou disparus pour envoyer des informations complémentaires à la commune.
         = link_to_button "Envoyer l'examen à la commune", "#", class: "fr-btn", disabled: true, data: { turbo_action: "advance" }
 
-  .fr-mb-4w
-    - if @dossier&.notes_commune.present?
-      %p
-        = t("activerecord.attributes.dossier.notes_commune")
-      = blockquote(@dossier.notes_commune)
+  - if @dossier&.notes_commune.present? || @dossier&.recenseur.present?
+    .fr-grid-row.fr-grid-row--gutters
+      - if @dossier&.notes_commune.present?
+        .fr-col-md-6.fr-mb-4w
+          = t("activerecord.attributes.dossier.notes_commune")
+          = blockquote(@dossier.notes_commune)
+      - if @dossier&.recenseur.present?
+        .fr-col-md-6.fr-mb-4w
+          = t("activerecord.attributes.dossier.recenseur")
+          = blockquote(@dossier.recenseur)
 
 
   = render "edifices/list", edifices: @edifices

--- a/app/views/pages/conditions.html.haml
+++ b/app/views/pages/conditions.html.haml
@@ -3,85 +3,83 @@
     %h1 Conditions générales d’utilisation
 
     :markdown
-      *Dernière mise à jour le 03/05/2022*
+      *Dernière mise à jour le 4 juillet 2024*
 
-      Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme « Collectif Objets » et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
+      Les présentes conditions générales d’utilisation (dites « CGU ») fixent le cadre juridique de la Plateforme « Collectif Objets » et définissent les conditions d’accès et d’utilisation des services par l’Utilisateur.
 
-      ## Quel est le produit concerné par le présent document ?
+      ## Article 1 - Champ d’application
 
-      La plateforme, dénommée « Collectif Objets » accompagne les communes dans la protection et la valorisation du patrimoine culturel, afin de notamment lutter contre les vols et les dégradations des objets monuments historiques.
+      **Le présent document a pour objet d’encadrer l’utilisation de la Plateforme.**
 
-      Vous vous engagez à respecter l’ensemble de ses dispositions, ainsi que ses éventuelles mises à jour.
+      **Toute utilisation de la Plateforme est subordonnée au respect intégral des présentes CGU.**
 
+      ## Article 2 - Objet
 
-      ## Quelles sont les définitions ?
+      La Plateforme, dénommée « Collectif Objets » accompagne les communes dans la protection et la valorisation du patrimoine culturel, dans le but de lutter notamment contre les vols et les dégradations des objets monuments historiques.
 
-      Les termes employés avec une majuscule dans le document ont la définition suivante :
+      ## Article 3 - Définitions
 
-      - « Utilisateur » désigne toute personne utilisant la Plateforme ;
+      - **« Plateforme » désigne le service numérique Collectif Objets.**
+      - **« Services » désigne les fonctionnalités offertes par la Plateforme pour répondre à ses finalités.**
+      - **« Utilisateur » est tout conservateur ou conservatrice qui utilise la Plateforme.**
 
+      ## Article 4 - Fonctionnalités
 
-      ## Quelles sont les fonctionnalités de la plateforme ?
+      Plusieurs fonctionnalités sont disponibles sur la plateforme :
 
-      Plusieurs fonctionnalités sont disponibles sur la plateforme :
+      ### Compte Utilisateur
 
-
-      ### Compte utilisateur
-
-      Le compte utilisateur sur la plateforme est créé au préalable à partir du mail générique de la mairie concernée, ainsi que la liste des objets monuments historiques rattachés à chaque municipalité. Nous envoyons un lien de connexion automatique pour accéder au compte, qui peut être utilisé par toute personne ayant un accès habilité à l’adresse mail générique de la mairie concernée.
-
-      Dans le cadre de l’utilisation de la plateforme, l'agent n'a pas besoin de créer de compte individuel, en ce sens aucune donnée à caractère personnel n’est traitée par Collectif Objets.
-
+      Le compte Utilisateur sur la Plateforme est créé au préalable à partir du mail générique de la mairie concernée, ainsi que la liste des objets monuments historiques rattachés à chaque municipalité. Nous envoyons un lien de connexion automatique pour accéder au compte, qui peut être utilisé par toute personne ayant un accès habilité à l’adresse mail générique de la mairie concernée.
 
       ### Découverte des objets d’une commune
 
-      La plateforme recense et permet d’accéder à une liste d’objets détenus par les communes. Des statistiques sur le suivi global de Collectif Objets sont également disponibles sur la plateforme.
+      La Plateforme recense et permet d’accéder à une liste d’objets détenus par les communes. Des statistiques sur le suivi global de Collectif Objets sont également disponibles sur la Plateforme.
 
+      ### Recensement des objets
 
-      ## Quels sont les engagements respectifs ?
+      À la fin de chaque recensement, les personnes concernées peuvent renseigner leurs informations personnelles. Ils peuvent notamment ajouter des informations complémentaires sur leur recensement dans une zone de champ libre, sans pour autant indiquer de données identifiantes supplémentaires ou de données sensibles.
 
-      ### L’éditeur de la Plateforme
+      ## Article 5 - Responsabilités
 
-      L’éditeur de la Plateforme s’engage à :
+      ### 5.1 L’Éditeur de la Plateforme
+
+      L’Éditeur de la Plateforme s’engage à :
 
       - mettre à disposition de l’Utilisateur une Plateforme permettant les fonctionnalités décrites ci-avant ;
       - mettre à disposition le service gratuitement ;
       - collecter, conserver, traiter, héberger les données et/ou contributions de manière loyale et conformément aux finalités de la Plateforme ;
       - prendre toute mesure nécessaire de nature à garantir la sécurité et la confidentialité des informations fournies par l’usager et notamment empêcher qu’elles soient déformées, endommagées ou que des tiers non autorisés y aient accès ;
-      - ne commercialiser, d’aucune manière, les informations et pièces justificatives récoltées dans le cadre de la Plateforme ;
+      - ne commercialiser, d’aucune manière, les informations et pièces justificatives récoltées dans le cadre de la Plateforme.
 
-      L’éditeur s’autorise à supprimer, sans préavis ni indemnité d’aucune sorte, tout compte faisant l’objet d’une utilisation contrevenante aux présentes CGU.
+      L’Éditeur s’autorise à supprimer, sans préavis ni indemnité d’aucune sorte, tout compte faisant l’objet d’une utilisation contrevenante aux présentes CGU.
 
       L’indisponibilité de la Plateforme ne donne droit à aucune indemnité.
 
-      L’Éditeur de la Plateforme, dans le cadre de ses missions et à titre de modération, dispose d’un accès à la messagerie.
-      Cet accès est strictement limité aux seules personnes habilitées de l’équipe Collectif Objets.
+      L’Éditeur de la Plateforme, dans le cadre de ses missions et à titre de modération, dispose d’un accès à la messagerie. Cet accès est strictement limité aux seules personnes habilitées de l’équipe Collectif Objets.
 
-      ### L’Utilisateur
+
+      ### 5.2 L’Utilisateur
 
       L’Utilisateur reconnait avoir lu les présentes CGU et s’engage à :
 
       - accepter toute modification à venir des présentes CGU dont il aura été informé au préalable par mail ;
-      - prévenir immédiatement l’éditeur de toute utilisation non autorisée de son compte ou de ses informations ;
+      - prévenir immédiatement l’Éditeur de toute utilisation non autorisée de son compte ou de ses informations ;
       - communiquer des informations à jour et exactes notamment s’agissant des informations relatives au profil, sa situation personnelle et les missions proposées. Il est rappelé que toute personne procédant à une fausse déclaration pour elle-même ou pour autrui s’expose, notamment, aux sanctions prévues à l’article 441-1 du Code Pénal, prévoyant des peines pouvant aller jusqu’à trois ans d’emprisonnement et 45 000 euros d’amende.
 
       Les Utilisateurs peuvent signaler toute description, information ou commentaire ne répondant pas aux CGU.
 
-      L’éditeur se réserve le droit de supprimer et de modérer sans préavis, si les présentes règles ne sont pas respectées.
+      L’Utilisateur s’engage notamment à ne pas renseigner d’autres données à caractère personnel ou des données sensibles dans la zone de champ libre à la fin du recensement.
 
+      ## Article 6 - Mise à jour des conditions générales d’utilisation
 
-      ## Comment sont mises à jour des conditions d’utilisation ?
+      Les termes des présentes conditions générales d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire. Chaque modification donne lieu à une nouvelle version qui est acceptée par les parties.
 
-      Les termes des présentes conditions d’utilisation peuvent être amendés à tout moment, sans préavis, en fonction des modifications apportées à la plateforme, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
+      ## Article 7 - Propriété intellectuelle
 
-
-      ## Propriété intellectuelle
-
-      Conformément au décret n°2017-638 prévu par l’article L323-2 du Code des Relations entre le Public et l’Administration (CRPA), les administrations publiques peuvent ouvrir leurs données et soumettre la réutilisation à titre gratuit des informations publiques qu'elle détient sous la licence ouverte.
+      Conformément au décret n° 2017-638 prévu par l’article L. 323-2 du Code des Relations entre le Public et l’Administration (CRPA), les administrations publiques peuvent ouvrir leurs données et soumettre la réutilisation à titre gratuit des informations publiques qu'elle détient sous la licence ouverte.
 
       En cochant la case lors de l’envoi de vos documents, vous renoncez à vos droits sur ceux-ci et prenez connaissance qu'ils seront placés sous licence ouverte.
 
-
       ## Prise de contact
 
-      Tout utilisateur peut contacter Collectif Objet via l’adresse mail suivante : #{CONTACT_EMAIL}
+      Tout utilisateur peut contacter Collectif Objet via l’adresse mail suivante : [#{CONTACT_EMAIL}](mailto:#{CONTACT_EMAIL})

--- a/app/views/pages/confidentialite.html.haml
+++ b/app/views/pages/confidentialite.html.haml
@@ -31,7 +31,7 @@
 
       ### Pendant combien de temps conservons-nous vos données à caractère personnel ?
 
-      **Les données relatives aux recensements sont conservées pendant 2 ans à compter du dernier contact avec la personne concernée. Les données relatives à la newsletter sont conservées jusqu’à la désinscription. Les données relatives à la traçabilité sont conservées pendant 1 an, conformément à la LCEN.**
+      **Les données relatives aux recensements sont conservées pendant 6 ans à compter du dernier contact avec la personne concernée. Les données relatives à la newsletter sont conservées jusqu’à la désinscription. Les données relatives à la traçabilité sont conservées pendant 1 an, conformément à la LCEN.**
 
       ### Quels sont vos droits ?
 

--- a/app/views/pages/confidentialite.html.haml
+++ b/app/views/pages/confidentialite.html.haml
@@ -1,82 +1,111 @@
 %main#contenu.fr-grid-row.fr-container.fr-grid-row--center.fr-pb-8w.fr-pt-2w
   .fr-col-md-8
     %h1 Politique de confidentialité
+
     :markdown
-      *Dernière mise à jour le 03/05/2022*
+      *Dernière mise à jour le 4 juillet 2024*
 
-      ## Traitement de données à caractère personnel
+      ## Qui sommes-nous ?
 
-      La plateforme, dénommée «&nbsp;Collectif Objets&nbsp;» accompagne les communes dans la protection et la valorisation du patrimoine culturel, afin de notamment lutter contre les vols et les dégradations des objets monuments historiques.
+      **Collectif Objets est un service public numérique, sous la responsabilité de traitement du ministère de la Culture**, qui accompagne les communes dans la protection et la valorisation du patrimoine culturel, dans le but de lutter notamment contre les vols et les dégradations des objets monuments historiques.
 
+      ### Pourquoi traitons-nous des données à caractère personnel ?
 
-      ## Responsable de traitement
+      Collectif Objets traite des données identifiantes pour permettre aux conservateurs de bénéficier d’un espace personnel pour prendre contact avec les communes pour les guider dans la mise en valeur de leur patrimoine.
 
-      Le responsable de traitement est la Direction régionale des affaires culturelles (DRAC) Grand Est
+      ### Quelles sont les données à caractère personnel que nous traitons ?
 
+      Collectif Objets va être amené à collecter les données suivantes :
 
-      ## Données à caractère personnel traitées
+      - Données relatives aux recensements : nom, prénom, fonction, adresse e-mail, numéro de téléphone et champs libres ;
+      - Données relatives à la newsletter : adresse e-mail ;
+      - Données de traçabilité : logs et adresse IP.
 
-      Collectif Objets va être amené à collecter les données suivantes&nbsp;:
+      ### Qu’est-ce qui nous autorise à traiter des données à caractère personnel ?
 
-      - Données de cookies&nbsp;: Erreur rencontrée, Adresse IP, type de navigateur, système d'exploitation et URL de référence.
+      **Collectif Objets traite des données à caractère personnel pour l’exécution d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement conformément à l’article 6-1 e) du RGPD.**
 
-      Collectif Objets dispose d’un accès à la messagerie où les messages échangés sont ponctuels et ne révèlent pas de données à caractère personnel.
+      Cette mission d’intérêt public se traduit en pratique par :
 
-      ## Base légale
+      **Le décret n° 2024-34 du 24 janvier 2024 relatif aux attributions du ministre de la Culture, notamment son article premier.**
 
-      Pour le traitement de ces données, la base légale est le consentement des personnes concernées.
+      ### Pendant combien de temps conservons-nous vos données à caractère personnel ?
 
+      **Les données relatives aux recensements sont conservées pendant 2 ans à compter du dernier contact avec la personne concernée. Les données relatives à la newsletter sont conservées jusqu’à la désinscription. Les données relatives à la traçabilité sont conservées pendant 1 an, conformément à la LCEN.**
 
-      ## Finalités
-
-      Le traitement réalisé par Collectif Objets a pour but de gérer et analyser les erreurs liées à la plateforme.
-
-
-      ## Durée de conservation
-
-      Les données à caractère personnel sont conservées :
-
-      - **Données de cookies** : Erreur rencontrée, Adresse IP, type de navigateur, système d'exploitation et URL de référence. Ces données sont conservées 13 mois maximum ou jusquʼau retrait du consentement.
-
-
-      ## Droit des personnes concernées
+      ### Quels sont vos droits ?
 
       Vous disposez des droits suivants concernant vos données à caractère personnel :
 
-      - Droit dʼinformation ;
-      - Droit dʼaccès aux données ;
+      - Droit dʼinformation et droit d’accès aux données ;
       - Droit de rectification ;
-      - Droit de suppression des données.
+      - Droit d’opposition ;
+      - Droit à la limitation du traitement de vos données.
 
-      Pour les exercer, faites-nous parvenir une demande en précisant la date et lʼheure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à lʼadresse suivante : #{mail_to(CONTACT_EMAIL)}
+      Pour les exercer, vous pouvez contacter l’adresse suivante : [#{CONTACT_EMAIL}](mailto:#{CONTACT_EMAIL})
 
-      En raison de lʼobligation de sécurité et de confidentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, vous trouverez ici :
+      Ou par voie postale :
 
-      <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank" rel="noopener">cnil.fr/fr/modele/courrier/exercer-son-droit-dacces</a>
+      Ministère de la Culture
 
-      Nous nous engageons à ne jamais céder ces informations à des tiers.
+      À l’attention du délégué à la protection des données (DPD)
 
+      182 rue Saint-Honoré\\
+      75001 Paris, France
 
-      ## Délais de réponse
+      Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure de vous identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être amenés à vous demander une preuve de votre identité.
 
-      Le responsable de traitement et lʼéquipe responsable de Collectif dʼobjets sʼengage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+      Pour vous aider dans votre démarche, la CNIL a élaboré un [modèle de courrier](https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces).
 
+      Le responsable de traitement s’engage à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
 
-      ## Sous-traitants
+      ### Qui peut accéder à vos données ?
 
-      Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions.
-      Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité, dʼusage et de protection des données.
+      Les destinataires des données sont les membres de l’équipe Collectif Objets et les communes.
 
+      ### Qui nous aide à traiter vos données à caractère personnel ?
 
-      ## Utilisation de témoins de connexion (« cookies »)
+      Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de confidentialité et de sécurité des données.
 
-      Collectif Objets utilise des cookies de statistiques anonymes, Matomo (Piwik), qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet.
+      <table class="fr-table">
+        <thead>
+          <tr>
+            <th>Partenaire</th>
+            <th>Pays destinataire</th>
+            <th>Traitement réalisé</th>
+            <th>Garanties</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>OVH</th>
+            <td>France</td>
+            <td>Hébergement des données</td>
+            <td>https://us.ovhcloud.com/legal/data-processing-agreement/</td>
+          </tr>
+          <tr>
+            <th>Brevo</th>
+            <td>France</td>
+            <td>Newsletter</td>
+            <td>https://www.brevo.com/legal/termsofuse/#annex</td>
+          </tr>
+        </tbody>
+      </table>
 
-      Collectif Objets utilise Sentry pour gérer et analyser les erreurs liées à la plateforme.
+      ## Cookies et traceurs
 
-      À tout moment, vous pouvez refuser lʼutilisation des cookies et désactiver le dép&#xF4;t sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera).
+      Un cookie est un fichier déposé sur votre terminal lors de la visite d’un site. Il a pour but de collecter des informations relatives à votre navigation et de vous adresser des services adaptés à votre terminal (ordinateur, mobile ou tablette).
 
-      Pour aller plus loin, vous pouvez consulter les fiches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL) :
+      En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à caractère personnel et la protection de la vie privée dans le secteur des communications électroniques, transposée à l’article 82 de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les traceurs ou cookies suivent deux régimes distincts.
 
-        - Cookies  traceurs : que dit la loi ?
-        - Cookies : les outils pour les maîtriser
+      - Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter la communication par voie électronique sont dispensés de consentement préalable au titre de l’article 82 de la loi n°78-17 du 6 janvier 1978.
+      - Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la communication par voie électronique doivent être consenti par l’utilisateur.
+
+      Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au sens du RGPD et doit être entendu au sens de l'article 6-1 a) du Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre circulation de ces données.
+
+      Collectif Objets utilise Matomo, configuré en mode exempté et ne nécessitant pas le recueil de votre consentement, conformément aux recommandations de la CNIL.
+
+      Pour en savoir plus, vous pouvez consulter les fiches suivantes proposées par la CNIL :
+
+      - [Cookies & traceurs : que dit la loi ?](https://www.cnil.fr/fr/cookies-et-autres-traceurs/regles/cookies/que-dit-la-loi)
+      - [Cookies : les outils pour les maîtriser](https://www.cnil.fr/fr/cookies-et-autres-traceurs/comment-se-proteger/maitriser-votre-navigateur)

--- a/app/views/pages/mentions_legales.html.haml
+++ b/app/views/pages/mentions_legales.html.haml
@@ -3,37 +3,42 @@
     %h1 Mentions légales
 
     :markdown
-      ## Éditeur
+      ## Éditeur de la plateforme
 
-      Ce site est édité par le Ministère de la culture, 182, rue Saint-Honoré 75001 Paris
+      Cette plateforme est éditée par :
 
+      Ministère de la culture,\\
+      182, rue Saint-Honoré\\
+      75001 Paris, France
 
-      ## Directeur de la publication
+      Téléphone : [01 40 15 80 00](tel:+33140158000)
 
-      Monsieur Romain Delassus, chef du service du numérique du Ministère de la Culture
+      ## Directrice  de la publication
 
+      La directrice de la publication est Madame Rachida DATI, ministre de la Culture.
 
-      ## Hébergement du site
+      ## Hébergement de la plateforme
 
-      Ce site est hébergé par Outscale, 1, rue Royale – 319 Bureaux de la Colline 92210 Saint-Cloud
+      Cette plateforme est hébergée par :
 
+      OVH\\
+      2, rue Kellermann\\
+      59100 Roubaix, France
 
       ## Accessibilité
 
-      La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous.
+      La conformité aux normes d’accessibilité numérique est un [objectif ultérieur](#{declaration_accessibilite_path}) mais nous tâchons de rendre cette plateforme accessible à toutes et à tous.
 
+      Pour en savoir plus, vous pouvez consulter la [politique d’accessibilité numérique de l’État](https://accessibilite.numerique.gouv.fr/).
 
-      ## Signaler un dysfonctionnement
+      ### Signaler un dysfonctionnement
 
-      Si vous rencontrez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part.
+      Si vous rencontrez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, merci de nous en faire part : [#{CONTACT_EMAIL}](mailto:#{CONTACT_EMAIL})
 
       Si vous n’obtenez pas de réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.
 
-      Pour en savoir plus sur la politique d’accessibilité numérique de l’État : <a href="http://references.modernisation.gouv.fr/accessibilite-numerique" target="_blank" rel="noopener">references.modernisation.gouv.fr/accessibilite-numerique</a>
-
-
       ## Sécurité
 
-      Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges.
+      La plateforme  est protégée par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges.
 
       En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels pour demander la saisie d’informations personnelles.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -267,6 +267,8 @@ fr:
       dossier:
         notes_commune: Commentaires de la commune
         notes_conservateur: Commentaires des conservateurs à destination de la commune
+        recenseur: Coordonnées de la personne ayant effectué le recensement
+        recenseur_hint_html: Indiquez ici uniquement le nom et les coordonnées de la personne en charge du recensement afin de faciliter le suivi des objets protégés. Ces données sont couvertes par notre <a href="%{confidentialite_path}" target="_blank" rel="noopener">politique de confidentialité</a>.
         interface_communes:
           notes_commune: Vos commentaires à destination des conservateurs
         interface_conservateurs:

--- a/db/migrate/20240715122757_add_recenseur_to_dossiers.rb
+++ b/db/migrate/20240715122757_add_recenseur_to_dossiers.rb
@@ -1,0 +1,5 @@
+class AddRecenseurToDossiers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :dossiers, :recenseur, :text
+  end
+end

--- a/spec/jobs/remove_personal_information_job_spec.rb
+++ b/spec/jobs/remove_personal_information_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemovePersonalInformationJob, type: :job do
+  describe "#perform" do
+    it "removes personal information and resets updated_at" do
+      recenseur = "Grace Hopper"
+      dossier = create(:dossier, created_at: 6.years.ago, updated_at: 2.years.ago, recenseur:)
+      expect do
+        subject.perform(dossier.id)
+        dossier.reload
+      end.to  change(dossier, :recenseur).from(recenseur).to(nil)
+         .and change(dossier, :updated_at)
+    end
+  end
+end

--- a/spec/jobs/schedule_remove_personal_information_job_spec.rb
+++ b/spec/jobs/schedule_remove_personal_information_job_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScheduleRemovePersonalInformationJob, type: :job do
+  describe "#dossiers" do
+    it "selects the appropriate dossiers" do
+      create(:dossier, created_at: 6.years.ago, recenseur: nil)
+      create(:dossier, created_at: 5.years.ago, recenseur: "Jean Bartik")
+      dossiers = [create(:dossier, created_at: 6.years.ago, recenseur: "Grace Hopper")]
+      expect(described_class.dossiers).to eq dossiers
+    end
+  end
+end

--- a/spec/requests/completion_spec.rb
+++ b/spec/requests/completion_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Communes::CompletionsController, type: :request do
+  let(:commune) { create(:commune, :with_user, :en_cours_de_recensement) }
+  let(:objet) { create(:objet, commune:) }
+  let(:recensement) { create(:recensement, objet:) }
+  let(:dossier) { commune.dossier }
+  let(:user) { commune.users.first }
+
+  before(:each) { login_as(user, scope: :user) }
+
+  context "POST communes/1/completion/new" do
+    it "soumet le dossier" do
+      path = commune_completion_path(commune)
+      notes_commune = "Notes commune"
+      recenseur = "Recenseur"
+      params = { dossier_completion: { notes_commune:, recenseur: } }
+      expect do
+        post(path, params:)
+        dossier.reload # Requis parce qu'on passe par commune pour obtenir le dossier
+      end.to change(dossier, :status).from("construction").to("submitted")
+      expect(dossier.notes_commune).to eq notes_commune
+      expect(dossier.recenseur).to eq recenseur
+    end
+  end
+end


### PR DESCRIPTION
- [x] Ajouter un champ "Coordonnées de la personne recenseuse" à la fin du recensement
- [x] Afficher le nom de la personne recenseuse côté conservateur et commune
- [x] Mettre à jour les mentions légales
- [x] Mettre à jour les conditions générales d'utilisation
- [x] Mettre à jour la politique de confidentialité
- [x] Supprimer automatiquement les infos des recenseurs