### PR TITLE
Mise à jour des bordereaux de récolement

### DIFF
--- a/app/controllers/conservateurs/bordereaux_controller.rb
+++ b/app/controllers/conservateurs/bordereaux_controller.rb
@@ -6,7 +6,7 @@ module Conservateurs
     skip_after_action :verify_policy_scoped, only: :index
 
     def index
-      @edifices = @commune.edifices.with_objets_classés_ou_inscrits.ordered_by_nom
+      @edifices = @commune.edifices.with_objets_classés_ou_inscrits.ordered_by_nom.includes(bordereau_attachment: :blob)
     end
 
     def create

--- a/app/controllers/conservateurs/bordereaux_controller.rb
+++ b/app/controllers/conservateurs/bordereaux_controller.rb
@@ -3,8 +3,9 @@
 module Conservateurs
   class BordereauxController < BaseController
     before_action :set_commune, :set_dossier
+    skip_after_action :verify_policy_scoped, only: :index
 
-    def new
+    def index
       @edifices = @commune.edifices.with_objets_classés_ou_inscrits.ordered_by_nom
     end
 
@@ -19,7 +20,7 @@ module Conservateurs
 
       respond_to do |format|
         format.html do
-          redirect_to new_conservateurs_commune_bordereau_path(@commune),
+          redirect_to conservateurs_commune_bordereaux_path(@commune),
                       notice: "Le bordereau est en cours de génération …"
         end
         format.turbo_stream

--- a/app/controllers/conservateurs/bordereaux_controller.rb
+++ b/app/controllers/conservateurs/bordereaux_controller.rb
@@ -9,7 +9,7 @@ module Conservateurs
     end
 
     def create
-      @edifice = Edifice.find(params[:edifice_id])
+      @edifice = Edifice.find(params[:edifice])
       raise unless @edifice.commune == @dossier.commune
 
       @edifice.bordereau&.purge

--- a/app/helpers/conservateur_helper.rb
+++ b/app/helpers/conservateur_helper.rb
@@ -7,7 +7,7 @@ module ConservateurHelper
       tab.new(:analyse, "Recensement", conservateurs_commune_path(commune)),
       tab.new(:messagerie, commune_messagerie_title(commune), conservateurs_commune_messages_path(commune)),
       tab.new(:rapport, "Examen", conservateurs_commune_dossier_path(commune)),
-      tab.new(:bordereau, "Bordereaux de récolement", new_conservateurs_commune_bordereau_path(commune)),
+      tab.new(:bordereaux, "Bordereaux de récolement", conservateurs_commune_bordereaux_path(commune)),
       if commune.archived_dossiers.any?
         tab.new(:historique, "Historique",
                 conservateurs_commune_historique_path(commune))

--- a/app/jobs/generate_bordereau_pdf_job.rb
+++ b/app/jobs/generate_bordereau_pdf_job.rb
@@ -10,10 +10,10 @@ class GenerateBordereauPdfJob < ApplicationJob
     # raise unless edifice.objets.classés.count.positive?
     raise unless dossier.accepted?
 
-    prawn_doc = Bordereau::Pdf.new(dossier, edifice).build_prawn_doc
+    pdf = Bordereau::Pdf.new(dossier, edifice)
     edifice.bordereau.attach \
-      io: StringIO.new(prawn_doc.render),
-      filename: "bordereau-#{dossier.commune.to_s.parameterize}-#{edifice.nom.parameterize}.pdf",
-      content_type: "application/pdf"
+      io: pdf.to_io,
+      filename: pdf.filename,
+      content_type: Mime[:pdf]
   end
 end

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -32,35 +32,11 @@ module Bordereau
       setup_fonts
       define_grid(columns: 5, rows: 8, gutter: 0)
 
-      # Partie en haut à gauche avec les logos
-      grid([0, 0], [1, 0]).bounding_box do
-        image Rails.root.join("prawn_assets/logo-ministere-culture.png"), width: 100
-        move_down 20
-        image Rails.root.join("prawn_assets/logo-monument-historique.png"), width: 100
-      end
-      # Partie en haut et centrée avec les titres
-      grid([0, 1], [1, 3]).bounding_box do
-        text "Direction régionale des affaires culturelles", align: :center, style: :bold, size: 10
-        move_down 2
-        text "Conservation des antiquités et objets d’art".upcase, align: :center, style: :bold, size: 10
-        stroke_horizontal_rule
-        move_down 10
-        text "Bordereau de récolement des objets mobilier".upcase, align: :center, style: :bold, size: 14
-        move_down 10
-        text "Département : #{dossier.departement}", align: :center
-        move_down 5
-        text "Commune de : #{dossier.commune.nom}", align: :center
-        move_down 5
-        text "Édifice : #{edifice.nom.upcase_first}", align: :center
-        # TODO: Ajouter l'adresse récupérée lors de l'import depuis Palissy
-      end
+      add_logos
+      add_header
 
       recensements_objets_classés = recensements_des_objets_de_l_edifice_typés("classés")
       if recensements_objets_classés.present?
-        # Liste des objets classés
-        text "Récolement des objets classés de l'édifice #{edifice.nom}", align: :center, style: :bold
-        move_down 10
-
         ajout_table_objets_recensés(recensements_objets_classés)
 
         # Page de signature
