### PR TITLE
Simplifie l'utilisation des campagnes

### DIFF
--- a/app/controllers/conservateurs/campaigns_controller.rb
+++ b/app/controllers/conservateurs/campaigns_controller.rb
@@ -13,6 +13,9 @@ module Conservateurs
 
     def new
       @departement = Departement.find(params[:departement_id])
+      @campaign = Campaign.new(departement: @departement)
+      authorize(@campaign)
+
       defaults = @departement.campaigns.select(:sender_name, :nom_drac, :signature).last&.attributes
       defaults ||= {
         sender_name: current_conservateur.full_name,
@@ -24,8 +27,7 @@ module Conservateurs
           "DRAC #{@departement.region}"
         ].join("\n")
       }
-      @campaign = Campaign.new(defaults.merge(departement: @departement))
-      authorize(@campaign)
+      @campaign.assign_attributes(defaults)
     end
 
     private

--- a/app/controllers/conservateurs/campaigns_controller.rb
+++ b/app/controllers/conservateurs/campaigns_controller.rb
@@ -13,7 +13,17 @@ module Conservateurs
 
     def new
       @departement = Departement.find(params[:departement_id])
-      @previous = @departement.campaigns.select(:sender_name, :nom_drac, :signature).last&.attributes || {}
+      @previous = @departement.campaigns.select(:sender_name, :nom_drac, :signature).last&.attributes
+      @previous ||= {
+        sender_name: current_conservateur.full_name,
+        nom_drac: @departement.region,
+        signature: [
+          current_conservateur.full_name,
+          nil,
+          "conservateur en charge des monuments historiques",
+          "DRAC #{@departement.region}"
+        ].join("\n")
+      }
       @campaign = Campaign.new(@previous.merge(departement: @departement))
       authorize(@campaign)
     end

--- a/app/controllers/conservateurs/campaigns_controller.rb
+++ b/app/controllers/conservateurs/campaigns_controller.rb
@@ -13,8 +13,8 @@ module Conservateurs
 
     def new
       @departement = Departement.find(params[:departement_id])
-      @previous = @departement.campaigns.select(:sender_name, :nom_drac, :signature).last&.attributes
-      @previous ||= {
+      defaults = @departement.campaigns.select(:sender_name, :nom_drac, :signature).last&.attributes
+      defaults ||= {
         sender_name: current_conservateur.full_name,
         nom_drac: @departement.region,
         signature: [
@@ -24,7 +24,7 @@ module Conservateurs
           "DRAC #{@departement.region}"
         ].join("\n")
       }
-      @campaign = Campaign.new(@previous.merge(departement: @departement))
+      @campaign = Campaign.new(defaults.merge(departement: @departement))
       authorize(@campaign)
     end
 

--- a/app/views/shared/campaigns/_show_content.html.haml
+++ b/app/views/shared/campaigns/_show_content.html.haml
@@ -51,7 +51,7 @@
       %li
         = button_to "Modifier la configuration", send("edit_#{r}_campaign_path", campaign), class: "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-pencil-line", method: :get, disabled: !campaign.draft?
       %li
-        = button_to "Prévisualiser les messages", send("#{r}_campaign_mail_previews_path", campaign), method: :get, class: "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-eye-line fr-my-1w fr-mt-md-0", disabled: campaign.communes.empty? || !campaign.draft_or_planned?
+        = button_to "Prévisualiser les messages", send("#{r}_campaign_mail_previews_path", campaign), method: :get, class: "fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-eye-line fr-my-1w fr-mt-md-0", disabled: campaign.communes.empty?
 
   .fr-col-lg-6
     %h2 Dates


### PR DESCRIPTION
- [x] On peut désormais prévisualiser une campagne, peu importe son statut, à partir du moment où il y a un destinataire ou plus.
- [x] Le nom de l'émetteur, la DRAC et la signature sont automatiquement préremplis dès la première campagne, à partir des données disponibles (nom du conservateur et région dont le département fait partie).

Le code a été réorganisé pour améliorer la lisibilité, et s'interrompre plus rapidement si l'utilisateur tente de créer une campagne pour un département auquel il n'a pas accès.