### PR TITLE
Corrige les statistiques de campagnes apres re-recensement

### DIFF
--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -9,7 +9,7 @@ module Conservateurs
     end
 
     def show
-      @stats = Co::DepartementStats.new(@departement.code)
+      @stats = Co::DepartementStats.new(@departement)
       set_communes
       if params[:vue] == "carte"
         @communes.select(%w[code_insee nom status objets_count en_peril_count latitude longitude]).to_a

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -21,20 +21,24 @@ module CampaignHelper
   end
 
   def campaign_communes_statuses_line_chart_datasets(statuses_stats)
+    started = statuses_stats.fetch("construction", 0)
+    submitted = statuses_stats.fetch("submitted", 0)
+    accepted = statuses_stats.fetch("accepted", 0)
+    inactive = statuses_stats.fetch("total", 0) - (started + submitted + accepted)
     [
-      { label: "Inactive", backgroundColor: "rgba(254, 238, 113, 1)", data: [statuses_stats.fetch("inactive", 0)] },
-      { label: "Recensement démarré", backgroundColor: "rgba(94, 100, 255, 1)",
-        data: [statuses_stats.fetch("started", 0)] },
-      { label: "Recensement terminé", backgroundColor: "rgba(30, 100, 30, 1)",
-        data: [statuses_stats.fetch("completed", 0)] }
+      { label: "Inactive", data: [inactive], backgroundColor: "rgb(254, 247, 218)" },
+      { label: "En cours de recensement", data: [started], backgroundColor: "rgb(252, 198, 58)" },
+      { label: "Recensement terminé", data: [submitted], backgroundColor: "rgb(192, 140, 101)" },
+      { label: "Recensement examiné", data: [accepted], backgroundColor: "rgb(149, 226, 87)" }
     ]
   end
 
   def campaign_objets_statuses_line_chart_datasets(objets_stats)
+    recensés = objets_stats.fetch("recensed", 0)
+    non_recensés = objets_stats.fetch("not_recensed", 0)
     [
-      { label: "Pas encore recensé", backgroundColor: "rgba(254, 238, 113, 1)",
-        data: [objets_stats.fetch("not_recensed", 0)] },
-      { label: "Recensé", backgroundColor: "rgba(94, 100, 255, 1)", data: [objets_stats.fetch("recensed", 0)] }
+      { label: "Pas encore recensé", data: [non_recensés], backgroundColor: "rgb(254, 247, 218)" },
+      { label: "Recensé", data: [recensés], backgroundColor: "rgb(149, 226, 87)" }
     ]
   end
 end

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Rails/OutputSafety
 module CampaignHelper
   def campaign_status_badge(campaign)
     color = {
@@ -10,7 +9,7 @@ module CampaignHelper
       "finished" => :success
     }[campaign.status]
     text = I18n.t("activerecord.attributes.campaign.statuses.#{campaign.status}")
-    "<span class=\"fr-badge fr-badge--sm fr-badge--#{color}\">#{text}</span>".html_safe
+    tag.span text, class: "fr-badge fr-badge--sm fr-badge--#{color}"
   end
 
   def campaigns_statuses_options
@@ -39,4 +38,3 @@ module CampaignHelper
     ]
   end
 end
-# rubocop:enable Rails/OutputSafety

--- a/app/helpers/campaign_helper.rb
+++ b/app/helpers/campaign_helper.rb
@@ -21,24 +21,24 @@ module CampaignHelper
   end
 
   def campaign_communes_statuses_line_chart_datasets(statuses_stats)