@@ -120,8 +96,42 @@ module Bordereau
         ajout_table_objets_recensés(recensements_objets_inscrits)
       end
 
-      # Mentions légales (remplissent une page entière en taille 10)
-      start_new_page
+      add_legalese
+
+      # Les pages générées après `number_pages` ne sont pas numérotées
+      number_pages "<page>/<total>", at: [bounds.right - 150, 0], align: :right
+
+      document
+    end
+
+    def add_logos
+      grid([0, 0], [1, 0]).bounding_box do
+        image Rails.root.join("prawn_assets/logo-ministere-culture.png"), width: 100
+        move_down 20
+        image Rails.root.join("prawn_assets/logo-monument-historique.png"), width: 100
+      end
+    end
+
+    def add_header
+      grid([0, 1], [1, 3]).bounding_box do
+        text "Direction régionale des affaires culturelles", align: :center, style: :bold, size: 10
+        move_down 2
+        text "Conservation des antiquités et objets d’art".upcase, align: :center, style: :bold, size: 10
+        stroke_horizontal_rule
+        move_down 10
+        text "Bordereau de récolement des objets mobilier".upcase, align: :center, style: :bold, size: 14
+        move_down 10
+        text "Département : #{dossier.departement}", align: :center
+        move_down 5
+        text "Commune de : #{dossier.commune.nom}", align: :center
+        move_down 5
+        text "Édifice : #{edifice.nom.upcase_first}", align: :center
+        # TODO: Ajouter l'adresse récupérée lors de l'import depuis Palissy
+      end
+    end
+
+    def add_legalese
+      start_new_page # On remplit une page entière en taille 10
       text <<~TEXT, inline_format: true, size: 10
         <b>Références législatives et réglementaires dans le code du patrimoine</b>
 
@@ -148,11 +158,6 @@ module Bordereau
         Le préfet de région dresse une liste des objets mobiliers inscrits de la région qui contient les mêmes renseignements que ceux énumérés à l'article R.622-9.
         Un exemplaire de cette liste, tenue à jour, est déposé au ministère chargé de la culture, à la direction régionale des affaires culturelles et auprès du conservateur des antiquités et des objets d'art.
       TEXT
-
-      # Les pages générées après `number_pages` ne sont pas numérotées
-      number_pages "<page>/<total>", at: [bounds.right - 150, 0], align: :right
-
-      document
     end
 
     # TODO: À refacto dans un modèle (Recensement ou Objet)

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -77,7 +77,7 @@ module Bordereau
     def add_signatures
       start_new_page
       define_grid(columns: 5, rows: 8, gutter: 0)
-      text "Participants au récolement¹ :", style: :bold
+      text "Participants au récolement :", style: :bold
       move_down 20
       text <<~TEXT, inline_format: true
         Les soussignés (<i>nom, prénom en toutes lettres, fonction et signature</i>) certifient que les objets mobiliers ou immeubles par destination portés au present etat figurent dans l’édifice «#{edifice.nom}», #{commune}, lors du récolement en date du #{ellipsis}
@@ -88,8 +88,8 @@ module Bordereau
       table \
         [
           [
-            "<i>Le propriétaire² ou son représentant,</i>",
-            "<i>L’affectataire³,</i>",
+            "<i>Le propriétaire ou son représentant,</i>",
+            "<i>L’affectataire¹,</i>",
             "<i>Le Conservateur des Antiquités et Objets d’Art,</i>"
           ]
         ],
@@ -112,9 +112,7 @@ module Bordereau
       grid([7, 0], [7, 4]).bounding_box do
         move_down 20
         text <<~TEXT, size: 8
-          1    Le cas échéant, indiquer les autres personnes présentes participant au récolement.
-          2    Le propriétaire peut être une personne publique ou privée. Préciser, s’il y a lieu, l’affectataire domanial.
-          3    Pour les biens affectés au culte au sens de la loi du 9 décembre 1905 concernant la séparation des Églises et de l’État.
+          1    Pour les biens affectés au culte au sens de la loi du 9 décembre 1905 concernant la séparation des Églises et de l’État.
         TEXT
       end
     end

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -177,11 +177,10 @@ module Bordereau
                        "<b>Dénomination</b>",
                        "<b>Date de protection</b>",
                        "<b>Etat de conservation</b>",
-                       "<b>Observations du conservateur</b>",
-                       "<b>Observations sur le terrain</b>",
+                       "<b>Observations</b>",
                        "<b>Photographie</b>"
                      ])
-      table(lignes, column_widths: [75, 122, 122, 122, 122, 122, 75],
+      table(lignes, column_widths: [75, 122, 122, 122, 244, 75],
                     cell_style: { size: 8, border_color: "CCCCCC", inline_format: true },
                     header: true)
     end

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -165,7 +165,7 @@ module Bordereau
                        "<b>Observations</b>",
                        "<b>Photographie</b>"
                      ])
