### PR TITLE
Permet d'accéder à l'utilisateur de la commune

### DIFF
--- a/app/controllers/concerns/campaign_recipients_controller_concern.rb
+++ b/app/controllers/concerns/campaign_recipients_controller_concern.rb
@@ -39,7 +39,7 @@ module CampaignRecipientsControllerConcern
     @recipient = CampaignRecipient.includes(:campaign, :commune).find(params[:id] || params[:recipient_id])
     @commune = @recipient.commune
     @campaign = @recipient.campaign
-    @user = @commune.users.first
+    @user = @commune.user
   end
 
   def validate_mail_preview_params

--- a/app/jobs/auto_submit_dossier_job.rb
+++ b/app/jobs/auto_submit_dossier_job.rb
@@ -15,6 +15,6 @@ class AutoSubmitDossierJob < ApplicationJob
   delegate :commune, to: :dossier
 
   def user
-    dossier.commune.users.first
+    dossier.commune.user
   end
 end

--- a/app/jobs/campaigns/cron_job.rb
+++ b/app/jobs/campaigns/cron_job.rb
@@ -18,7 +18,7 @@ module Campaigns
           next unless commune.shall_receive_email_objets_verts?(date)
 
           commune.dossier.update(replied_automatically_at: date)
-          UserMailer.with(user: commune.users.first, commune:).commune_avec_objets_verts_email.deliver_later
+          UserMailer.with(user: commune.user, commune:).commune_avec_objets_verts_email.deliver_later
         end
       end
     end

--- a/app/jobs/derniere_relance_dossier_incomplet_job.rb
+++ b/app/jobs/derniere_relance_dossier_incomplet_job.rb
@@ -4,7 +4,7 @@ class DerniereRelanceDossierIncompletJob < ApplicationJob
   def perform(dossier_id)
     dossier = Dossier.find(dossier_id)
     commune = dossier.commune
-    user = commune.users.first
+    user = commune.user
     UserMailer.with(user:, commune:).derniere_relance_dossier_incomplet.deliver_later
   end
 end

--- a/app/jobs/relance_dossier_incomplet_job.rb
+++ b/app/jobs/relance_dossier_incomplet_job.rb
@@ -4,7 +4,7 @@ class RelanceDossierIncompletJob < ApplicationJob
   def perform(dossier_id)
     dossier = Dossier.find(dossier_id)
     commune = dossier.commune
-    user = commune.users.first
+    user = commune.user
     UserMailer.with(user:, commune:).relance_dossier_incomplet.deliver_later
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -26,7 +26,7 @@ class UserMailer < ApplicationMailer
   def dossier_accepted_email
     @dossier = params[:dossier]
     @commune = @dossier.commune
-    @user = @commune.users.first
+    @user = @commune.user
     @conservateur = @dossier.conservateur || params[:conservateur]
     @cta_url = commune_dossier_url(@commune)
     mail \

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -181,6 +181,8 @@ class Commune < ApplicationRecord
     "#{nom} (#{code_insee})"
   end
 
+  def user = users.first
+
   def highlighted_objet
     # used in campaigns
     Objet.select_best_objet_in_list(objets.where.not(palissy_TICO: nil).to_a)

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -17,7 +17,7 @@
             %br
             et terminé le #{l(@commune.completed_at, format: :long_with_weekday)}
 
-      - user = @commune.users.first
+      - user = @commune.user
       - if user.nil?
         %p Aucun usager
         %p

--- a/app/views/conservateurs/messages/index.html.haml
+++ b/app/views/conservateurs/messages/index.html.haml
@@ -19,6 +19,6 @@
     - if sp_prefix = @commune.departement.service_public_prefix
       .fr-mb-1w
         = link_to "Mairie de #{@commune} sur service-public.fr", "https://lannuaire.service-public.fr/#{sp_prefix}/mairie-#{@commune.code_insee}-01", class: "fr-link fr-icon-information-line fr-link--icon-left", target: "_blank", rel: "noopener"