-    started = statuses_stats.fetch("construction", 0)
-    submitted = statuses_stats.fetch("submitted", 0)
-    accepted = statuses_stats.fetch("accepted", 0)
-    inactive = statuses_stats.fetch("total", 0) - (started + submitted + accepted)
+    nb_started = statuses_stats.fetch("construction", 0)
+    nb_submitted = statuses_stats.fetch("submitted", 0)
+    nb_accepted = statuses_stats.fetch("accepted", 0)
+    nb_inactive = statuses_stats.fetch("total", 0) - (nb_started + nb_submitted + nb_accepted)
     [
-      { label: "Inactive", data: [inactive], backgroundColor: "rgb(254, 247, 218)" },
-      { label: "En cours de recensement", data: [started], backgroundColor: "rgb(252, 198, 58)" },
-      { label: "Recensement terminé", data: [submitted], backgroundColor: "rgb(192, 140, 101)" },
-      { label: "Recensement examiné", data: [accepted], backgroundColor: "rgb(149, 226, 87)" }
+      { label: "Inactive", data: [nb_inactive], backgroundColor: "rgb(254, 247, 218)" },
+      { label: "En cours de recensement", data: [nb_started], backgroundColor: "rgb(252, 198, 58)" },
+      { label: "Recensement terminé", data: [nb_submitted], backgroundColor: "rgb(192, 140, 101)" },
+      { label: "Recensement examiné", data: [nb_accepted], backgroundColor: "rgb(149, 226, 87)" }
     ]
   end
 
   def campaign_objets_statuses_line_chart_datasets(objets_stats)
-    recensés = objets_stats.fetch("recensed", 0)
-    non_recensés = objets_stats.fetch("not_recensed", 0)
+    nb_recensés = objets_stats.fetch("recensed", 0)
+    nb_non_recensés = objets_stats.fetch("not_recensed", 0)
     [
-      { label: "Pas encore recensé", data: [non_recensés], backgroundColor: "rgb(254, 247, 218)" },
-      { label: "Recensé", data: [recensés], backgroundColor: "rgb(149, 226, 87)" }
+      { label: "Pas encore recensé", data: [nb_non_recensés], backgroundColor: "rgb(254, 247, 218)" },
+      { label: "Recensé", data: [nb_recensés], backgroundColor: "rgb(149, 226, 87)" }
     ]
   end
 end

--- a/app/jobs/campaigns/refresh_campaign_stats_job.rb
+++ b/app/jobs/campaigns/refresh_campaign_stats_job.rb
@@ -4,7 +4,7 @@ module Campaigns
   class RefreshCampaignStatsJob < ApplicationJob
     def perform(campaign_id)
       @campaign = Campaign.find(campaign_id)
-      @campaign.update_columns(stats: CampaignStats.new(@campaign).stats)
+      @campaign.refresh_stats
     end
   end
 end

--- a/app/lib/co/departement_stats.rb
+++ b/app/lib/co/departement_stats.rb
@@ -6,13 +6,16 @@ module Co
       @departement = departement
     end
 
+    attr_reader :departement
+
+    delegate :code, :communes_count, to: :departement
+
     def objets_count
-      @objets_count ||= Objet.where(lieu_actuel_departement_code: @departement).count
+      @objets_count ||= Objet.in_departement(code).count
     end
 
     def objets_recenses_count
-      @objets_recenses_count ||=
-        Objet.where(lieu_actuel_departement_code: @departement).where.associated(:recensements).count
+      @objets_recenses_count ||= Recensement.in_departement(code).count
     end
 
     def objets_recenses_percentage
@@ -21,12 +24,8 @@ module Co
       @objets_recenses_percentage ||= (objets_recenses_count.to_f / objets_count * 100).round
     end
 
-    def communes_count
-      @communes_count ||= Commune.where(departement: @departement).count
-    end
-
     def communes_completed_count
-      @communes_completed_count ||= Commune.where(departement: @departement).completed.count
+      @communes_completed_count ||= departement.communes.completed.count
     end
 
     def communes_completed_percentage
@@ -36,8 +35,7 @@ module Co
     end
 
     def etats_sanitaires_value_counts
-      @etats_sanitaires_value_counts ||=
-        Recensement.in_departement(@departement).etats_sanitaires_value_counts
+      @etats_sanitaires_value_counts ||= departement.recensements.etats_sanitaires_value_counts
     end
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -29,8 +29,6 @@ class Campaign < ApplicationRecord
     event(:finish) { transitions from: :ongoing, to: :finished }
   end
 
-  scope :active, -> { where(status: [:ongoing, :finished], date_lancement: Date.current.., date_fin: ..Date.current) }
-
   validates :date_lancement, :date_relance1, :date_relance2, :date_relance3, :date_fin, presence: true
   validates :sender_name, :signature, :nom_drac, presence: true, unless: :draft?
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -11,6 +11,7 @@ class Campaign < ApplicationRecord
   has_many :communes, through: :recipients
   has_many :objets, through: :communes
   has_many :dossiers, dependent: nil # Pour le calcul des statistiques