-      table(lignes, column_widths: [75, 122, 122, 122, 244, 75],
+      table(lignes, column_widths: [75, 110, 75, 75, 350, 75],
                     cell_style: { size: 8, border_color: "CCCCCC", inline_format: true },
                     header: true)
     end

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -120,6 +120,35 @@ module Bordereau
         ajout_table_objets_recensés(recensements_objets_inscrits)
       end
 
+      # Mentions légales (remplissent une page entière en taille 10)
+      start_new_page
+      text <<~TEXT, inline_format: true, size: 10
+        <b>Références législatives et réglementaires dans le code du patrimoine</b>
+
+        <b>Article L.622-8</b>
+        Il est procédé, par l'autorité administrative, au moins tous les cinq ans, au récolement des objets mobiliers classés au titre des monuments historiques.
+        En outre, les propriétaires ou détenteurs de ces objets sont tenus, lorsqu'ils en sont requis, de les présenter aux agents accrédités par l'autorité administrative.
+
+        <b>Article R.622-9</b>
+        La liste générale des objets mobiliers et des ensembles historiques mobiliers classés, établie et publiée par le ministère chargé de la culture, comprend :
+        1° La dénomination ou la désignation et les principales caractéristiques de ces objets et ensembles historiques mobiliers ;
+        2° L'indication de l'immeuble et de la commune où ils sont conservés, et, le cas échéant, de la servitude de maintien dans les lieux attachés à l'objet mobilier ou à l'ensemble historique mobilier concerné. Toutefois, si l'objet mobilier ou l'ensemble historique mobilier appartient à un propriétaire privé, celui-ci peut demander que seule l'indication du département soit mentionnée ;
+        3° La qualité de personne publique ou privée de leur propriétaire et, s'il y a lieu, l'affectataire domanial ;
+        4° La date de la décision de classement.
+
+        <b>Article R.622-24</b>
+        La présentation des objets mobiliers classés, faite à la demande des services de l’État chargés des monuments historiques en application du deuxième alinéa de l'article L.622-8, s'effectue sur leur lieu habituel de conservation. Toutefois, les propriétaires, affectataires, détenteurs ou dépositaires de ces objets peuvent demander que cette présentation s'effectue dans un autre lieu.
+        Le contrôle sur place des biens protégés s'effectue en présence du propriétaire, de l'affectataire ou de leur représentant. En cas d'absence, il s'effectue avec leur accord.
+
+        <b>Article R.622-25</b>
+        Le conservateur des antiquités et des objets d'art procède au moins tous les cinq ans au récolement des objets mobiliers classés.
+        Le préfet du département accrédite les agents auxquels les propriétaires ou détenteurs de ces objets sont tenus, en application du second alinéa de l'article L.622-8, de les présenter.
+
+        <b>Article R.622-38</b>
+        Le préfet de région dresse une liste des objets mobiliers inscrits de la région qui contient les mêmes renseignements que ceux énumérés à l'article R.622-9.
+        Un exemplaire de cette liste, tenue à jour, est déposé au ministère chargé de la culture, à la direction régionale des affaires culturelles et auprès du conservateur des antiquités et des objets d'art.
+      TEXT
+
       # Les pages générées après `number_pages` ne sont pas numérotées
       number_pages "<page>/<total>", at: [bounds.right - 150, 0], align: :right
 

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -120,6 +120,9 @@ module Bordereau
         ajout_table_objets_recensés(recensements_objets_inscrits)
       end
 
+      # Les pages générées après `number_pages` ne sont pas numérotées
+      number_pages "<page>/<total>", at: [bounds.right - 150, 0], align: :right
+
       document
     end
 

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -10,12 +10,23 @@ module Bordereau
     def initialize(dossier, edifice)
       @dossier = dossier
       @edifice = edifice
+      build_prawn_doc
     end
 
     # Utilisé comme référence par Prawn::View
     def document
       @document ||= Prawn::Document.new page_layout: :landscape, page_size: "A4"
     end
+
+    def to_io
+      StringIO.new(document.render)
+    end
+
+    def filename
+      "bordereau-#{dossier.commune.to_s.parameterize}-#{edifice.nom.parameterize}.pdf"
+    end
+
+    private
 
     def build_prawn_doc
       setup_fonts
@@ -106,8 +117,6 @@ module Bordereau
 
       document
     end
-
-    private
 
     # TODO: À refacto dans un modèle (Recensement ou Objet)
     def recensements_des_objets_de_l_edifice_typés(niveau_de_protection)

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -93,7 +93,7 @@ module Bordereau
             "<b>L’affectataire¹,</b>
             <i>(nom et prénom en toutes lettres)</i>",
             "<b>Le Conservateur des Antiquités et Objets d’Art,</b>
-            <i>(nom et prénom en toutes lettres)</i>",
+            <i>(nom et prénom en toutes lettres)</i>"
           ]
         ],
         column_widths: [256, 240, 272],
@@ -168,8 +168,8 @@ module Bordereau
         "<b>Photographie</b>"
       ]]
       table(headers + recensements, column_widths: [75, 110, 75, 75, 350, 75],
-                    cell_style: { size: 8, border_color: "CCCCCC", inline_format: true },
-                    header: true)
+                                    cell_style: { size: 8, border_color: "CCCCCC", inline_format: true },
+                                    header: true)
     end
 
     def setup_fonts

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -38,49 +38,8 @@ module Bordereau
       recensements_objets_classés = recensements_des_objets_de_l_edifice_typés("classés")
       if recensements_objets_classés.present?
         ajout_table_objets_recensés(recensements_objets_classés)
