### PR TITLE
Corrige le texte d'alerte sur les communes à rerecenser

### DIFF
--- a/app/components/unfold_component/unfold_component.haml
+++ b/app/components/unfold_component/unfold_component.haml
@@ -2,5 +2,5 @@
   .co-overflow--hidden.co-position-relative{"data-max-height": max_height_px, "data-unfold-component-target": "content"}
     = content
   .co-text--center
-    %button.fr-link.hide.fr-mt-1w{"data-action": "unfold-component#displayAll", "data-unfold-component-target": "button"}
+    %button.fr-link.hide.fr-mt-1w.fr-p-1w{"data-action": "unfold-component#displayAll", "data-unfold-component-target": "button"}
       = button_text

--- a/app/controllers/conservateurs/campaigns_controller.rb
+++ b/app/controllers/conservateurs/campaigns_controller.rb
@@ -7,7 +7,6 @@ module Conservateurs
     # rubocop:disable Rails/LexicallyScopedActionFilter
     # Certaines actions sont définies dans le concern partagés par admins et conservateurs
     before_action :authorize_campaign, except: %i[new create]
-    before_action :set_show_new_selection_message, only: :edit_recipients
     after_action :enqueue_admin_mail, only: %i[update_status]
     # rubocop:enable Rails/LexicallyScopedActionFilter
 
@@ -42,17 +41,5 @@ module Conservateurs
     def after_destroy_path = conservateurs_departement_path @campaign.departement
     def authorize_campaign = authorize @campaign
     def active_nav_links = ["Mes départements", @departement.to_s]
-
-    def set_show_new_selection_message
-      date = Date.new(2024, 6, 10)
-      return if date.before?(1.year.ago)
-
-      # N'afficher que pour les conservateurs ayant créés des campagnes
-      # avant, et pas après le changement
-      departement = @campaign.departement
-      @show_new_selection_message =
-        departement.campaigns.where("created_at < ?", date).exists? &&
-        departement.campaigns.where.not("created_at > ?", date).exists?
-    end
   end
 end

--- a/app/views/shared/campaigns/_edit_recipients_content.html.haml
+++ b/app/views/shared/campaigns/_edit_recipients_content.html.haml
@@ -1,7 +1,3 @@
-- if @show_new_selection_message
-  .fr-alert.fr-alert--info.fr-alert--sm.fr-mb-4w
-    %p.fr-alert__description= t("campaigns.edit_recipients_tooltip")
-
 %p.fr-mb-4w= "Liste des #{campaign.available_communes.load.size} communes abritant des objets <abbr title='Monuments Historiques'>MH</abbr> #{campaign.departement.dans_nom}.".html_safe
 
 = form_for campaign, builder: FormBuilderDsfr, url: send("#{routes_prefix}_campaign_update_recipients_path", campaign), data: { controller: "multichecker" } do |f|
@@ -24,7 +20,7 @@
         .co-columns-auto.co-columns-sm-2.co-columns-lg-3.fr-mx-0.w-100
           - campaign.available_communes.each do |commune|
             - disabled = commune.users_count.zero? || commune.dossier&.construction?