+  has_many :recensements, through: :dossiers
   has_many :emails, class_name: "CampaignEmail", through: :recipients
 
   accepts_nested_attributes_for :recipients, allow_destroy: true

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -158,6 +158,10 @@ class Campaign < ApplicationRecord
     "Campagne #{departement} du #{date_lancement} au #{date_fin}"
   end
 
+  def refresh_stats
+    update_columns(stats: CampaignStats.new(self).stats)
+  end
+
   private
 
   def prod? = Rails.configuration.x.environment_specific_name == "production"

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -10,6 +10,7 @@ class Campaign < ApplicationRecord
   has_many :recipients, class_name: "CampaignRecipient", dependent: :destroy
   has_many :communes, through: :recipients
   has_many :objets, through: :communes
+  has_many :dossiers, dependent: nil # Pour le calcul des statistiques
   has_many :emails, class_name: "CampaignEmail", through: :recipients
 
   accepts_nested_attributes_for :recipients, allow_destroy: true
@@ -26,6 +27,8 @@ class Campaign < ApplicationRecord
     event(:start, before: :archive_dossiers) { transitions from: :planned, to: :ongoing }
     event(:finish) { transitions from: :ongoing, to: :finished }
   end
+
+  scope :active, -> { where(status: [:ongoing, :finished], date_lancement: Date.current.., date_fin: ..Date.current) }
 
   validates :date_lancement, :date_relance1, :date_relance2, :date_relance3, :date_fin, presence: true
   validates :sender_name, :signature, :nom_drac, presence: true, unless: :draft?

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -10,7 +10,7 @@ class Campaign < ApplicationRecord
   has_many :recipients, class_name: "CampaignRecipient", dependent: :destroy
   has_many :communes, through: :recipients
   has_many :objets, through: :communes
-  has_many :dossiers, dependent: nil # Pour le calcul des statistiques
+  has_many :dossiers, dependent: :nullify # Pour le calcul des statistiques
   has_many :recensements, through: :dossiers
   has_many :emails, class_name: "CampaignEmail", through: :recipients
 

--- a/app/models/campaign_stats.rb
+++ b/app/models/campaign_stats.rb
@@ -17,9 +17,8 @@ class CampaignStats
 
   def objets_stats
     total = campaign.objets.count
