### PR TITLE
Redirige sur le seul département quand on incarne un conservateur n'en ayant qu'un

### DIFF
--- a/app/controllers/admin/conservateurs_controller.rb
+++ b/app/controllers/admin/conservateurs_controller.rb
@@ -40,7 +40,11 @@ module Admin
     def impersonate
       @conservateur = Conservateur.find(params[:conservateur_id])
       impersonate_conservateur(@conservateur)
-      redirect_to conservateurs_departements_path
+      if @conservateur.departements.count == 1
+        redirect_to conservateurs_departement_path @conservateur.departements.first
+      else
+        redirect_to conservateurs_departements_path
+      end
     end
 
     def toggle_impersonate_mode

--- a/app/controllers/admin/conservateurs_controller.rb
+++ b/app/controllers/admin/conservateurs_controller.rb
@@ -40,11 +40,7 @@ module Admin
     def impersonate
       @conservateur = Conservateur.find(params[:conservateur_id])
       impersonate_conservateur(@conservateur)
-      if @conservateur.departements.count == 1
-        redirect_to conservateurs_departement_path @conservateur.departements.first
-      else
-        redirect_to conservateurs_departements_path
-      end
+      redirect_to after_sign_in_path_for_conservateur(@conservateur)
     end
 
     def toggle_impersonate_mode


### PR DESCRIPTION
Actuellement les admins sont redirigés vers la page conservateur/départements quand ils incarnent un conservateur, même si celui-ci n'a accès qu'à un seul département. Ce commit le corrige.