### PR TITLE
Supprime Loom de la CSP puisque les videos ont été migrées

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -39,8 +39,7 @@ Rails.application.configure do
 
     policy.frame_src :self, # for the PDFs served by the rails server through <embed> cf https://stackoverflow.com/a/69147536
       "https://collectif-objets-metabase.osc-secnum-fr1.scalingo.io/",
-      "https://tube.numerique.gouv.fr/",
-      "https://www.loom.com/" # to remove, once the loom video is transferred to peertube
+      "https://tube.numerique.gouv.fr/"
   end
 
   # Generate session nonces for permitted importmap and inline scripts


### PR DESCRIPTION
Comme indiqué dans le commentaire, autoriser Loom dans la CSP n'était nécessaire que tant que des vidéos étaient hébergées dessus. Ce n'est plus le cas, il faut donc mettre la CSP à jour.