### PR TITLE
Envoie le mail objets verts dès le lendemain

### DIFF
--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -203,7 +203,7 @@ class Commune < ApplicationRecord
       statut_global == Commune::ORDRE_EXAMEN_PRIORITAIRE &&
       !dossier.a_des_objets_prioritaires? &&
       dossier.replied_automatically_at.nil? &&
-      dossier.submitted_at < date - 1.week &&
+      dossier.submitted_at.to_date < date - 1.day &&
       !date.on_weekend?
   end
 

--- a/spec/jobs/campaigns/cron_job_spec.rb
+++ b/spec/jobs/campaigns/cron_job_spec.rb
@@ -79,11 +79,11 @@ RSpec.describe Campaigns::CronJob, type: :job do
     end
 
     it "envoie un email aux communes avec uniquement des objets verts \
-        ayant fini leur recensement il y a plus d'une semaine et ayant démarré après le 05/10/2023" do
-      commune_sans_objets_prioritaires.dossier.update(submitted_at: Date.new(2023, 11, 1))
+        ayant fini leur recensement il y a plus d'un jour et ayant démarré après le 05/10/2023" do
+      commune_sans_objets_prioritaires.dossier.update(submitted_at: Date.new(2023, 11, 14))
       commune_sans_objets_prioritaires2.dossier.update(submitted_at: Date.new(2023, 9, 15))
 
-      Campaigns::CronJob.new.perform(Date.new(2023, 11, 13))
+      Campaigns::CronJob.new.perform(Date.new(2023, 11, 16))
       perform_enqueued_jobs
 
       expect(ActionMailer::Base.deliveries.count).to eq(1)

--- a/spec/models/commune_spec.rb
+++ b/spec/models/commune_spec.rb
@@ -110,20 +110,20 @@ RSpec.describe Commune, type: :model do
         commune.update(status: "completed")
       end
 
-      context "mais le dossier a été soumis il y a moins d'une semaine" do
-        let(:date) { Date.new(2023, 11, 10) }
-        before { dossier.update(submitted_at: Date.new(2023, 11, 9)) }
+      context "mais le dossier a été soumis il y a moins d'un jour" do
+        let(:date) { Date.new(2023, 11, 14) }
+        before { dossier.update(submitted_at: Date.new(2023, 11, 13)) }
         it { is_expected.to be_falsey }
       end
 
       context "mais on est le weekend" do
-        let(:date) { Date.new(2023, 11, 13) }
+        let(:date) { Date.new(2023, 11, 12) }
         it { is_expected.to be_falsey }
       end
 
-      context "il y a plus d'une semaine et la date d'envoi est hors weekend" do
-        let(:date) { Date.new(2023, 11, 13) }
-        before { dossier.update(submitted_at: Date.new(2023, 11, 3)) }
+      context "il y a plus d'un jour et la date d'envoi est hors weekend" do
+        let(:date) { Date.new(2023, 11, 15) }
+        before { dossier.update(submitted_at: Date.new(2023, 11, 13)) }
 
         it "returns false si la commune a des objets prioritaires" do
           create(:recensement, :en_peril, dossier:)


### PR DESCRIPTION
Suite au renommage des statuts "Examen optionnel" et "À examiner" en "À examiner" et "À examiner en priorité", les communes non prioritaires sont affichées comme tel 10 jours durant.
Ce changement raccourcit le délai d'envoi du mail "Objets verts" pour qu'il parte le lendemain (ou le lundi suivant si le dossier est soumis le vendredi). De cette manière, les dossiers non prioritaires basculeront plus rapidement au statut "À examiner" afin d'aider les conservateurs à prioriser leurs analyses.