-
-        # Page de signature
-        start_new_page
-        define_grid(columns: 5, rows: 8, gutter: 0)
-        text "Participants au récolement¹ :", style: :bold
-        move_down 20
-        text <<~TEXT, inline_format: true
-          Les soussignés (<i>nom, prénom en toutes lettres, fonction et signature</i>) certifient que les objets mobiliers ou immeubles par destination portés au present etat figurent dans l’édifice «#{edifice.nom}», #{commune}, lors du récolement en date du #{ellipsis}
-        TEXT
-        move_down 40
-        text "Fait à #{ellipsis}, le #{ellipsis}", align: :right
-        move_down 40
-        table \
-          [
-            [
-              "<i>Le propriétaire² ou son représentant,</i>",
-              "<i>L’affectataire³,</i>",
-              "<i>Le Conservateur des Antiquités et Objets d’Art,</i>"
-            ]
-          ],
-          column_widths: [256, 256, 256],
-          cell_style: { border_color: "FFFFFF", style: :italic, inline_format: true, size: 11 }
-
-        # Partie avec les signataires et destinataires
-        grid([6, 0], [6, 4]).bounding_box do
-          text "Diffusion du bordereau :", style: :bold, size: 10
-          text <<~TEXT, size: 8
-            Signataires du présent bordereau,
-            Préfecture du département, conservation des antiquités et objets d'art
-            Direction régionale des affaires culturelles - conservation régionale des monuments historiques
-            Direction générale des patrimoines et de l’architecture – Bureau de la conservation des monuments historiques mobiliers – Médiathèque du patrimoine et de la photographie
-          TEXT
-        end
-
-        # Légendes, notes de bas de page
-        grid([7, 0], [7, 4]).bounding_box do
-          move_down 20
-          text <<~TEXT, size: 8
-            1    Le cas échéant, indiquer les autres personnes présentes participant au récolement.
-            2    Le propriétaire peut être une personne publique ou privée. Préciser, s’il y a lieu, l’affectataire domanial.
-            3    Pour les biens affectés au culte au sens de la loi du 9 décembre 1905 concernant la séparation des Églises et de l’État.
-          TEXT
-        end
+        add_signatures
+        add_footnotes
       end
 
       # Page de la liste des objets inscrits
@@ -127,6 +86,51 @@ module Bordereau
         move_down 5
         text "Édifice : #{edifice.nom.upcase_first}", align: :center
         # TODO: Ajouter l'adresse récupérée lors de l'import depuis Palissy
+      end
+    end
+
+    def add_signatures
+      start_new_page
+      define_grid(columns: 5, rows: 8, gutter: 0)
+      text "Participants au récolement¹ :", style: :bold
+      move_down 20
+      text <<~TEXT, inline_format: true
+        Les soussignés (<i>nom, prénom en toutes lettres, fonction et signature</i>) certifient que les objets mobiliers ou immeubles par destination portés au present etat figurent dans l’édifice «#{edifice.nom}», #{commune}, lors du récolement en date du #{ellipsis}
+      TEXT
+      move_down 40
+      text "Fait à #{ellipsis}, le #{ellipsis}", align: :right
+      move_down 40
+      table \
+        [
+          [
+            "<i>Le propriétaire² ou son représentant,</i>",
+            "<i>L’affectataire³,</i>",
+            "<i>Le Conservateur des Antiquités et Objets d’Art,</i>"
+          ]
+        ],
+        column_widths: [256, 256, 256],
+        cell_style: { border_color: "FFFFFF", style: :italic, inline_format: true, size: 11 }
+
+      # Partie avec les signataires et destinataires
+      grid([6, 0], [6, 4]).bounding_box do
+        text "Diffusion du bordereau :", style: :bold, size: 10
+        text <<~TEXT, size: 8
+          Signataires du présent bordereau,
+          Préfecture du département, conservation des antiquités et objets d'art
+          Direction régionale des affaires culturelles - conservation régionale des monuments historiques
+          Direction générale des patrimoines et de l’architecture – Bureau de la conservation des monuments historiques mobiliers – Médiathèque du patrimoine et de la photographie
+        TEXT
+      end
+    end
+
+    def add_footnotes
+      grid([7, 0], [7, 4]).bounding_box do
+        move_down 20
+        text <<~TEXT, size: 8
+          1    Le cas échéant, indiquer les autres personnes présentes participant au récolement.
+          2    Le propriétaire peut être une personne publique ou privée. Préciser, s’il y a lieu, l’affectataire domanial.
+          3    Pour les biens affectés au culte au sens de la loi du 9 décembre 1905 concernant la séparation des Églises et de l’État.
+        TEXT
       end
     end
 

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -113,7 +113,9 @@ module Bordereau
 
     def add_footnotes
       grid([7, 0], [7, 4]).bounding_box do
-        move_down 20
+        move_down 30
+        stroke_horizontal_rule
+        move_down 10
         text <<~TEXT, size: 8
           1    Pour les biens affectés au culte au sens de la loi du 9 décembre 1905 concernant la séparation des Églises et de l’État.
         TEXT

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -35,25 +35,10 @@ module Bordereau
       add_logos
       add_header
 
-      recensements_objets_classés = recensements_des_objets_de_l_edifice_typés("classés")
-      if recensements_objets_classés.present?
-        ajout_table_objets_recensés(recensements_objets_classés)
-        add_signatures
-        add_footnotes
-      end
+      add_objects_table
 