-    - if email = @commune.users.first&.email
+    - if email = @commune.user&.email
       .fr-mb-1w
         = link_to email, "mailto:#{email}", class: "fr-link fr-icon-mail-line fr-link--icon-left"

--- a/app/views/shared/campaigns/_mail_previews_content.html.haml
+++ b/app/views/shared/campaigns/_mail_previews_content.html.haml
@@ -5,5 +5,5 @@
   .fr-input-group
     = f.submit "Prévisualiser le mail", name: nil, class: "fr-hidden"
 
-- mail = CampaignV1Mailer.with(user: recipient.commune.users.first, commune: recipient.commune, campaign:).lancement_email
+- mail = CampaignV1Mailer.with(user: recipient.commune.user, commune: recipient.commune, campaign:).lancement_email
 = render Conservateurs::MailIframeComponent.new mail:, display_headers: false, fit: true

--- a/app/views/users/unsubscribes/new.html.haml
+++ b/app/views/users/unsubscribes/new.html.haml
@@ -10,7 +10,7 @@
       %p
         En cliquant sur ce bouton, vous désinscrirez la commune
         = @recipient.commune.nom
-        = "(#{ @recipient.commune.users.first.email })"
+        = "(#{ @recipient.commune.user.email })"
         de tous les prochains emails de la part de Collectif Objets au sujet de la campagne de campagne de recensement
         = @campaign.departement.dans_nom
         du

--- a/db/migrate/20220323134040_add_user_id_to_recensements.rb
+++ b/db/migrate/20220323134040_add_user_id_to_recensements.rb
@@ -5,7 +5,7 @@ class AddUserIdToRecensements < ActiveRecord::Migration[7.0]
       .where(user_id: nil)
       .includes(objet: { commune: [:users]})
       .find_each do |recensement|
-        user = recensement.commune.users.first
+        user = recensement.commune.user
         raise "missing user for recensement #{recensement.id} on objet #{recensement.objet.ref_pop}, commune #{recensement.commune.nom} (#{recensement.commune.code_insee})" if user.nil?
 
         recensement.update_columns(user_id: user.id)

--- a/lib/mailer_previews/campaign_v1_mailer_preview.rb
+++ b/lib/mailer_previews/campaign_v1_mailer_preview.rb
@@ -11,7 +11,7 @@ class CampaignV1MailerPreview < ApplicationMailerPreview
   private
 
   def user
-    @user ||= commune.users.first
+    @user ||= commune.user
   end
 
   def commune

--- a/lib/mailer_previews/user_mailer_preview.rb
+++ b/lib/mailer_previews/user_mailer_preview.rb
@@ -37,7 +37,7 @@ class UserMailerPreview < ApplicationMailerPreview
 
   def message_received
     message = Message.from_conservateur.first
-    user = message.commune.users.first
+    user = message.commune.user
     UserMailer.with(message:, user:).message_received_email
   end
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     created_at { 1.day.ago }
 
     trait :from_commune do
-      author { commune.users.first }
+      author { commune.user }
     end
   end
 end

--- a/spec/jobs/synchronizer/communes/revision_spec.rb
+++ b/spec/jobs/synchronizer/communes/revision_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Synchronizer::Communes::Revision do
       expect(commune.nom).to eq "Ambérieu"
       expect(commune.phone_number).to eq "01 02 03 04 05"
       expect(commune.departement_code).to eq "01"
-      user = commune.users.first
+      user = commune.user
       expect(user.email).to eq "contact@amberieu.fr"
       expect(revision.action_commune).to eq :create
       expect(revision.action_user).to eq :create
@@ -44,7 +44,7 @@ RSpec.describe Synchronizer::Communes::Revision do
       expect(commune.nom).to eq "Ambérieu"
       expect(commune.phone_number).to eq "01 02 03 04 05"
       expect(commune.departement_code).to eq "01"
-      user = commune.users.first
+      user = commune.user
       expect(user.email).to eq "contact@amberieu.fr"
       expect(revision.action_commune).to eq :update
       expect(revision.action_user).to eq :create
