### PR TITLE
Correctif de la manipulation de photos dans les exports Mémoire

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -9,13 +9,13 @@ module Admin
         unless %w[90 -90].include?(params[:degrees])
 
       @attachment.rotate!(degrees: params[:degrees].to_i)
-      render partial: "admin/exports/memoires/photo", locals: { photo: @attachment }
+      render partial: "admin/exports/memoire/photo", locals: { photo: @attachment }
     end
 
     def exportable
       @attachment.update!(exportable: params[:exportable] == "true")
 
-      render partial: "admin/exports/memoires/photo", locals: { photo: @attachment }
+      render partial: "admin/exports/memoire/photo", locals: { photo: @attachment }
     end
 
     def destroy


### PR DESCRIPTION
La rotation et le marquage en "non exportable" d'une photo dans un export Mémoire ne fonctionnaient plus.

![Screenshot 2024-09-16 at 13 24 47](https://github.com/user-attachments/assets/164dbd9f-947c-442c-9b74-dce370f9872b)

Il s'agissait d'un mauvais path de partial suite à la ré organisation des fichiers lors de l'ajout de l'export des objets manquants et déplacés.