-    recensed = campaign.objets.where.associated(:recensements).count
-    recensed_with_photo = campaign
-      .objets.where.associated(:recensements).where.not(recensements: { photos_count: 0 }).count
+    recensed = campaign.recensements.count
+    recensed_with_photo = campaign.recensements.with_photos.count
     {
       total:,
       recensed:,
@@ -30,7 +29,7 @@ class CampaignStats
   end
 
   def statuses_stats
-    campaign.communes.group(:status).count
+    { total: campaign.recipients_count }.merge campaign.dossiers.group(:status).count
   end
 
   def mails_stats

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -39,6 +39,7 @@ class Commune < ApplicationRecord
   has_one :dossier, -> { where.not(status: :archived) }, dependent: :restrict_with_error, inverse_of: :commune
   has_many :recensements, through: :dossier, source: :recensements
   has_many :campaign_recipients, dependent: :destroy
+  has_many :campaigns, through: :campaign_recipients
   has_many :admin_comments, dependent: :destroy, as: :resource
   has_many :survey_votes, dependent: :nullify
   has_many :messages, dependent: :destroy

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -112,6 +112,6 @@ class Dossier < ApplicationRecord
   private
 
   def set_campaign
-    self.campaign_id ||= commune.campaigns.ongoing.ids.first if commune
+    self.campaign_id ||= commune.campaigns.ongoing.ids.first
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -2,6 +2,7 @@
 
 class Dossier < ApplicationRecord
   belongs_to :commune
+  belongs_to :campaign, optional: true
   has_many :recensements, dependent: :nullify
   has_many :objets, through: :recensements
   belongs_to :conservateur, optional: true
@@ -42,6 +43,8 @@ class Dossier < ApplicationRecord
   scope :auto_submittable, -> { where(id: auto_submittable_ids) }
   scope :to_visit, -> { where.not(visit: nil) }
   scope :current, -> { where.not(status: "archived") }
+
+  before_create :set_campaign
 
   def self.auto_submittable_ids
     construction.includes(:recensements, commune: [:objets])
@@ -105,4 +108,10 @@ class Dossier < ApplicationRecord
   end
 
   def self.ransackable_attributes(_ = nil) = %w[status submitted_at]
+
+  private
+
+  def set_campaign
+    self.campaign_id ||= commune.campaigns.active.ids.first if commune
+  end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -112,6 +112,6 @@ class Dossier < ApplicationRecord
   private
 
   def set_campaign
-    self.campaign_id ||= commune.campaigns.active.ids.first if commune
+    self.campaign_id ||= commune.campaigns.ongoing.ids.first if commune
   end
 end

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -17,6 +17,8 @@ class Objet < ApplicationRecord
 
   accepts_nested_attributes_for :edifice
 
+  scope :in_departement, ->(code) { where(lieu_actuel_departement_code: code) if code }
+
   scope :order_by_recensement_priorite, lambda {
     left_outer_joins(commune: :dossier)
     .joins("LEFT JOIN recensements ON recensements.objet_id = objets.id AND recensements.deleted_at IS NULL \

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -85,9 +85,8 @@ class Recensement < ApplicationRecord
       localisation: [LOCALISATION_EDIFICE_INITIAL, LOCALISATION_AUTRE_EDIFICE]
     )
   }
-  scope :missing_photos, lambda {
-    present_and_recensable.where.missing(:photos_attachments)
-  }
+  scope :with_photos, -> { present_and_recensable.where.associated(:photos_attachments) }
+  scope :missing_photos, -> { present_and_recensable.where.missing(:photos_attachments) }
   scope :photos_presence_in, ->(presence) { presence ? all : missing_photos }
   scope :absent, -> { where(localisation: LOCALISATION_ABSENT) }
   scope :déplacés, -> {

--- a/app/views/admin/campaigns/show.html.haml
+++ b/app/views/admin/campaigns/show.html.haml
@@ -9,24 +9,25 @@
 
   = render "shared/campaigns/show_content", campaign: @campaign, excluded_communes: @excluded_communes, routes_prefix: :admin
 
-  %h2.fr-mt-4w ⚙️ Admin
+  - if @campaign.can_force_start? || @campaign.can_force_step_up?
+    %h2.fr-mt-4w ⚙️ Admin
 
-  - if @campaign.can_force_start?
-    .fr-callout.fr-callout--brown-caramel.fr-fi-warning-line
-      %h3.fr-callout__title Lancer la campagne tout de suite [DEBUG]
-      %p.fr-callout__text
-        Ceci est une action exceptionnelle pour tester le fonctionnement des campagnes. Les mails seront vraiment envoyés ! Vérifiez les adresses emails avant de lancer.
-      = button_to "Lancer tout de suite",
-          admin_campaign_force_start_path(@campaign),
-          method: :post,
-          class: "fr-btn fr-btn--icon-left fr-icon-warning-line"
+    - if @campaign.can_force_start?
+      .fr-callout.fr-callout--brown-caramel.fr-fi-warning-line
+        %h3.fr-callout__title Lancer la campagne tout de suite [DEBUG]
+        %p.fr-callout__text
+          Ceci est une action exceptionnelle pour tester le fonctionnement des campagnes. Les mails seront vraiment envoyés ! Vérifiez les adresses emails avant de lancer.
+        = button_to "Lancer tout de suite",
+            admin_campaign_force_start_path(@campaign),
+            method: :post,
+            class: "fr-btn fr-btn--icon-left fr-icon-warning-line"
 
-  - elsif @campaign.can_force_step_up?
-    .fr-callout.fr-callout--brown-caramel.fr-fi-warning-line
-      %h3.fr-callout__title Passer à l'étape suivante tout de suite [DEBUG]
-      %p.fr-callout__text
-        Ceci est une action exceptionnelle pour tester le fonctionnement des campagnes. Les mails seront vraiment envoyés ! Vérifiez les adresses emails avant de lancer.
-      = button_to "Passer à l'étape #{t("campaigns.step_names.#{@campaign.next_step}").downcase}",
-          admin_campaign_force_step_up_path(@campaign),
-          method: :post,
-          class: "fr-btn fr-btn--icon-left fr-icon-warning-line"
+    - elsif @campaign.can_force_step_up?
+      .fr-callout.fr-callout--brown-caramel.fr-fi-warning-line
+        %h3.fr-callout__title Passer à l'étape suivante tout de suite [DEBUG]
+        %p.fr-callout__text
+          Ceci est une action exceptionnelle pour tester le fonctionnement des campagnes. Les mails seront vraiment envoyés ! Vérifiez les adresses emails avant de lancer.
+        = button_to "Passer à l'étape #{t("campaigns.step_names.#{@campaign.next_step}").downcase}",
+            admin_campaign_force_step_up_path(@campaign),
+            method: :post,
+            class: "fr-btn fr-btn--icon-left fr-icon-warning-line"

--- a/app/views/conservateurs/departements/_stats.html.haml
+++ b/app/views/conservateurs/departements/_stats.html.haml
@@ -44,3 +44,8 @@
       %strong= stats.objets_recenses_count
       objets sur
       %strong= "#{stats.objets_count}."
+
+    %p.fr-mb-0 État sanitaire des #{stats.objets_count} objets recensés :
+    %ul
+      - departement_etat_objets_line_chart_data(stats).each do |stat|
+        %li #{stat[:label]} : #{stat[:data].first}

--- a/app/views/conservateurs/departements/_stats.html.haml
+++ b/app/views/conservateurs/departements/_stats.html.haml
@@ -6,15 +6,15 @@
       .fr-card
         .fr-card__body
           .fr-card__content
-            %h3.fr-card__title.fr-text-title--blue-france #{stats.communes_completed_percentage}%
-            %p.fr-card__desc de communes recenseuses, soit #{stats.communes_completed_count} communes sur #{stats.communes_count}
+            %h3.fr-card__title.fr-text-title--blue-france Communes recenseuses : #{stats.communes_completed_percentage}%
+            %p.fr-card__desc Soit #{stats.communes_completed_count} communes sur #{stats.communes_count}.
 
     .fr-col-md-3.fr-col-12
       .fr-card
         .fr-card__body
           .fr-card__content
-            %h3.fr-card__title.fr-text-title--blue-france #{stats.objets_recenses_percentage}%
-            %p.fr-card__desc d'objets recensés, soit #{stats.objets_recenses_count} objets sur #{stats.objets_count}
+            %h3.fr-card__title.fr-text-title--blue-france Objets recensés : #{stats.objets_recenses_percentage}%
+            %p.fr-card__desc Soit #{stats.objets_recenses_count} objets sur #{stats.objets_count}.
 
     .fr-col-md-6
       .fr-card
@@ -25,23 +25,22 @@
               %canvas.co-height-150px{data: { controller: "stacked-line-chart",
                 datasets: departement_etat_objets_line_chart_data(stats).to_json,
                 "unit-suffix": "objet(s)",
-                "x-title": "nombre d’objets"} }
+                "x-title": "Nombre d’objets"} }
 -# version mobile
 .fr-mb-4w.fr-accordion.fr-background-alt--blue-france.hide.co-display--sm
   %h2.fr-accordion__title
     %button.fr-accordion__btn{"aria-expanded" => "false", "aria-controls" => "accordion-stats"} Voir les statistiques du département
