### PR TITLE
Permettre aux communes de se connecter avec un code deja utilisé

### DIFF
--- a/app/controllers/admin/session_codes_controller.rb
+++ b/app/controllers/admin/session_codes_controller.rb
@@ -4,9 +4,7 @@ module Admin
   class SessionCodesController < BaseController
     def index
       @total = SessionCode.count
-      @limit = 10
-      @offset = params.fetch(:offset, 0).to_i
-      @session_codes = SessionCode.includes(:commune).order(created_at: :desc).limit(@limit).offset(@offset * @limit)
+      @pagy, @session_codes = pagy SessionCode.includes(:commune).order(created_at: :desc), limit: 10
     end
 
     private

--- a/app/models/session_authentication.rb
+++ b/app/models/session_authentication.rb
@@ -9,7 +9,7 @@ class SessionAuthentication
   validates :email, presence: true
   validates :code, presence: true
   validates :user, presence: { message: "Aucun utilisateur trouvé pour cet email" }
-  validate :validate_code_format, :validate_codes_match, :validate_code_not_expired, :validate_code_not_used
+  validate :validate_code_format, :validate_codes_match, :validate_code_not_expired
 
   def initialize(email, code)
     @email = email.to_s.strip
@@ -64,14 +64,6 @@ class SessionAuthentication
       message: "Code de connexion incorrect. " \
                "Vérifiez que vous avez bien recopié le code et qu’il provient bien du dernier mail envoyé."
     )
-  end
-
-  def validate_code_not_used
-    return if errors.any?
-
-    return unless session_code.used?
-
-    errors.add :code, :used, message: "Code de connexion déjà utilisé"
   end
 
   def validate_code_not_expired

--- a/app/models/session_code.rb
+++ b/app/models/session_code.rb
@@ -9,7 +9,7 @@ class SessionCode < ApplicationRecord
 
   scope :used, -> { where.not(used_at: nil) }
   scope :unused, -> { where(used_at: nil) }
-  scope :valid, -> { unused.where(created_at: EXPIRE_AFTER.ago..) }
+  scope :valid, -> { where(created_at: EXPIRE_AFTER.ago..) }
   scope :expired, -> { where(created_at: ..EXPIRE_AFTER.ago) }
   scope :outdated, -> { where(created_at: ..1.month.ago) }
 

--- a/app/views/admin/session_codes/_session_codes.haml
+++ b/app/views/admin/session_codes/_session_codes.haml
@@ -22,18 +22,4 @@
               %td.text-center= session_code.used? ? "Oui" : "Non"
               %td.text-end= l session_code.valid_until, format: :long
 
-    .co-pagination-wrapper
-      %nav.fr-pagination{role: :navigation, "aria-label": "Pagination"}
-        %ul.fr-pagination__list
-          %li
-            - if offset.positive?
-              = link_to "Codes plus récents", url_for(offset: offset - 1), role: :link, class: "fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label", "data-turbo-action": :restore
-            - else
-              %a.fr-pagination__link.fr-pagination__link--prev.fr-pagination__link--lg-label Codes plus récents
-            %li
-              %a{class: "fr-pagination__link", "aria-current": :page, title: "Page #{offset}"}= offset
-          %li
-            - if limit * (offset + 1) < total
-              = link_to "Codes plus anciens", url_for(offset: offset + 1), role: :link, class: "fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label", "data-turbo-action": :advance
-            - else
-              %a.fr-pagination__link.fr-pagination__link--next.fr-pagination__link--lg-label Codes plus anciens
+    = render "shared/pagy_nav", pagy: @pagy if @pagy.pages > 1

--- a/app/views/admin/session_codes/index.html.haml
+++ b/app/views/admin/session_codes/index.html.haml
@@ -33,4 +33,4 @@
               %td.text-end= @total
               %td.text-end 100 %
     .fr-col-md-8
-      = render "session_codes", session_codes: @session_codes, offset: @offset, limit: @limit, total: @total
+      = render "session_codes", session_codes: @session_codes

--- a/spec/models/session_authentication_spec.rb
+++ b/spec/models/session_authentication_spec.rb
@@ -110,23 +110,6 @@ RSpec.describe SessionAuthentication do
       end
     end
 
-    context "code is used" do
-      let(:used) { true }
-      let(:email) { "jean@delafontaine.fr" }
-      let(:code) { "123456" }
-
-      it { should eq false }
-      it "should not yield" do
-        expect { |b| session_authentication.authenticate(&b) }.not_to(yield_control)
-      end
-      it "should have used code error" do
-        subject
-        error = session_authentication.errors.first
-        expect(error).to have_attributes(attribute: :code, type: :used)
-        expect(session_authentication.error_message).to eq "Code de connexion déjà utilisé"
-      end
-    end
-
     context "codes mismatch" do
       let(:email) { "jean@delafontaine.fr" }
       let(:code) { "654321" }


### PR DESCRIPTION
Les codes de connexion des communes sont valables 24h… Mais expirent dès qu'on se connecte, ce qui n'est pas évident pour les communes. Une fois que les utilisateurs se sont déconnectés, ils doivent redemander un code.
Cette PR permet d'utiliser un code pour se connecter autant de fois qu'on veut tant qu'il est valide.

C'est ce qui explique qu'une même commune puisse avoir plusieurs codes générés dans la même journée, alors qu'ils sont sensés être valides durant 24h.

Au passage, j'ai corrigé l'affichage de la pagination des codes de connexion côté admin (le premier écran affichait 0, alors qu'on s'attend plutôt à commencer à 1).