### PR TITLE
Suppression des codes de session lors de la suppression d'une commune

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,9 @@ class User < ApplicationRecord
 
   has_one :session_code, -> { valid.order(created_at: :desc) }, dependent: :destroy, inverse_of: :user
 
+  # this association is mostly here to indicate that when a user is destroyed its session codes are destroyed too
+  has_many :session_codes, dependent: :destroy
+
   attr_accessor :impersonating
 
   validates :email, presence: true, uniqueness: true


### PR DESCRIPTION
Aujourd'hui, lorsqu'on supprime une commune qui n'a pas d'objets lors de l'import, une erreur apparaît si des codes de connexion existent encore en base.

Cette PR corrige le problème en supprimant en même temps que la commune.