### PR TITLE
Simplifier la gestion des codes de connexion par les admins

### DIFF
--- a/app/controllers/admin/communes_controller.rb
+++ b/app/controllers/admin/communes_controller.rb
@@ -15,6 +15,13 @@ module Admin
       @messages = Message.where(commune: @commune).order(created_at: :asc)
     end
 
+    def session_code
+      @commune = Commune.find(params[:id])
+      user = @commune.users.first
+      @session_code = user.session_code || user.create_session_code
+      redirect_to [:admin, @commune]
+    end
+
     private
 
     def active_nav_links = %w[Communes]

--- a/app/controllers/admin/session_codes_controller.rb
+++ b/app/controllers/admin/session_codes_controller.rb
@@ -4,9 +4,8 @@ module Admin
   class SessionCodesController < BaseController
     def index
       @total = SessionCode.count
-      @limit = 10
-      @offset = params.fetch(:offset, 0).to_i
-      @session_codes = SessionCode.includes(:commune).order(created_at: :desc).limit(@limit).offset(@offset * @limit)
+      @pagy, @session_codes = pagy SessionCode.includes(:commune).order(created_at: :desc), limit: 10
+      @search = Commune.ransack(params[:nom])
     end
 
     private

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -30,6 +30,17 @@
       - if user || @commune.departement.conservateurs.load.any?
         .co-flex.co-flex--wrap.co-flex--gap-05rem
           - if user
+            - if session_code = user.session_code
+              = link_to "Code de connexion #{session_code.code}",
+                new_user_session_path(email: user.email, code: session_code.code),
+                id: dom_id(@commune, :session_code),
+                class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-user-star-line co-width-md-40",
+                title: "Code #{session_code.code}, valable jusqu'à #{l session_code.valid_until, format: :long}"
+            - else
+              = button_to "Générer un code de connexion",
+                session_code_admin_commune_path,
+                id: dom_id(@commune, :session_code),
+                form_class: "co-width-md-40", class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line w-100"
             = link_to "Incarner la commune",
               admin_user_impersonate_path(user),
               class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-warning-line co-width-md-40"

--- a/app/views/admin/session_codes/index.html.haml
+++ b/app/views/admin/session_codes/index.html.haml
@@ -32,5 +32,13 @@
               %th Total des codes
               %td.text-end= @total
               %td.text-end 100 %
+      %h2 Chercher une commune
+      = search_form_for @search, url: admin_communes_path, method: :get, builder: FormBuilderDsfr do |f|
+        .fr-input-group
+          = f.label :nom_unaccented_cont, "Nom de commune", class: "fr-mb-1w"
+          .co-flex
+            = f.text_field :nom_unaccented_cont
+            %button.fr-btn.fr-btn--tertiary.fr-icon-search-line{ aria: { label: "Chercher" } }
+
     .fr-col-md-8
       = render "session_codes", session_codes: @session_codes, offset: @offset, limit: @limit, total: @total

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,7 +144,9 @@ Rails.application.routes.draw do
   ## -----
 
   namespace :admin do
-    resources :communes, only: %i[index show]
+    resources :communes, only: %i[index show] do
+      post :session_code, on: :member
+    end
     resources :conservateurs, except: [:destroy] do
       get :impersonate
       collection do


### PR DESCRIPTION
Puisque les emails mettent parfois longtemps à arriver, ou finissent en spam voire silencieusement avalés par les filtres anti-spam, on simplifie un peu plus la gestion des codes de connexion pour les admins.

- Le code de connexion courant est désormais affiché sur la page admin de la commune.
- S'il n'y a pas de code, le bouton permet d'en générer un, et l'affiche dans la page.
- Si on clique sur le bouton qui contient le code, on arrive sur la page de connexion de la commune, avec le code préremplit. Il n'y a plus qu'à copier-coller dans un mail pour la commune, ou à leur dicter au téléphone.
- Un mini moteur de recherche permet de chercher une commune depuis la liste des codes de connexion.