### PR TITLE
Clarifie la fonction du crayon dans le récap recensement commune

### DIFF
--- a/app/helpers/recensement_helper.rb
+++ b/app/helpers/recensement_helper.rb
@@ -88,10 +88,10 @@ module RecensementHelper
 
   def edit_recensement_step_link(recensement, step, **)
     button_to(
-      "",
+      "Modifier",
       edit_commune_objet_recensement_path(recensement.commune, recensement.objet, recensement),
       params: { step: },
-      class: "fr-btn fr-btn--sm fr-icon-edit-line fr-btn--tertiary fr-btn--tertiary-no-outline",
+      class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-edit-line fr-btn--tertiary fr-btn--tertiary-no-outline",
       data: { turbo_action: "advance" },
       form_class: "co-display--inline co-edit-button",
       method: :get,

--- a/app/views/communes/recensements/_step7.html.haml
+++ b/app/views/communes/recensements/_step7.html.haml
@@ -22,7 +22,7 @@
 %section.fr-mb-4w
   %h3.fr-text--lg.fr-mb-1v
     Avez-vous trouvé l’objet ?
-    = edit_recensement_step_link recensement, 1, "aria-label": "Modifier la localisation de l’objet"
+    = edit_recensement_step_link recensement, 1, title: "Modifier la localisation de l’objet"
   %div
     = t "recensement.localisation.answers.#{recensement.localisation}_html",
       nom_edifice: recensement_nom_edifice(recensement), nom_commune_localisation_objet: nom_commune_localisation_objet(recensement)
@@ -32,14 +32,14 @@
   %section.fr-mb-4w
     %h3.fr-text--lg.fr-mb-1v
       L’objet est-il recensable ?
-      = edit_recensement_step_link recensement, 3, "aria-label": "Modifier la réponse"
+      = edit_recensement_step_link recensement, 3, title: "Modifier la réponse"
     %div= t "recensement.recensable_choices.#{recensement.recensable.to_s}"
 
 - if recensement.recensable?
   %section.fr-mb-4w
     %h3.fr-text--lg.fr-mb-1v
       Photos
-      = edit_recensement_step_link recensement, 4, "aria-label": "Modifier les photos"
+      = edit_recensement_step_link recensement, 4, title: "Modifier les photos"
     - if recensement.photos.any?
       .co-flex.co-flex--gap-1rem.co-flex--wrap
         - recensement.photos.each do |photo|
@@ -52,7 +52,7 @@
     %h3.fr-text--lg.fr-mb-1v
       Quel est l’état de l’objet ?
       - unless recensement.analyse_etat_sanitaire.present?
-        = edit_recensement_step_link recensement, 5, "aria-label": "Modifier l’état de l’objet"
+        = edit_recensement_step_link recensement, 5, title: "Modifier l’état de l’objet"
     %div
       - if recensement.analyse_etat_sanitaire.present?
         %div.co-text--strikethrough.co-semi-transparent.fr-mr-1w
@@ -66,7 +66,7 @@
     %h3.fr-text--lg.fr-mb-1v
       L’objet est-il en sécurité ?
       - unless recensement.analyse_securisation.present?
-        = edit_recensement_step_link recensement, 5, "aria-label": "Modifier la réponse"
+        = edit_recensement_step_link recensement, 5, title: "Modifier la réponse"
     - if recensement.analyse_securisation.present?
       %div.co-text--strikethrough.co-semi-transparent.fr-mr-1w
         = t "recensement.securisation_choices.#{recensement.securisation}"
@@ -78,7 +78,7 @@
 %section.fr-mb-4w
   %h3.fr-text--lg.fr-mb-1v
     Vos commentaires
-    = edit_recensement_step_link recensement, 6, "aria-label": "Modifier les commentaires"
+    = edit_recensement_step_link recensement, 6, title: "Modifier les commentaires"
   - if recensement.notes.present?
     .co-blockquote= recensement.notes
   - else

--- a/spec/features/communes/recensement_spec.rb
+++ b/spec/features/communes/recensement_spec.rb
@@ -306,7 +306,7 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
     expect(card_bouquet).to have_text(/Recensé/i)
     card_bouquet.click
     step7_validate
-    find("section", text: "L’objet n’est pas recensable").find('button[aria-label="Modifier la réponse"]').click
+    find("section", text: "L’objet n’est pas recensable").find('button[title="Modifier la réponse"]').click
     step3_validate
     find("label", text: "L’objet est recensable").click
     click_on "Passer à l’étape suivante"
@@ -468,7 +468,7 @@ RSpec.feature "Communes - Recensement", type: :feature, js: true do
     expect(page).to have_text("Oui, il a été déplacé temporairement")
     expect(page).not_to have_text("L’objet est-il recensable ?")
     find("section", text: "Oui, il a été déplacé temporairement")
-      .find('button[aria-label="Modifier la localisation de l’objet"]').click
+      .find('button[title="Modifier la localisation de l’objet"]').click
 
     step1_validate
     expect(find(".fr-radio-group", text: "Oui, mais l’objet a été déplacé temporairement")


### PR DESCRIPTION
Apparemment, plusieurs communes ne comprennent pas l'usage du crayon. Ajouter le texte "Modifier" pour clarifier la fonction.