### PR TITLE
Ajoute un écran d'administration des administrateurs

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminUsersController < BaseController
+    before_action :set_admin_user, only: [:show, :edit, :update, :destroy]
+
+    def index
+      @admin_users = AdminUser.order(:first_name, :last_name)
+    end
+
+    def show; end
+
+    def new
+      @admin_user = AdminUser.new
+    end
+
+    def edit; end
+
+    def create
+      @admin_user = AdminUser.new(admin_user_params)
+      if @admin_user.save
+        redirect_to [:admin, @admin_user], notice: "Administrateur créé !"
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
+    def update
+      if @admin_user.update(admin_user_params)
+        redirect_to [:admin, @admin_user], notice: "Administrateur modifié !"
+      else
+        render :edit, status: :unprocessable_content
+      end
+    end
+
+    def destroy
+      if @admin_user.destroy
+        redirect_to admin_admin_users_path, notice: "Administrateur supprimé !"
+      else
+        render :show, status: :unprocessable_content
+      end
+    end
+
+    private
+
+    def set_admin_user
+      @admin_user = AdminUser.find(params[:id])
+    end
+
+    def admin_user_params
+      authorized_params = [:email, :first_name, :last_name]
+      authorized_params.push(:password) if action_name == "create"
+      params.require(:admin_user).permit(*authorized_params)
+    end
+
+    def active_nav_links = %w[Administration Admins]
+  end
+end

--- a/app/views/admin/admin_users/_form.html.haml
+++ b/app/views/admin/admin_users/_form.html.haml
@@ -1,0 +1,29 @@
+- if admin_user.errors.any?
+  .fr-alert.fr-alert--error.fr-mb-4w
+    %p
+      Erreur(s)
+    %ul
+      - admin_user.errors.full_messages.each do |message|
+        %li= message
+
+= form_for [:admin, admin_user], builder: FormBuilderDsfr do |f|
+  .fr-input-group
+    = f.label :first_name do
+      Prénom (*)
+    = f.text_field :first_name, required: true
+  .fr-input-group
+    = f.label :last_name do
+      Nom de famille (*)
+    = f.text_field :last_name
+  .fr-input-group
+    = f.label :email do
+      Email (*)
+    = f.text_field :email, required: true
+  - if admin_user.new_record?
+    .fr-input-group{ "data-controller": "password-visibility" }
+      = f.label :password, class: "co-flex co-flex--space-between" do
+        Mot de passe (*)
+        %button.fr-btn.fr-btn--tertiary.fr-btn--icon-left.fr-fi-eye-line{ type: :button, data: { action: "password-visibility#toggle", "password-visibility-target": :button } }
+          Afficher
+      = f.password_field :password, "data-password-visibility-target": :input
+  = f.submit "Enregistrer"

--- a/app/views/admin/admin_users/edit.html.haml
+++ b/app/views/admin/admin_users/edit.html.haml
@@ -1,0 +1,8 @@
+- content_for(:head_title) { "Administration - Modifier l'administrateur #{@admin_user}" }
+
+%main#contenu.fr-container.fr-pt-2w.fr-pb-4w
+  = render "shared/breadcrumbs", links: [["Administration", admin_path], ["Administrateurs", admin_admin_users_path]], current_page_label: "Modifier l'administrateur"
+
+  %h1 Modifier l'administrateur
+
+  = render "form", admin_user: @admin_user

--- a/app/views/admin/admin_users/index.html.haml
+++ b/app/views/admin/admin_users/index.html.haml
@@ -1,0 +1,27 @@
+- content_for(:head_title) { "Administration - Administrateurs" }
+
+%main#contenu.fr-container.fr-grid-row.fr-pt-2w.fr-pb-4w
+  .fr-col-md-10
+    = render("shared/breadcrumbs", links: [["Administration", admin_path]], current_page_label: "Administrateurs")
+
+    .co-flex.co-flex--space-between
+      %h1
+        Administrateurs
+      %div= link_to "Ajouter un nouvel administrateur", new_admin_admin_user_path, class: "fr-btn"
+
+    .fr-table
+      %table
+        %thead
+          %tr
+            %th Nom complet
+            %th Email
+            %th Date d'ajout
+
+        %tbody
+          - @admin_users.each do |admin_user|
+            %tr
+              %td.co-min-width-200px= link_to admin_user, [:admin, admin_user]
+              %td.co-min-width-200px= admin_user.email
+              %td.co-min-width-200px
+                = l admin_user.created_at, format: :long
+                = "(il y a #{time_ago_in_words admin_user.created_at})"

--- a/app/views/admin/admin_users/new.html.haml
+++ b/app/views/admin/admin_users/new.html.haml
@@ -1,0 +1,8 @@
+- content_for(:head_title) { "Administration - Nouvel administrateur" }
+
+%main#contenu.fr-container.fr-pt-2w.fr-pb-4w
+  = render "shared/breadcrumbs", links: [["Administration", admin_path], ["Administrateurs", admin_admin_users_path]], current_page_label: "Nouvel administrateur"
+
+  %h1 Créer un nouvel administrateur
+
+  = render "form", admin_user: @admin_user