-      # Page de la liste des objets inscrits
-      recensements_objets_inscrits = recensements_des_objets_de_l_edifice_typés("inscrits")
-      if recensements_objets_inscrits.present?
-        start_new_page if recensements_objets_classés.present?
-
-        text "Liste des objets inscrits de l'édifice #{edifice.nom}", align: :center, style: :bold, size: 12
-        text "Toutes les informations liées à ces objets figurent dans Collectif Objets " \
-             "et dans l'examen transmis par vos CMH et CAOA",
-             align: :center, size: 10
-        move_down(10)
-        ajout_table_objets_recensés(recensements_objets_inscrits)
-      end
+      add_signatures
+      add_footnotes
 
       add_legalese
 
@@ -165,16 +150,12 @@ module Bordereau
     end
 
     # TODO: À refacto dans un modèle (Recensement ou Objet)
-    def recensements_des_objets_de_l_edifice_typés(niveau_de_protection)
-      @dossier
-        .recensements
-        .joins(:objet)
-        .where(objets: { edifice_id: edifice.id })
-        .merge(niveau_de_protection == "classés" ? Objet.classés : Objet.inscrits)
-        .order('objets."palissy_REF"')
+    def recensements
+      @dossier.recensements.joins(:objet).where(objets: { edifice_id: edifice.id })
+        .order('objets."palissy_EMPL", objets."palissy_TICO"')
     end
 
