### PR TITLE
Envoie les campagnes avec l'adresse de messagerie

### DIFF
--- a/app/mailers/campaign_v1_mailer.rb
+++ b/app/mailers/campaign_v1_mailer.rb
@@ -5,8 +5,10 @@ class CampaignV1Mailer < ApplicationMailer
   before_action :set_campaign_commune_and_user
   default \
     to: -> { @user.email },
-    from: -> { email_address_with_name(CONTACT_EMAIL, @campaign.sender_name) },
-    reply_to: -> { @commune.support_email(role: :user) }
+    from: -> {
+            email_address_with_name(@commune.support_email(role: :user),
+                                    "#{@campaign.sender_name} via Collectif Objets")
+          }
 
   MAIL_NAMES = (
     %w[lancement] +

--- a/app/views/shared/campaigns/_form.html.haml
+++ b/app/views/shared/campaigns/_form.html.haml
@@ -20,8 +20,8 @@
           = t("activerecord.attributes.campaign.sender_name")
           %span.fr-hint-text
             C'est ce nom qui sera affiché dans les mails reçus par les communes.
-            Les mails seront toujours envoyés avec l'adresse #{CONTACT_EMAIL}.
-            Les réponses par mail arriveront dans la messagerie et vous recevrez des notifications.
+            Les mails seront envoyés de "[nom émetteur] via Collectif Objets", avec l'adresse de la messagerie.
+            Vous serez notifiés à chaque nouveau message de la commune dans la messagerie.
         = f.text_field :sender_name, placeholder: "Jeanne Dupont"
       .fr-input-group
         = f.label :nom_drac do

--- a/spec/mailers/campaign_v1_mailer_spec.rb
+++ b/spec/mailers/campaign_v1_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples "campaign email commons" do
     # it "recipient is users' email" do
     expect(mail.to).to eq(["jean@mairie.fr"])
     # it "sender is collectif objets" do
-    expect(mail.from).to eq([CONTACT_EMAIL])
+    expect(mail.from).to eq([commune.support_email(role: :user)])
   end
 
   describe "contains the campaign signature" do


### PR DESCRIPTION
Quand un mail est transféré, l'en-tête `Reply-To` n'est pas conservé. Dans ce cas, relativement fréquent, les mails des communes arrivent sur la boîte mail générique de la plateforme au lieu de la messagerie des conservateurs associés.

Avec ce changement, ce problème ne devrait plus se produire.