-  .fr-collapse{id: "accordion-stats"}
-    .fr-grid-row.fr-grid-row--gutters.fr-mb-2w.fr-background-alt--blue-france
-      .fr-col-md-3.fr-col-12
-        .fr-card
-          .fr-card__body
-            .fr-card__content
-              %h3.fr-card__title.fr-text-title--blue-france #{stats.communes_completed_percentage}%
-              %p.fr-card__desc de communes recenseuses, soit #{stats.communes_completed_count} communes sur #{stats.communes_count}
+  .fr-collapse.fr-px-2w.fr-pb-0#accordion-stats
+    %p
+      %strong= "#{stats.communes_completed_percentage}%"
+      de communes recenseuses, soit
+      %strong= stats.communes_completed_count
+      communes sur
+      %strong= "#{stats.communes_count}."
 
-      .fr-col-md-3.fr-col-12
-        .fr-card
-          .fr-card__body
-            .fr-card__content
-              %h3.fr-card__title.fr-text-title--blue-france #{stats.objets_recenses_percentage}%
-              %p.fr-card__desc d'objets recensés, soit #{stats.objets_recenses_count} objets sur #{stats.objets_count}
+    %p
+      %strong= "#{stats.objets_recenses_percentage}%"
+      des objets sont recensés, soit
+      %strong= stats.objets_recenses_count
+      objets sur
+      %strong= "#{stats.objets_count}."

