### PR TITLE
Corrige le compteur d'objets déjà recencés suite au re-recensement

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
 
   def home
     @stats = Rails.cache.fetch("homepage_stats", expires_in: 24.hours) do
-      { recensements: Objet.where.associated(:recensements).count, communes: Commune.completed.count }
+      { recensements: Objet.where.associated(:recensements).uniq.count, communes: Commune.completed.count }
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
 
   def home
     @stats = Rails.cache.fetch("homepage_stats", expires_in: 24.hours) do
-      { recensements: Recensement.count, communes: Commune.completed.count }
+      { recensements: Objet.where.associated(:recensements).count, communes: Commune.completed.count }
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
 
   def home
     @stats = Rails.cache.fetch("homepage_stats", expires_in: 24.hours) do
-      { recensements: Objet.where.associated(:recensements).uniq.count, communes: Commune.completed.count }
+      { recensements: Recensement.select(:objet_id).distinct.count, communes: Commune.completed.count }
     end
   end
 


### PR DESCRIPTION
Le compteur d'objets sur la page d'accueil n'était plus bon car il ne prenait pas en compte la possibilité du re-recensement.

NB : il n'est pas tout à fait le même que sur Metabase car il est mis à jour tous les 24h environ