-            - checked = !disabled && (communes_ids.empty? || communes_ids.include?(commune.id))
+            - checked = !disabled && (communes_ids.include?(commune.id) || (communes_ids.empty? && !commune.dossier&.submitted?))
             - input_id = "campaign_commune_#{commune.id}"
             .fr-checkbox-group.fr-checkbox-group--sm.fr-mb-1w.co-break-avoid-column
               %input{type: :checkbox,

--- a/app/views/shared/campaigns/_show_content.html.haml
+++ b/app/views/shared/campaigns/_show_content.html.haml
@@ -82,7 +82,7 @@
   - if (campaign.draft? || campaign.planned?) && campaign.communes_en_cours.load.any?
     = dsfr_alert(type: :warning, title: "Communes en cours d'examen", classes: "fr-mb-2w") do
       %p
-        Attention, vous vous apprêtez à recontacter une ou plusieurs communes dont l’examen n'est pas terminé.
+        Attention, vous vous apprêtez à recontacter #{Commune.human_attribute_name(:count, count: campaign.communes_en_cours.size)} dont l’examen n'est pas terminé.
         %br
         Nous vous invitons à finaliser l'examen avant de relancer une campagne, sans quoi les dossiers non examinés seront perdus.
         %br

--- a/app/views/shared/campaigns/_show_content.html.haml
+++ b/app/views/shared/campaigns/_show_content.html.haml
@@ -82,7 +82,9 @@
   - if (campaign.draft? || campaign.planned?) && campaign.communes_en_cours.load.any?
     = dsfr_alert(type: :warning, title: "Communes en cours d'examen", classes: "fr-mb-2w") do
       %p
-        Attention, vous vous apprêtez à recontacter une ou plusieurs communes dont l’examen n'est pas terminé. Nous vous invitons à finaliser l'examen avant de relancer une campagne, sans quoi les dossiers non examinés seront perdus.
+        Attention, vous vous apprêtez à recontacter une ou plusieurs communes dont l’examen n'est pas terminé.
+        %br
+        Nous vous invitons à finaliser l'examen avant de relancer une campagne, sans quoi les dossiers non examinés seront perdus.
         %br
         Communes à terminer d’examiner&nbsp;:
         = "#{campaign.communes_en_cours.collect { |commune| link_to(commune.nom, conservateurs_commune_dossier_path(commune)) }.to_sentence.html_safe}."

--- a/app/views/shared/campaigns/_show_content.html.haml
+++ b/app/views/shared/campaigns/_show_content.html.haml
@@ -83,10 +83,11 @@
     = dsfr_alert(type: :warning, title: "Communes en cours d'examen", classes: "fr-mb-2w") do
       %p
         Attention, vous vous apprêtez à recontacter #{Commune.human_attribute_name(:count, count: campaign.communes_en_cours.size)} dont l’examen n'est pas terminé.
+        %strong
+          Les données saisies par ces communes seront perdues.
         %br
-        Nous vous invitons à finaliser l'examen avant de relancer une campagne, sans quoi les dossiers non examinés seront perdus.
+        Nous vous invitons à finaliser l'examen des communes suivantes avant de les inclure dans une nouvelle campagne&nbsp;:
         %br
-        Communes à terminer d’examiner&nbsp;:
         = "#{campaign.communes_en_cours.collect { |commune| link_to(commune.nom, conservateurs_commune_dossier_path(commune)) }.to_sentence.html_safe}."
   = render UnfoldComponent.new(max_height_px: 200, button_text: "Afficher toutes les communes…") do
     %ul.co-columns-auto.co-columns-sm-2.co-columns-lg-3.fr-mx-0

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -599,7 +599,6 @@ fr:
       option2: si vous connaissez une personne liée à leur propriétaire qui pourrait les recenser, nous vous invitons à lui transférer ce courriel.
       question: Pour toute question complémentaire, vous avez la possibilité de répondre à ce courriel.
   campaigns:
-    edit_recipients_tooltip: Attention ! Dorénavant, toutes les communes sont sélectionnées par défaut, y compris celles dont le dossier n'a pas encore été examiné.
     mail_names:
       lancement: Mail de lancement
       relance1: Première relance


### PR DESCRIPTION
Le texte d'alerte sur les communes non examinées ajoutées à une nouvelle campagne n'était pas très clair. Il est donc reformulé pour être plus compréhensible, et les communes en cours d'examen ou de recensement sont désormais exclues de la sélection automatique, pour éviter que ce problème ne se produise à l'insu des conservateurs. 
Il leur est toujours possible de rajouter les communes en cours d'examen en cliquant sur "Tout sélectionner" ou en cochant ces communes une par une, auquel cas le texte d'alerte sera affiché.

Le bandeau indiquant que les communes en cours d'examen sont désormais sélectionnées par défaut est retiré puisque ce n'est plus le cas.

J'en ai profité pour agrandir la zone de clic du bouton "Afficher tout…" dans le composant Unfold, pour améliorer l'ergonomie.