### PR TITLE
Corrige les communes répétées dans la vue tableau du département

### DIFF
--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -45,9 +45,7 @@ module Conservateurs
     end
 
     def set_communes
-      @communes = policy_scope(Commune)
-        .where(departement_code: @departement.code)
-        .include_statut_global
+      @communes = @departement.communes.include_statut_global
     end
 
     def set_status_global_filter

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -17,9 +17,7 @@ module Conservateurs
         render "show_map"
       else
         set_status_global_filter
-        @ransack = @communes
-          .select("nom")
-          .ransack(params[:q])
+        @ransack = @communes.select("nom").ransack(params[:q])
 
         # Remonte par défaut les communes avec le plus d'objets en péril
         @ransack.sorts = "en_peril_count DESC" if @ransack.sorts.empty?

--- a/app/controllers/conservateurs/departements_controller.rb
+++ b/app/controllers/conservateurs/departements_controller.rb
@@ -22,7 +22,8 @@ module Conservateurs
           .ransack(params[:q])
 
         # Remonte par défaut les communes avec le plus d'objets en péril
-        @ransack.sorts = "en_peril_count desc" if @ransack.sorts.empty?
+        @ransack.sorts = "en_peril_count DESC" if @ransack.sorts.empty?
+        @ransack.sorts = "nom ASC" unless @ransack.sorts.collect(&:attr).include? "unaccent(nom)"
 
         @pagy, @communes = pagy @ransack.result, items: 15
         @query_present = params[:q].present?


### PR DESCRIPTION
La dernière commune du tableau était répétée de page en page, sauf si on triait par nom.

Corrigé, mais en bidouillant parce que l'API de tri de Ransack est… [contre-intuitive](https://github.com/activerecord-hackery/ransack/issues/994).