--- a/app/views/conservateurs/departements/show.html.haml
+++ b/app/views/conservateurs/departements/show.html.haml
@@ -1,4 +1,4 @@
-- content_for(:head_title) { t(".head_title", departement: @departement) }
+- content_for(:head_title) { "#{@departement.nom} - Vue tableau" }
 
 %main#contenu.fr-container.fr-mb-8w
   = render "shared/breadcrumbs", links: [["Départements", conservateurs_departements_path]], current_page_label: @departement.nom

--- a/app/views/conservateurs/departements/show_map.html.haml
+++ b/app/views/conservateurs/departements/show_map.html.haml
@@ -1,4 +1,4 @@
-- content_for(:head_title) { t(".head_title", departement: @departement) }
+- content_for(:head_title) { "#{@departement.nom} - Vue carte" }
 
 = vite_javascript_tag "conservateur_map"
 

--- a/app/views/shared/campaigns/_stats.html.haml
+++ b/app/views/shared/campaigns/_stats.html.haml
@@ -5,7 +5,7 @@
       .fr-col-md-6
         - if stats[:statuses].present?
           %p
-            Statut des #{@campaign.communes.count} communes
+            Statut des #{@campaign.recipients_count} communes
           %canvas{data: { controller: "stacked-line-chart",
             datasets: campaign_communes_statuses_line_chart_datasets(stats[:statuses]).to_json,
             "unit-suffix": "commune(s)",

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -4,54 +4,54 @@ Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
     sanity_checks: {
-      cron: "0 5 * * *",
+      cron: "0 5 * * *", # À 5h du matin, tous les jours
       class: "Sanity::ChecksJob"
     },
     sanity_remove_deprecated_edifices: {
-      cron: "0 3 * * 0", # every sunday at 3am
+      cron: "0 3 * * 0", # À 3h du matin, tous les dimanches
       class: "Sanity::RemoveDeprecatedEdificesJob"
     },
     campaigns: {
-      cron: "30 10 * * *",
+      cron: "30 10 * * *", # À 10h30, tous les jours
       class: "Campaigns::CronJob"
     },
     dossiers: {
-      cron: "0 8 1 * *", # the first day of every month at 8am
+      cron: "0 8 1 * *", # À 8h tous les 1er du mois
       class: "RelanceDossiersJob"
     },
     refresh_all_campaign_stats: {
-      cron: "0 8 * * mon-fri",
+      cron: "0 8 * * mon-fri", # À 8h tous les jours de semaine
       class: "Campaigns::RefreshAllCampaignStatsJob"
     },
     auto_submit_dossiers: {
-      cron: "0 9 * * *",
+      cron: "0 9 * * *", # À 9h du matin, tous les jours
       class: "AutoSubmitDossiersJob"
     },
     purge_unattached_blobs: {
-      cron: "0 2 * * *",
+      cron: "0 2 * * *", # À 2h du matin, tous les jours
       class: "PurgeUnattachedBlobsJob"
     },
     remove_old_session_codes: {
-      cron: "0 4 * * *",
+      cron: "0 4 * * *", # À 4h du matin, tous les jours
       class: "Sanity::RemoveOldSessionCodesJob"
     },
     synchronize_objets: {
-      cron: "0 2 * * 1", # every monday at 2am,
+      cron: "0 2 * * 1", # À 2h du matin, tous les lundis
       class: "Synchronizer::Objets::SynchronizeAllJob"
     },
     synchronize_communes: {
       # better to do it after the objets synchronization
-      cron: "0 3 * * 1", # every monday at 3am,
+      cron: "0 3 * * 1", # À 3h du matin, tous les lundis
       class: "Synchronizer::Communes::SynchronizeAllJob"
     },
     synchronize_edifices: {
       # better to do it after the communes synchronization
-      cron: "0 4 * * 1", # every monday at 4am,
+      cron: "0 4 * * 1", # À 4h du matin, tous les lundis
       class: "Synchronizer::Edifices::SynchronizeAllJob"
     },
     synchronize_photos: {
       # better to do it after the objets synchronization
-      cron: "0 5 * * 1", # every monday at 5am,
+      cron: "0 5 * * 1", # À 5h du matin, tous les lundis
       class: "Synchronizer::Photos::SynchronizeAllJob"
     },
   }

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
       class: "RelanceDossiersJob"
     },
     refresh_all_campaign_stats: {
-      cron: "0 * * * *",
+      cron: "0 8 * * mon-fri",
       class: "Campaigns::RefreshAllCampaignStatsJob"
     },
     auto_submit_dossiers: {

--- a/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
+++ b/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
@@ -11,7 +11,7 @@ class AddCampaignIdToDossiers < ActiveRecord::Migration[7.1]
     say_with_time "Add campaign_id to dossiers" do
       Campaign.where(status: [:ongoing, :finished]).includes(:recipients).find_each do |campaign|
         commune_id = campaign.recipients.collect(&:commune_id)
-        created_at = campaign.date_lancement..(campaign.date_fin + 6.months)
+        created_at = campaign.date_lancement..(campaign.date_fin + 1.year)
         Dossier.where(campaign_id: nil, commune_id:, created_at:).update_all(campaign_id: campaign.id)
       end
       # Return the number of dossiers updated

--- a/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
+++ b/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
@@ -1,0 +1,20 @@
+class AddCampaignIdToDossiers < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :dossiers, :campaign, foreign_key: true
+    backfill unless reverting?
+  end
+
+  private
+
+  def backfill
+    say_with_time "Add campaign_id to dossiers" do
+      Campaign.where(status: [:ongoing, :finished]).includes(:recipients).find_each do |campaign|
+        commune_id = campaign.recipients.collect(&:commune_id)
+        created_at = campaign.date_lancement..(campaign.date_fin + 6.months)
+        Dossier.where(campaign_id: nil, commune_id:, created_at:).update_all(campaign_id: campaign.id)
+      end
+      # Return the number of dossiers updated
+      Dossier.where.not(campaign_id: nil).count
+    end
+  end
+end

--- a/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
+++ b/db/migrate/20240801080839_add_campaign_id_to_dossiers.rb
@@ -2,6 +2,7 @@ class AddCampaignIdToDossiers < ActiveRecord::Migration[7.1]
   def change
     add_reference :dossiers, :campaign, foreign_key: true
     backfill unless reverting?
+    RefreshAllCampaignStatsJob.set(wait: 5.minutes).perform_later unless reverting?
   end
 
   private

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_094329) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_080839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -196,6 +196,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_094329) do
     t.datetime "replied_automatically_at"
     t.datetime "archived_at"
     t.text "recenseur"