--- a/app/views/admin/admin_users/show.html.haml
+++ b/app/views/admin/admin_users/show.html.haml
@@ -1,0 +1,24 @@
+- content_for(:head_title) { "Administration - Admins - #{@admin_user}" }
+
+%main#contenu.fr-container.fr-mb-8w
+  = render "shared/breadcrumbs", links: [["Administration", admin_path], ["Admins", admin_admin_users_path]], current_page_label: @admin_user.to_s
+
+  %h1= @admin_user
+
+  %p
+    %strong Date d'ajout :
+    = l @admin_user.created_at, format: :long
+    = "(il y a #{time_ago_in_words @admin_user.created_at})"
+  %p
+    %strong Prénom :
+    = @admin_user.first_name
+  %p
+    %strong Nom de famille :
+    = @admin_user.last_name
+  %p
+    %strong Email :
+    = mail_to @admin_user.email, @admin_user.email, class: "fr-btn fr-btn--sm fr-btn--secondary"
+
+  .fr-btns-group.fr-btns-group--inline-md.fr-btns-group--icon-left
+    = link_to "Modifier", edit_admin_admin_user_path, class: "fr-btn fr-btn--secondary fr-icon-pencil-line"
+    = button_to "Supprimer", admin_admin_user_path, class: "fr-btn fr-btn--tertiary fr-icon-delete-line", method: :delete, data: { turbo_confirm: "Êtes-vous sûr ?" }

--- a/app/views/pages/admin.html.haml
+++ b/app/views/pages/admin.html.haml
@@ -12,6 +12,7 @@
           %li= link_to "Communes", admin_communes_path
           %li= link_to "Conservateurs", admin_conservateurs_path
           %li= link_to "Campagnes", admin_campaigns_path
+          %li= link_to "Administrateurs", admin_admin_users_path
           %li
             = link_to "Fiches et articles de presse (dans le CMS)", "https://collectif-objets-cms.netlify.app/",
               target: "_blank", rel: "noopener"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,7 @@ Rails.application.routes.draw do
     resources :mail_previews, only: [:index] do
       get "/:mailer/:email", on: :collection, action: :show, as: :preview
     end
+    resources :admin_users
   end
 
   # -----

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -40,6 +40,21 @@ feature "Admin", js: true do
     it_behaves_like "an accessible page"
   end
 
+  describe "admin_users" do
+    let(:path) { admin_admin_users_path }
+    it_behaves_like "an accessible page"
+  end
+
+  describe "admin_users/new" do
+    let(:path) { new_admin_admin_user_path }
+    it_behaves_like "an accessible page"
+  end
+
+  describe "admin_users/1" do
+    let(:path) { admin_admin_user_path(admin) }
+    it_behaves_like "an accessible page"
+  end
+
   describe "campaigns" do
     let(:path) { admin_campaigns_path }
     it_behaves_like "an accessible page"

--- a/spec/requests/admin_users_spec.rb
+++ b/spec/requests/admin_users_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::AdminUsersController, type: :request do
+  let(:admin_user) { create(:admin_user) }
+  let(:params) { {} }
+
+  before(:each) { login_as(admin_user, scope: :admin_user) }
+
+  subject(:perform_request) { send(method, path, params:) }
+
+  context "GET admin/admin_users" do
+    let(:method) { :get }
+    let(:path) { admin_admin_users_path }
+
+    it "liste les admins" do
+      perform_request
+      expect(response.body).to match admin_user.to_s
+    end
+  end
+
+  context "GET admin/admin_users/1" do
+    let(:method) { :get }
+    let(:path) { admin_admin_user_path(admin_user) }
+
+    it "affiche l'admin" do
+      perform_request
+      expect(response.body).to match admin_user.to_s
+    end
+  end
+
+  context "POST admin/admin_users" do
+    let(:method) { :post }
+    let(:path) { admin_admin_users_path }
+
+    context "quand les paramètres sont valides" do
+      let(:params) { { admin_user: attributes_for(:admin_user) } }
+      it "crée un nouvel admin" do
+        expect { perform_request }.to change(AdminUser, :count).by(1)
+      end
+    end
+
+    context "quand les paramètres sont invalides" do
+      let(:params) { { admin_user: attributes_for(:admin_user).except(:email) } }
+      it "n'enregistre pas de nouvel admin" do
+        expect { perform_request }.to change(AdminUser, :count).by(0)
+      end
+    end
+  end
+
+  context "PATCH admin/admin_users/1" do
+    let(:method) { :patch }
+    let(:path) { admin_admin_user_path(admin_user) }
+
+    context "quand les paramètres sont valides" do
+      let(:params) { { admin_user: attributes_for(:admin_user).except(:password) } }
+      it "modifie l'admin" do
+        expect do
+          perform_request
+          admin_user.reload
+        end.to change(admin_user, :email).to(params[:admin_user][:email])
+      end
+    end
+
+    context "quand les paramètres sont invalides" do
+      let(:params) { { admin_user: attributes_for(:admin_user).except(:email) } }
+      it "ne modifie pas l'admin" do
+        expect { perform_request }.not_to change(admin_user, :email)
+      end
+    end
+  end
+
+  context "DELETE admin/admin_users/1" do
+    let(:method) { :delete }
+    let(:path) { admin_admin_user_path(admin_user) }
+
+    it "supprime le recensement" do
+      expect { perform_request }.to change(AdminUser, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Puisque l'équipe se réduit, et que des accès n'ont pas été supprimés suite à des départs, ces nouveaux écrans permettent de voir les administrateurs et leur ancienneté, et de révoquer leur accès si besoin.