@@ -63,7 +63,7 @@ RSpec.describe Synchronizer::Communes::Revision do
     end
 
     before do
-      persisted_commune.users.first.update!(email: "anciencontact@amberieu.fr")
+      persisted_commune.user.update!(email: "anciencontact@amberieu.fr")
     end
 
     it "updates the commune & updates the user email" do
@@ -72,7 +72,7 @@ RSpec.describe Synchronizer::Communes::Revision do
       expect(commune.nom).to eq "Ambérieu"
       expect(commune.phone_number).to eq "01 02 03 04 05"
       expect(commune.departement_code).to eq "01"
-      user = commune.users.first
+      user = commune.user
       expect(user.email).to eq "contact@amberieu.fr"
       expect(revision.action_commune).to eq :update
       expect(revision.action_user).to eq :update_email

--- a/spec/mailers/campaign_v1_mailer_spec.rb
+++ b/spec/mailers/campaign_v1_mailer_spec.rb
@@ -46,7 +46,7 @@ end
 RSpec.describe CampaignV1Mailer, type: :mailer do
   let(:departement) { build(:departement, code: "78", nom: "Yvelines", dans_nom: "dans les Yvelines") }
   let!(:commune) { create(:commune_with_user, departement:, nom: "Joinville") }
-  let!(:user) { commune.users.first }
+  let!(:user) { commune.user }
   before { user.update!(email: "jean@mairie.fr") }
   before { travel_to(Time.zone.today.next_week(:monday).to_time + 10.hours) }
   let(:objet) { create(:objet, commune:) }

--- a/spec/models/departement_spec.rb
+++ b/spec/models/departement_spec.rb
@@ -87,13 +87,13 @@ describe Departement, type: :model do
     context "quand des communes ont écrit des messages" do
       it "indique le nombre de messages par nom de commune" do
         # Message trop ancien
-        create(:message, commune:, author: commune.users.first, created_at: date_range.first - 1.day)
+        create(:message, commune:, author: commune.user, created_at: date_range.first - 1.day)
         # Message d'une commune hors département
-        create(:message, commune: commune_autre_departement, author: commune_autre_departement.users.first,
+        create(:message, commune: commune_autre_departement, author: commune_autre_departement.user,
                          created_at: date_range.first + 1.day)
         # Messages attendus
-        create(:message, commune:, author: commune.users.first, created_at: date_range.first + 1.hour)
-        create(:message, commune: commune2, author: commune2.users.first, created_at: date_range.last - 1.hour)
+        create(:message, commune:, author: commune.user, created_at: date_range.first + 1.hour)
+        create(:message, commune: commune2, author: commune2.user, created_at: date_range.last - 1.hour)
         expect(commune_messages_count).to eq({ commune => 1, commune2 => 1 })
       end
     end

--- a/spec/requests/completion_spec.rb
+++ b/spec/requests/completion_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Communes::CompletionsController, type: :request do
   let(:objet) { create(:objet, commune:) }
   let(:recensement) { create(:recensement, objet:) }
   let(:dossier) { commune.dossier }
-  let(:user) { commune.users.first }
+  let(:user) { commune.user }
 
   before(:each) { login_as(user, scope: :user) }
 

--- a/spec/requests/recensement_wizard_spec.rb
+++ b/spec/requests/recensement_wizard_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Communes::RecensementsController, type: :request do
   let(:commune) { create(:commune, :with_user) }
   let(:objet) { create(:objet, commune:) }
-  let(:user) { commune.users.first }
+  let(:user) { commune.user }
   let(:params) { {} }
 
   before(:each) { login_as(user, scope: :user) }


### PR DESCRIPTION
Puisqu'il n'y en a qu'un dans l'immense majorité des cas, et que seul le premier utilisateur peut se connecter de toute façon.

👋 `commune.users.first`

Pour plus tard : fusionner les données de l'utilisateur dans la commune, pour simplier le code encore plus.