### PR TITLE
Corrige l'installation de libvips qui échoue désormais en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install -y libvips --no-install-recommends
+        run: sudo apt-get install -y libvips --no-install-recommends
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips42 --no-install-recommends --fix-missing
+        run: sudo apt-get install -y libvips --no-install-recommends --fix-missing
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips --no-install-recommends
+        run: sudo apt-get update && sudo apt-get install -y libvips
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips
+        run: sudo apt-get install -y libvips42
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips --no-install-recommends --fix-missing
+        run: sudo apt-get update && sudo apt-get install -y libvips --no-install-recommends
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips42
+        run: sudo apt-get install -y libvips42 --no-install-recommends
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install libvips
-        run: sudo apt-get install -y libvips42 --no-install-recommends
+        run: sudo apt-get install -y libvips42 --no-install-recommends --fix-missing
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
L'installation de `libvips` ne passe plus en CI, ce qui fait échouer tous les tests.
Il semble que la version d'Ubuntu utilisée par Github Actions est passée en EOL, le package `libvips` a changé d'adresse.

```
Err:25 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libpoppler118 amd64 22.02.0-2ubuntu0.4
  404  Not Found [IP: 52.147.219.192 80]
Err:26 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libpoppler-glib8 amd64 22.02.0-2ubuntu0.4
  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler118_22.02.0-2ubuntu0.4_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/poppler/libpoppler-glib8_22.02.0-2ubuntu0.4_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 14.1 MB in 1s (18.9 MB/s)
Error: Process completed with exit code 100.
```