### PR TITLE
Modifie le texte et les couleurs des statuts des communes

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,8 @@ Ci-dessous les étapes avec le détail des différents statuts en base de donné
 |-----|-------------|----------------|-----------------------------------------|----------------------------------------------------|
 | 1 | Non recensé  | `inactive`     | _aucun recensement_ <br>ou tous `draft` | _aucun dossier_  |
 | 2 | En cours de recensement        | `started`      | au moins un `completed`  | `construction` |
-| 3 | À examiner         | `completed`    | tous `completed`  | `submitted`|
-| 4 | Examen optionnel   | `completed`    | tous `completed` | `submitted`  et `replied_automatically_at` présent |
+| 3 | À examiner en priorité | `completed`    | tous `completed`  | `submitted`|
+| 4 | À examiner   | `completed`    | tous `completed` | `submitted`  et `replied_automatically_at` présent |
 | 5 | En cours d'examen  | `completed`    | au moins un `completed` et examiné | `submitted` |
 | 6 | Examiné  | `completed`    | tous `completed` et tous examinés  | `accepted` |
 | 7 | Non recensé  | `inactive`    | _aucun recensement_   | ancien dossier `archived`  |

--- a/app/components/conservateurs/objet_card_component.rb
+++ b/app/components/conservateurs/objet_card_component.rb
@@ -63,9 +63,9 @@ module Conservateurs
       if recensement&.analysed?
         badge_struct.new "success", "Examiné"
       elsif recensement&.prioritaire?
-        badge_struct.new "blue-ecume", "À examiner"
+        badge_struct.new "warning", "À examiner en priorité"
       else
-        badge_struct.new "green-emeraude", "Examen optionnel"
+        badge_struct.new "blue-ecume", "À examiner"
       end
     end
 

--- a/app/helpers/commune_helper.rb
+++ b/app/helpers/commune_helper.rb
@@ -26,7 +26,7 @@ module CommuneHelper
       ["Tout sélectionner", ""],
       [Commune::STATUT_GLOBAL_EXAMINÉ, Commune::ORDRE_EXAMINÉ],
       [Commune::STATUT_GLOBAL_EN_COURS_D_EXAMEN, Commune::ORDRE_EN_COURS_D_EXAMEN],
-      [Commune::STATUT_GLOBAL_EXAMEN_OPTIONNEL, Commune::ORDRE_EXAMEN_OPTIONNEL],
+      [Commune::STATUT_GLOBAL_EXAMEN_PRIORITAIRE, Commune::ORDRE_EXAMEN_PRIORITAIRE],
       [Commune::STATUT_GLOBAL_A_EXAMINER, Commune::ORDRE_A_EXAMINER],
       [Commune::STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT, Commune::ORDRE_EN_COURS_DE_RECENSEMENT],
       [Commune::STATUT_GLOBAL_NON_RECENSÉ, Commune::ORDRE_NON_RECENSÉ]
@@ -34,7 +34,7 @@ module CommuneHelper
   end
 
   def commune_statut_global_badge(commune, **options)
-    colors = ["", "", "green-emeraude", "blue-ecume", "blue-ecume", "success"]
+    colors = ["", "", "blue-ecume", "warning", "blue-ecume", "success"]
     content_tag(
       "p",
       commune.statut_global_texte,

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -105,10 +105,10 @@ class Commune < ApplicationRecord
   ORDRE_NON_RECENSÉ = 0
   STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT = "En cours de recensement"
   ORDRE_EN_COURS_DE_RECENSEMENT = 1
-  STATUT_GLOBAL_EXAMEN_OPTIONNEL = "Examen optionnel"
-  ORDRE_EXAMEN_OPTIONNEL = 2
   STATUT_GLOBAL_A_EXAMINER = "À examiner"
-  ORDRE_A_EXAMINER = 3
+  ORDRE_A_EXAMINER = 2
+  STATUT_GLOBAL_EXAMEN_PRIORITAIRE = "À examiner en priorité"
+  ORDRE_EXAMEN_PRIORITAIRE = 3
   STATUT_GLOBAL_EN_COURS_D_EXAMEN = "En cours d'examen"
   ORDRE_EN_COURS_D_EXAMEN = 4
   STATUT_GLOBAL_EXAMINÉ = "Examiné"
@@ -117,8 +117,8 @@ class Commune < ApplicationRecord
   STATUT_GLOBAUX = [
     STATUT_GLOBAL_NON_RECENSÉ,
     STATUT_GLOBAL_EN_COURS_DE_RECENSEMENT,
-    STATUT_GLOBAL_EXAMEN_OPTIONNEL,
     STATUT_GLOBAL_A_EXAMINER,
+    STATUT_GLOBAL_EXAMEN_PRIORITAIRE,
     STATUT_GLOBAL_EN_COURS_D_EXAMEN,
     STATUT_GLOBAL_EXAMINÉ
   ].freeze
@@ -139,11 +139,11 @@ class Commune < ApplicationRecord
     elsif dossier&.accepted?
       ORDRE_EXAMINÉ
     elsif dossier&.replied_automatically?
-      ORDRE_EXAMEN_OPTIONNEL
+      ORDRE_A_EXAMINER
     else # dossier.submitted?
       recensements_analysed_count = recensements.where.not(analysed_at: nil).count
       if recensements_analysed_count.zero?
-        ORDRE_A_EXAMINER
+        ORDRE_EXAMEN_PRIORITAIRE
       else # recensements_analysed_count > 0
         ORDRE_EN_COURS_D_EXAMEN
       end
@@ -196,7 +196,7 @@ class Commune < ApplicationRecord
 
   def shall_receive_email_objets_verts?(date)
     users.any? &&
-      statut_global == Commune::ORDRE_A_EXAMINER &&
+      statut_global == Commune::ORDRE_EXAMEN_PRIORITAIRE &&
       !dossier.a_des_objets_prioritaires? &&
       dossier.replied_automatically_at.nil? &&
       dossier.submitted_at < date - 1.week &&

--- a/app/models/concerns/communes/include_statut_global_concern.rb
+++ b/app/models/concerns/communes/include_statut_global_concern.rb
@@ -16,9 +16,9 @@ module Communes
                 WHEN dossiers.status = 'construction' THEN #{Commune::ORDRE_EN_COURS_DE_RECENSEMENT}
                 WHEN dossiers.status = 'accepted' then #{Commune::ORDRE_EXAMINÉ}
                 WHEN dossiers.status = 'submitted' AND dossiers.replied_automatically_at IS NOT NULL
-                  THEN #{Commune::ORDRE_EXAMEN_OPTIONNEL}
-                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0
                   THEN #{Commune::ORDRE_A_EXAMINER}
+                WHEN dossiers.status = 'submitted' AND recensements_analysed_count = 0
+                  THEN #{Commune::ORDRE_EXAMEN_PRIORITAIRE}
                 WHEN dossiers.status = 'submitted' AND recensements_analysed_count > 0
                   THEN #{Commune::ORDRE_EN_COURS_D_EXAMEN}
                 END), #{Commune::ORDRE_NON_RECENSÉ}) AS statut_global,