-    def ajout_table_objets_recensés(recencements)
+    def add_objects_table
       lignes = recencements.map { RecensementRow.new(_1).to_a }
       lignes.prepend([
                        "<b>Référence Palissy</b>",

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -154,6 +154,7 @@ module Bordereau
     end
 
     def add_objects_table
+      move_down 20
       headers = [[
         "<b>Référence Palissy</b>",
         "<b>Dénomination</b>",

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -80,7 +80,7 @@ module Bordereau
       text "Participants au récolement :", style: :bold
       move_down 20
       text <<~TEXT, inline_format: true
-        Les soussignés (<i>nom, prénom en toutes lettres, fonction et signature</i>) certifient que les objets mobiliers ou immeubles par destination portés au present etat figurent dans l’édifice «#{edifice.nom}», #{commune}, lors du récolement en date du #{ellipsis}
+        Les soussignés certifient que les objets mobiliers ou immeubles par destination portés au present etat figurent dans l’édifice «#{edifice.nom}», #{commune}, lors du récolement en date du #{ellipsis}
       TEXT
       move_down 40
       text "Fait à #{ellipsis}, le #{ellipsis}", align: :right
@@ -88,13 +88,16 @@ module Bordereau
       table \
         [
           [
-            "<i>Le propriétaire ou son représentant,</i>",
-            "<i>L’affectataire¹,</i>",
-            "<i>Le Conservateur des Antiquités et Objets d’Art,</i>"
+            "<b>Le propriétaire ou son représentant,</b>
+            <i>(nom et prénom en toutes lettres)</i>",
+            "<b>L’affectataire¹,</b>
+            <i>(nom et prénom en toutes lettres)</i>",
+            "<b>Le Conservateur des Antiquités et Objets d’Art,</b>
+            <i>(nom et prénom en toutes lettres)</i>",
           ]
         ],
-        column_widths: [256, 256, 256],
-        cell_style: { border_color: "FFFFFF", style: :italic, inline_format: true, size: 11 }
+        column_widths: [256, 240, 272],
+        cell_style: { border_color: "FFFFFF", inline_format: true, size: 11 }
 
       # Partie avec les signataires et destinataires
       grid([6, 0], [6, 4]).bounding_box do

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -149,23 +149,22 @@ module Bordereau
       TEXT
     end
 
-    # TODO: À refacto dans un modèle (Recensement ou Objet)
     def recensements
       @dossier.recensements.joins(:objet).where(objets: { edifice_id: edifice.id })
         .order('objets."palissy_EMPL", objets."palissy_TICO"')
+        .map { RecensementRow.new(_1).to_a }
     end
 
     def add_objects_table
-      lignes = recencements.map { RecensementRow.new(_1).to_a }
-      lignes.prepend([
-                       "<b>Référence Palissy</b>",
-                       "<b>Dénomination</b>",
-                       "<b>Date de protection</b>",
-                       "<b>Etat de conservation</b>",
-                       "<b>Observations</b>",
-                       "<b>Photographie</b>"
-                     ])
-      table(lignes, column_widths: [75, 110, 75, 75, 350, 75],
+      headers = [[
+        "<b>Référence Palissy</b>",
+        "<b>Dénomination</b>",
+        "<b>Date de protection</b>",
+        "<b>Etat de conservation</b>",
+        "<b>Observations</b>",
+        "<b>Photographie</b>"
+      ]]
+      table(headers + recensements, column_widths: [75, 110, 75, 75, 350, 75],
                     cell_style: { size: 8, border_color: "CCCCCC", inline_format: true },
                     header: true)
     end

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -99,7 +99,6 @@ module Bordereau
         column_widths: [256, 240, 272],
         cell_style: { border_color: "FFFFFF", inline_format: true, size: 11 }
 
-      # Partie avec les signataires et destinataires
       grid([6, 0], [6, 4]).bounding_box do
         text "Diffusion du bordereau :", style: :bold, size: 10
         text <<~TEXT, size: 8

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -161,7 +161,7 @@ module Bordereau
       move_down 20
       headers = [[
         "<b>Référence Palissy</b>",
-        "<b>Dénomination</b>",
+        "<b>Objet</b>",
         "<b>Date de protection</b>",
         "<b>Etat de conservation</b>",
         "<b>Observations</b>",

--- a/app/models/bordereau/pdf.rb
+++ b/app/models/bordereau/pdf.rb
@@ -38,16 +38,21 @@ module Bordereau
         move_down 20
         image Rails.root.join("prawn_assets/logo-monument-historique.png"), width: 100
       end
-
       # Partie en haut et centrée avec les titres
       grid([0, 1], [1, 3]).bounding_box do
-        text "Direction régionale des affaires culturelles", align: :center, style: :bold
+        text "Direction régionale des affaires culturelles", align: :center, style: :bold, size: 10
+        move_down 2
+        text "Conservation des antiquités et objets d’art".upcase, align: :center, style: :bold, size: 10
+        stroke_horizontal_rule
         move_down 10
-        text "Conservation des antiquités et objets d’art", align: :center, style: :bold
+        text "Bordereau de récolement des objets mobilier".upcase, align: :center, style: :bold, size: 14
         move_down 10
         text "Département : #{dossier.departement}", align: :center
         move_down 5
         text "Commune de : #{dossier.commune.nom}", align: :center
+        move_down 5
+        text "Édifice : #{edifice.nom.upcase_first}", align: :center
+        # TODO: Ajouter l'adresse récupérée lors de l'import depuis Palissy
       end
 
       recensements_objets_classés = recensements_des_objets_de_l_edifice_typés("classés")

--- a/app/models/bordereau/recensement_row.rb
+++ b/app/models/bordereau/recensement_row.rb
@@ -12,8 +12,7 @@ module Bordereau
         nom,
         palissy_DPRO, # date de protection
         etat_sanitaire_cell,
-        recensement.analyse_notes,
-        observations_proprietaire_cell,
+        observations,
         photo_cell
       ]
     end
@@ -41,6 +40,15 @@ module Bordereau
       else
         etat_sanitaire
       end
+    end
+
+    def observations
+      [
+        "<b>Propriétaire :</b>",
+        observations_proprietaire_cell.presence || "Néant",
+        "<b>Conservateur :</b>",
+        recensement.analyse_notes.presence || "Néant",
+      ].join("\n")
     end
 
     def observations_proprietaire_cell

--- a/app/models/bordereau/recensement_row.rb
+++ b/app/models/bordereau/recensement_row.rb
@@ -9,7 +9,7 @@ module Bordereau
     def to_a
       [
         palissy_REF,
-        nom,
+        denomination_cell,
         palissy_DPRO, # date de protection
         etat_sanitaire_cell,
         observations,
@@ -26,8 +26,8 @@ module Bordereau
     delegate :palissy_REF, :palissy_DENO, :palissy_SCLE, :palissy_CATE, :palissy_DPRO, :nom, to: :objet
 
     def denomination_cell
-      materiaux = palissy_CATE ? palissy_CATE.split(";").compact_blank.join(", ") : ""
-      [palissy_DENO, palissy_SCLE, materiaux].compact_blank.join("\n")
+      materiaux = palissy_CATE ? palissy_CATE.split(";").compact_blank.join(", ").upcase_first : ""
+      [nom, palissy_SCLE, materiaux].compact_blank.join("\n")
     end
 
     def etat_sanitaire_cell

--- a/app/models/bordereau/recensement_row.rb
+++ b/app/models/bordereau/recensement_row.rb
@@ -44,8 +44,8 @@ module Bordereau
 
     def observations
       [
-        "<b>Propriétaire :</b>  " + observations_proprietaire_cell.presence || "Néant",
-        "<b>Conservateur :</b>  " + recensement.analyse_notes.presence || "Néant",
+        "<b>Propriétaire :</b>  #{observations_proprietaire_cell.presence || 'Néant'}",
+        "<b>Conservateur :</b>  #{recensement.analyse_notes.presence || 'Néant'}"
       ].join("\n")
     end
 

--- a/app/models/bordereau/recensement_row.rb
+++ b/app/models/bordereau/recensement_row.rb
@@ -44,10 +44,8 @@ module Bordereau
 
     def observations
       [
-        "<b>Propriétaire :</b>",
-        observations_proprietaire_cell.presence || "Néant",
-        "<b>Conservateur :</b>",
-        recensement.analyse_notes.presence || "Néant",
+        "<b>Propriétaire :</b>  " + observations_proprietaire_cell.presence || "Néant",
+        "<b>Conservateur :</b>  " + recensement.analyse_notes.presence || "Néant",
       ].join("\n")
     end
 

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -1,7 +1,7 @@
 -# locals: :edifice
 - commune = edifice.commune
 
-.co-flex.co-flex--align-items-center.co-flex--gap-1rem.fr-mb-2w{id: "bordereau-#{edifice.id}"}
+.d-md-flex.align-content-center.co-flex--gap-1rem.fr-mb-2w{id: "bordereau-#{edifice.id}"}
   %span
     = "#{edifice.nom.upcase_first} · #{texte_nombre_objets_protégés(edifice)}"
 

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -25,7 +25,7 @@
         La génération prend beaucoup de temps, il y a peut-être un problème.
   - else
     %span
-      = button_to "Générer",
+      = button_to "Générer le bordereau",
         conservateurs_commune_bordereaux_path(commune, edifice_id: edifice.id),
         method: :post,
         class: "fr-btn fr-btn--sm"

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -1,4 +1,5 @@
--# locals: :commune, :edifice
+-# locals: :edifice
+- commune = edifice.commune
 
 .co-flex.co-flex--align-items-center.co-flex--gap-1rem.fr-mb-2w{id: "bordereau-#{edifice.id}"}
   %span

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -9,7 +9,8 @@
     %span
       = link_to "Télécharger (PDF de #{number_to_human_size edifice.bordereau.byte_size})",
         rails_blob_path(edifice.bordereau, disposition: "attachment"),
-        class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-download-line"
+        class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-download-line",
+        title: "Bordereau de récolement · #{edifice.nom.upcase_first} (PDF de #{number_to_human_size edifice.bordereau.byte_size})"
     %span
       = button_to "Regénérer",
         conservateurs_commune_bordereaux_path(commune, edifice:),

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -2,7 +2,7 @@
 
 .co-flex.co-flex--align-items-center.co-flex--gap-1rem.fr-mb-2w{id: "bordereau-#{edifice.id}"}
   %span
-    = "#{edifice.nom} · #{texte_nombre_objets_protégés(edifice)}"
+    = "#{edifice.nom.upcase_first} · #{texte_nombre_objets_protégés(edifice)}"
 
   - if edifice.bordereau.present?
     %span

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -6,28 +6,24 @@
     = "#{edifice.nom.upcase_first} · #{texte_nombre_objets_protégés(edifice)}"
 
   - if edifice.bordereau.present?
-    %span
-      = link_to "Télécharger (PDF de #{number_to_human_size edifice.bordereau.byte_size})",
-        rails_blob_path(edifice.bordereau, disposition: "attachment"),
-        class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-download-line",
-        title: "Bordereau de récolement · #{edifice.nom.upcase_first} (PDF de #{number_to_human_size edifice.bordereau.byte_size})"
-    %span
-      = button_to "Regénérer",
-        conservateurs_commune_bordereaux_path(commune, edifice:),
-        method: :post,
-        class: "fr-btn fr-btn--sm fr-btn--secondary"
+    = link_to "Télécharger (PDF de #{number_to_human_size edifice.bordereau.byte_size})",
+      rails_blob_path(edifice.bordereau, disposition: "attachment"),
+      class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-download-line",
+      title: "Bordereau de récolement · #{edifice.nom.upcase_first} (PDF de #{number_to_human_size edifice.bordereau.byte_size})"
+    = button_to "Regénérer",
+      conservateurs_commune_bordereaux_path(commune, edifice:),
+      method: :post,
+      class: "fr-btn fr-btn--sm fr-btn--secondary"
   - elsif edifice.bordereau_generation_enqueued_at.present?
-    %span
-      = render DsfrComponent::BadgeComponent.new status: :info do
-        Génération en cours
+    = render DsfrComponent::BadgeComponent.new status: :info do
+      Génération en cours
     %span
       Veuillez rafraichir cette page d’ici quelques minutes.
     - if edifice.bordereau_generation_enqueued_at < 5.minutes.ago
       %span
         La génération prend beaucoup de temps, il y a peut-être un problème.
   - else
-    %span
-      = button_to "Générer le bordereau",
-        conservateurs_commune_bordereaux_path(commune, edifice:),
-        method: :post,
-        class: "fr-btn fr-btn--sm"
+    = button_to "Générer le bordereau",
+      conservateurs_commune_bordereaux_path(commune, edifice:),
+      method: :post,
+      class: "fr-btn fr-btn--sm"

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -12,7 +12,7 @@
         class: "fr-btn fr-btn--sm fr-btn--icon-left fr-icon-download-line"
     %span
       = button_to "Regénérer",
-        conservateurs_commune_bordereaux_path(commune, edifice_id: edifice.id),
+        conservateurs_commune_bordereaux_path(commune, edifice:),
         method: :post,
         class: "fr-btn fr-btn--sm fr-btn--secondary"
   - elsif edifice.bordereau_generation_enqueued_at.present?
@@ -27,6 +27,6 @@
   - else
     %span
       = button_to "Générer le bordereau",
-        conservateurs_commune_bordereaux_path(commune, edifice_id: edifice.id),
+        conservateurs_commune_bordereaux_path(commune, edifice:),
         method: :post,
         class: "fr-btn fr-btn--sm"

--- a/app/views/conservateurs/bordereaux/create.turbo_stream.erb
+++ b/app/views/conservateurs/bordereaux/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace "bordereau-#{@edifice.id}" do %>
-  <%= render "conservateurs/bordereaux/edifice", edifice: @edifice, commune: @commune %>
+  <%= render "conservateurs/bordereaux/edifice", edifice: @edifice %>
 <% end %>

--- a/app/views/conservateurs/bordereaux/index.html.haml
+++ b/app/views/conservateurs/bordereaux/index.html.haml
@@ -1,11 +1,11 @@
 = render layout: "conservateurs/communes/tabs",
-  locals: { commune: @commune, dossier: @dossier, current_tab: :bordereau } do
+  locals: { commune: @commune, dossier: @dossier, current_tab: :bordereaux } do
 
-  - if @dossier&.accepted? 
+  - if @dossier&.accepted?
     = dsfr_alert(type: :info, size: :sm, classes: ["fr-mb-4w"]) do
       %p
-        Vous pouvez générer des bordereaux de récolement pour les différents édifices de la commune. 
-        Les champs seront préremplis avec les données de recensement que vous avez précédemment examinées et acceptées. 
+        Vous pouvez générer des bordereaux de récolement pour les différents édifices de la commune.
+        Les champs seront préremplis avec les données de recensement que vous avez précédemment examinées et acceptées.
         %br
         En cas d’erreur pour les édifices, veuillez nous envoyer un mail à l’adresse : #{CONTACT_EMAIL}.
 

--- a/app/views/conservateurs/bordereaux/new.html.haml
+++ b/app/views/conservateurs/bordereaux/new.html.haml
@@ -14,9 +14,8 @@
         %span.fr-icon-warning-line(aria-hidden="true")
         Il n’y a aucun objet classé ou inscrit dans cette commune.
 
-    - else 
-      - @edifices.each do |edifice|
-        = render "conservateurs/bordereaux/edifice", edifice:
+    - else
+      = render partial: "conservateurs/bordereaux/edifice", collection: @edifices
   - else
     .co-readable
       %p

--- a/app/views/conservateurs/bordereaux/new.html.haml
+++ b/app/views/conservateurs/bordereaux/new.html.haml
@@ -8,8 +8,8 @@
         Les champs seront préremplis avec les données de recensement que vous avez précédemment examinées et acceptées. 
         %br
         En cas d’erreur pour les édifices, veuillez nous envoyer un mail à l’adresse : #{CONTACT_EMAIL}.
-    
-    - if @edifices.empty?
+
+    - if @edifices.load.empty?
       %p
         %span.fr-icon-warning-line(aria-hidden="true")
         Il n’y a aucun objet classé ou inscrit dans cette commune.

--- a/app/views/conservateurs/bordereaux/new.html.haml
+++ b/app/views/conservateurs/bordereaux/new.html.haml
@@ -16,7 +16,7 @@
 
     - else 
       - @edifices.each do |edifice|
-        = render "conservateurs/bordereaux/edifice", edifice:, commune: @commune
+        = render "conservateurs/bordereaux/edifice", edifice:
   - else
     .co-readable
       %p

--- a/app/views/conservateurs/departements/index.html.haml
+++ b/app/views/conservateurs/departements/index.html.haml
@@ -12,6 +12,6 @@
           = link_to(departement, conservateurs_departement_path(departement))
           %br/
           %span.fr-text--sm
-            = "#{departement.objets_count} objets protégés dans #{departement.communes_count} communes"
+            = "#{number_with_delimiter departement.objets_count} objets protégés dans #{departement.communes_count} communes"
   .fr-my-4w
     = link_to t("conservateurs.departements.index.contact"), "mailto:support@collectif-objets.beta.gouv.fr"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -784,3 +784,7 @@ fr:
       last_word_connector: " et "
       two_words_connector: " et "
       words_connector: ", "
+  number:
+    format:
+      delimiter: " "
+      separator: ","

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,7 +113,7 @@ Rails.application.routes.draw do
       end
       resource :dossier, only: :show
       get :historique, as: :historique, to: "dossiers#historique"
-      resources :bordereaux, only: %i[new create]
+      resources :bordereaux, only: %i[index create]
       resource :deleted_recensements, only: [:show]
     end
     resources :objets, only: [] do

--- a/spec/features/conservateurs_pages_spec.rb
+++ b/spec/features/conservateurs_pages_spec.rb
@@ -112,7 +112,7 @@ feature "Conservateurs", js: true do
 
   describe "communes/1/bordereaux/new" do
     let(:dossier) { create(:dossier, :accepted, commune:, conservateur:) }
-    let(:path) { new_conservateurs_commune_bordereau_path(dossier.commune) }
+    let(:path) { conservateurs_commune_bordereaux_path(dossier.commune) }
     it_behaves_like "an accessible page"
   end
 

--- a/spec/models/bordereau/pdf_spec.rb
+++ b/spec/models/bordereau/pdf_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Bordereau::Pdf" do
     # TODO: add mocked photos
 
     it "does not raise" do
-      expect { Bordereau::Pdf.new(dossier, edifice).build_prawn_doc }.not_to raise_error
+      expect { Bordereau::Pdf.new(dossier, edifice) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
À la demande des CAOA, les bordereaux de récolement ont été modifiés : 
- [x] Modification de l'en-tête du document
- [x] Modification des colonnes du tableau (largeur, contenu, intitulés)
- [x] Modification des notes de bas de page
- [x] Affichage de la page signature, peu importe le statut des objets listés (protégés/classés) 
- [x] Ajout de mentions légales
- [x] Ajout de numéros de pages

Au passage, quelques améliorations de l'interface et du code :
- [x] Amélioration de la lisibilité des grands nombres (999+) selon les règles de français
- [x] Amélioration de l'accessibilité des liens de téléchargement
- [x] Modification de la route (`index` plutôt que `new` pour être plus RESTful)
- [x] Amélioration des performances SQL (préchargement, suppression de requêtes inutiles)
- [x] Optimisation de la génération des pages (passage d'une collection au partiel)
- [x] Réorganisation du code de génération des PDFs pour faciliter sa lecture et sa modification