### PR TITLE
Mise à jour de Rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.0.11)
+    rack (3.1.8)
     rack-proxy (0.7.6)
       rack
     rack-session (2.0.0)

--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -7,7 +7,7 @@ module Admin
       if comment.save
         redirect_to [:admin, comment.resource], notice: "commentaire créé !"
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/admin/conservateurs_controller.rb
+++ b/app/controllers/admin/conservateurs_controller.rb
@@ -24,7 +24,7 @@ module Admin
       if @conservateur.save
         redirect_to edit_admin_conservateur_path(@conservateur), notice: "Conservateur créé !"
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 
@@ -33,7 +33,7 @@ module Admin
       if @conservateur.update(conservateur_params)
         redirect_to edit_admin_conservateur_path(@conservateur), notice: "Conservateur modifié !"
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/communes/campaign_recipients_controller.rb
+++ b/app/controllers/communes/campaign_recipients_controller.rb
@@ -8,7 +8,7 @@ module Communes
       if @recipient.update(recipient_params)
         redirect_to edit_user_registration_path, notice: "Vos préférences de communication ont été mises à jour"
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/communes/completions_controller.rb
+++ b/app/controllers/communes/completions_controller.rb
@@ -14,7 +14,7 @@ module Communes
       if @dossier_completion.create!(**dossier_completion_params)
         redirect_to commune_objets_path(@commune), notice: "Le recensement de votre commune est terminé !"
       else
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/communes/recensements_controller.rb
+++ b/app/controllers/communes/recensements_controller.rb
@@ -30,7 +30,7 @@ module Communes
       if @wizard.update(params_wizard)
         redirect_to @wizard.after_success_path
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 
@@ -40,7 +40,7 @@ module Communes
           commune_objet_path(@recensement.commune, @recensement.objet),
           success: "Recensement supprimé"
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/communes/users_controller.rb
+++ b/app/controllers/communes/users_controller.rb
@@ -7,7 +7,7 @@ module Communes
       if current_user.update(user_params)
         redirect_to edit_user_registration_path, notice: success_notice
       else
-        render "users/registrations/edit", status: :unprocessable_entity
+        render "users/registrations/edit", status: :unprocessable_content
       end
     end
 

--- a/app/controllers/concerns/campaign_recipients_controller_concern.rb
+++ b/app/controllers/concerns/campaign_recipients_controller_concern.rb
@@ -13,7 +13,7 @@ module CampaignRecipientsControllerConcern
       redirect_to send("#{routes_prefix}_campaign_recipient_path", @recipient.campaign, @recipient),
                   notice: "Destinataire mis à jour"
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/concerns/campaigns_controller_concern.rb
+++ b/app/controllers/concerns/campaigns_controller_concern.rb
@@ -31,7 +31,7 @@ module CampaignsControllerConcern
       redirect_to send("#{routes_prefix}_campaign_edit_recipients_path", @campaign),
                   notice: "La campagne a été créée avec succès, elle peut être configurée"
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -39,7 +39,7 @@ module CampaignsControllerConcern
     if @campaign.update campaign_params_sanitized
       redirect_to send("#{routes_prefix}_campaign_path", @campaign), notice: "La campagne a été modifiée"
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -50,7 +50,7 @@ module CampaignsControllerConcern
   rescue ActiveRecord::RecordInvalid => e
     @communes_ids = params_recipient_commune_ids
     render :edit_recipients,
-           status: :unprocessable_entity,
+           status: :unprocessable_content,
            alert: "#{e.record.commune.nom} : #{e.record.errors.first.message}"
   end
 
@@ -58,7 +58,7 @@ module CampaignsControllerConcern
     if @campaign.aasm.fire! params.require(:campaign).require(:status_event)
       redirect_to send("#{routes_prefix}_campaign_path", @campaign), notice: "La campagne a été modifiée"
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 
@@ -67,7 +67,7 @@ module CampaignsControllerConcern
       redirect_to after_destroy_path, status: :see_other, notice: "Le brouillon de campagne a été supprimé"
     else
       @campaign.errors.add(:base, "Impossible de supprimer ce brouillon de campagne")
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/concerns/messages_controller_concern.rb
+++ b/app/controllers/concerns/messages_controller_concern.rb
@@ -35,6 +35,6 @@ module MessagesControllerConcern
   def render_index_after_create_error
     set_messages
     @new_message = @message
-    render :index, status: :unprocessable_entity
+    render :index, status: :unprocessable_content
   end
 end

--- a/app/controllers/conservateurs/accepts_controller.rb
+++ b/app/controllers/conservateurs/accepts_controller.rb
@@ -11,7 +11,7 @@ module Conservateurs
         UserMailer.with(dossier: @dossier).dossier_accepted_email.deliver_now
         redirect_to conservateurs_commune_path(@commune), notice: "L'examen a été envoyé à la commune"
       else
-        render "conservateurs/accepts/new", status: :unprocessable_entity
+        render "conservateurs/accepts/new", status: :unprocessable_content
       end
     end
 

--- a/app/controllers/conservateurs/analyses_controller.rb
+++ b/app/controllers/conservateurs/analyses_controller.rb
@@ -10,7 +10,7 @@ module Conservateurs
       if @recensement.update(analyse_recensement_params)
         redirect_to conservateurs_commune_path(@objet.commune, analyse_saved: true)
       else
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       end
     end
 

--- a/app/controllers/conservateurs/conservateurs_controller.rb
+++ b/app/controllers/conservateurs/conservateurs_controller.rb
@@ -7,7 +7,7 @@ module Conservateurs
       if current_conservateur.update(conservateur_params)
         redirect_to edit_conservateur_registration_path, notice: success_notice
       else
-        render "users/registrations/edit", status: :unprocessable_entity
+        render "users/registrations/edit", status: :unprocessable_content
       end
     end
 

--- a/app/controllers/survey_votes_controller.rb
+++ b/app/controllers/survey_votes_controller.rb
@@ -17,7 +17,7 @@ class SurveyVotesController < ApplicationController
       redirect_to @commune, notice: "Merci pour votre réponse !"
     else
       @commune = @survey_vote.commune
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,7 +13,7 @@ module Users
       success = @session_authentication.authenticate { sign_in(_1) }
       unless success
         @error = @session_authentication.error_message
-        return render(:new, status: :unprocessable_entity)
+        return render(:new, status: :unprocessable_content)
       end
 
       redirect_to after_sign_in_path_for(@session_authentication.user), notice: "Vous êtes maintenant connecté(e)"

--- a/spec/requests/recensement_wizard_spec.rb
+++ b/spec/requests/recensement_wizard_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Communes::RecensementsController, type: :request do
         let(:next_step_number) { 5 }
         it "affiche un message d'erreur" do
           perform_request
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
     end
@@ -240,7 +240,7 @@ RSpec.describe Communes::RecensementsController, type: :request do
           recensement.update_columns(status: :completed, autre_commune_code_insee: nil,
                                      localisation: Recensement::LOCALISATION_DEPLACEMENT_AUTRE_COMMUNE)
           perform_request
-          expect(response).to have_http_status :unprocessable_entity
+          expect(response).to have_http_status :unprocessable_content
         end
       end
     end


### PR DESCRIPTION
Les nouvelles versions de Rails utilisent une version plus récente de Rack.
Celle-ci a récemment renommé le code 422 `:unprocessable_content` (précédemment appelé `:unprocessable_entity`), suivant en cela la décision de la RFC HTTP officielle.

Cette PR corrige les tests dans #1365, #1366, et #1367.