### PR TITLE
Suppression de la fonction "Repasser la commune en recensement et le dossier en construction"

### DIFF
--- a/app/controllers/admin/dossiers_controller.rb
+++ b/app/controllers/admin/dossiers_controller.rb
@@ -7,15 +7,6 @@ module Admin
       @commune = @dossier.commune # Requis par shared/dossier_rapport
     end
 
-    def update
-      @dossier = Dossier.find(params[:id])
-      raise if params[:status] != "construction"
-
-      @dossier.return_to_construction!
-      redirect_to admin_commune_path(@dossier.commune),
-                  notice: "Commune repassée en recensement & dossier repassé en construction"
-    end
-
     private
 
     def active_nav_links = %w[Communes]

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -74,10 +74,6 @@ class Dossier < ApplicationRecord
     recensements.where.not(analysed_at: nil).empty?
   end
 
-  def can_return_to_construction?
-    submitted? && not_analysed?
-  end
-
   def analyse_overrides?
     recensements.any?(&:analyse_overrides?)
   end

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -116,9 +116,6 @@
           %li accepté le #{l(dossier.accepted_at, format: :long_with_weekday)}
       %p #{dossier.recensements.count} recensements
 
-      - if dossier.can_return_to_construction?
-        = link_to admin_dossier_path(dossier, status: "construction"), class: "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-arrow-go-back-line", data: {"turbo-method": "PUT"} do
-          Repasser la commune en recensement et le dossier en construction
     = render UnfoldComponent.new(max_height_px: 800, button_text: "Voir tous les recensements") do
       .fr-table
         %table

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,7 +151,7 @@ Rails.application.routes.draw do
         post :toggle_impersonate_mode
       end
     end
-    resources :dossiers, only: [:show, :update]
+    resources :dossiers, only: [:show]
     resources :users, only: %i[] do
       get :impersonate
       collection do


### PR DESCRIPTION
La fonctionnalité n'est plus utilisée et semble de plus être au mauvais endroit, on peut donc l'enlever.