--- a/app/views/conservateurs/communes/show.html.haml
+++ b/app/views/conservateurs/communes/show.html.haml
@@ -9,11 +9,11 @@
 
   - elsif @dossier&.can_generate_rapport?
     = render "conservateurs/dossiers/accept_cta", dossier: @dossier
-  - elsif @commune.statut_global == Commune::ORDRE_EXAMEN_OPTIONNEL
+  - elsif @commune.statut_global == Commune::ORDRE_A_EXAMINER
     .fr-mb-4w
       = dsfr_alert type: :success, size: :sm do
-        Il n'y a pas d'objet à revoir, la commune a déjà reçu un email automatique, vous pouvez tout de même modifier ou commenter les recensements pour envoyer votre examen à la commune.
-  - elsif @commune.statut_global == Commune::ORDRE_A_EXAMINER || @commune.statut_global == Commune::ORDRE_EN_COURS_D_EXAMEN
+        La commune n'a pas indiqué de péril ou d'objets disparus, elle a donc reçu un mail automatique. Vous pouvez néanmoins consulter ou modifier les informations remontées par la commune et clore ce dossier.
+  - elsif @commune.statut_global == Commune::ORDRE_EXAMEN_PRIORITAIRE || @commune.statut_global == Commune::ORDRE_EN_COURS_D_EXAMEN
     .fr-mb-4w
       = dsfr_alert type: :info, size: :sm do
         Examinez l’ensemble des objets en péril ou disparus pour envoyer des informations complémentaires à la commune.

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -192,9 +192,9 @@ RSpec.describe Commune, type: :model do
         context "lorsque la commune a reçu une réponse automatique" do
           before { commune.dossier.update(replied_automatically_at: Time.zone.now) }
 
-          it "a un statut global sur le recensement et l'examen à Réponse automatique" do
-            expect(Commune.include_statut_global.first.statut_global).to eq Commune::ORDRE_EXAMEN_OPTIONNEL
-            expect(Commune.first.statut_global).to eq Commune::ORDRE_EXAMEN_OPTIONNEL
+          it "a un statut global sur le recensement et l'examen à À examiner" do
+            expect(Commune.include_statut_global.first.statut_global).to eq Commune::ORDRE_A_EXAMINER
+            expect(Commune.first.statut_global).to eq Commune::ORDRE_A_EXAMINER
           end
 
           it "passe en Examiné si le conservateur décide de faire l'examen tout de même" do
@@ -211,9 +211,9 @@ RSpec.describe Commune, type: :model do
                    etat_sanitaire: Recensement::ETAT_PERIL, dossier: commune.dossier, objet:, conservateur:)
           end
 
-          it "a un statut global sur le recensement et l'examen à À examiner" do
-            expect(Commune.include_statut_global.first.statut_global).to eq Commune::ORDRE_A_EXAMINER
-            expect(Commune.first.statut_global).to eq Commune::ORDRE_A_EXAMINER
+          it "a un statut global sur le recensement et l'examen à Examen prioritaire" do
+            expect(Commune.include_statut_global.first.statut_global).to eq Commune::ORDRE_EXAMEN_PRIORITAIRE
+            expect(Commune.first.statut_global).to eq Commune::ORDRE_EXAMEN_PRIORITAIRE
           end
 
           it "a un statut global sur le recensement et l'examen à En cours d'examen" do


### PR DESCRIPTION
Clarifie la différence entre les dossiers à examiner en priorité et ceux qu'il est bon de consulter mais ne nécessitent pas d'action urgente.
En effet, le texte "Examen optionnel" porte à croire qu'il n'est pas nécessaire d'ouvrir le dossier, pouvant conduire les conservateurs à ignorer des questions ou informations pertinentes envoyées par les communes lors de leur recensement.

Fait suite à la PR #1361.