### PR TITLE
Corrige l'erreur "édifice non renseigné" sur l'écran des bordereaux

### DIFF
--- a/app/helpers/objet_helper.rb
+++ b/app/helpers/objet_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 module ObjetHelper
-  def edifice_nom(nom)
-    return nom.upcase_first if nom.present?
-
-    content_tag(:i, "Édifice non renseigné")
-  end
-
   def palissy_url(objet)
     palissy_url_ref objet.palissy_REF
   end

--- a/app/models/edifice.rb
+++ b/app/models/edifice.rb
@@ -48,4 +48,6 @@ class Edifice < ApplicationRecord
   def to_s
     "Édifice #{nom} #{merimee_REF ? "(#{merimee_REF})" : '(sans référence Mérimée)'} - commune #{code_insee}"
   end
+
+  def nom = super || "édifice non renseigné"
 end

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -98,7 +98,7 @@
               %th(colspan="6")
                 %div.co-flex.co-flex--align-items-center.co-flex--gap-1rem
                   %div
-                    %h3.h5 Édifice #{edifice_nom(edifice.nom)}
+                    %h3.h5 Édifice #{edifice.nom.upcase_first}
                   %div= t("objets.count", count: edifice.objets.length)
             - edifice.objets.each do |objet|
               %tr

--- a/app/views/conservateurs/bordereaux/_edifice.html.haml
+++ b/app/views/conservateurs/bordereaux/_edifice.html.haml
@@ -1,9 +1,10 @@
 -# locals: :edifice
 - commune = edifice.commune
+- nom = edifice_nom(edifice.nom)
 
 .d-md-flex.align-content-center.co-flex--gap-1rem.fr-mb-2w{id: "bordereau-#{edifice.id}"}
   %span
-    = "#{edifice.nom.upcase_first} · #{texte_nombre_objets_protégés(edifice)}"
+    = "#{nom} · #{texte_nombre_objets_protégés(edifice)}"
 
   - if edifice.bordereau.present?
     = link_to "Télécharger (PDF de #{number_to_human_size edifice.bordereau.byte_size})",

--- a/app/views/edifices/_edifice.html.haml
+++ b/app/views/edifices/_edifice.html.haml
@@ -1,5 +1,5 @@
 %h2.fr-mt-4w{id: edifice.slug}
-  = edifice_nom(edifice.nom)
+  = edifice.nom.upcase_first
   ·
   = t("objets.count", count: edifice.objets.length)
 

--- a/app/views/edifices/_list.html.haml
+++ b/app/views/edifices/_list.html.haml
@@ -4,5 +4,5 @@
   %ul.fr-mb-8w
     - edifices.each do |edifice|
       %li
-        = link_to "#{edifice_nom(edifice.nom)}".html_safe, "##{edifice.slug}", "data-turbo": false
+        = link_to edifice.nom.upcase_first, "##{edifice.slug}", "data-turbo": false
         · #{t("objets.count", count: edifice.objets.length)}

--- a/app/views/edifices/_title.html.haml
+++ b/app/views/edifices/_title.html.haml
@@ -1,4 +1,4 @@
 %h2.fr-mt-4w{id: edifice.slug}
-  = edifice_nom(edifice.nom)
+  = edifice.nom.upcase_first
   ·
   = t("objets.count", count: edifice.objets.length)


### PR DESCRIPTION
Certains édifices n'ont pas de nom, ce qui provoque une erreur si on essaie de le capitaliser.