+    t.bigint "campaign_id"
+    t.index ["campaign_id"], name: "index_dossiers_on_campaign_id"
     t.index ["commune_id"], name: "index_dossiers_on_commune_id"
     t.index ["conservateur_id"], name: "index_dossiers_on_conservateur_id"
     t.index ["status"], name: "index_dossiers_on_status", using: :hash
@@ -433,6 +435,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_17_094329) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "dossiers", "campaigns"
   add_foreign_key "dossiers", "communes"
   add_foreign_key "messages", "communes"
   add_foreign_key "recensements", "objets"


### PR DESCRIPTION
- [x] Ajoute un lien entre dossiers et campagnes pour que les statistiques puissent se limiter aux dossiers d'une campagne
- [x] Corrige le calcul des statistiques de campagnes
- [x] Corrige le calcul des statistiques de département

## Bonus
- [x] Masque le titre "Admin" dans les campagnes où il n'y a aucune action admin possible
- [x] Ajuste les titres de pages département (vue tableau et carte)
- [x] Remplace les couleurs des graphiques par des couleurs de la charte du DSFR (compatibles daltoniens)
- [x] Simplifie la génération des badges de campagnes en s'appuyant sur Rails
- [x] Simplifie le calcul des statistiques de département
- [x] Corrige les niveaux de titres de la page département
- [x] Simplifie l'affichage des statistiques de département en mobile
- [x] Utilise le compteur de communes du département au lieu d'une requête inutile