### PR TITLE
Modifie l'adresse d'envoi des mails aux communes

### DIFF
--- a/app/mailers/conservateur_mailer.rb
+++ b/app/mailers/conservateur_mailer.rb
@@ -8,10 +8,9 @@ class ConservateurMailer < ApplicationMailer
   def message_received_email
     @message, @conservateur = params.values_at(:message, :conservateur)
     @commune = @message.commune
-    mail \
-      to: @conservateur.email,
-      reply_to: email_address_with_name(@commune.support_email(role: :conservateur), "Collectif Objets Messagerie"),
-      subject: "#{@commune.nom} vous a envoyé un message"
+    mail subject: "#{@commune.nom} vous a envoyé un message",
+         to: email_address_with_name(@conservateur.email, @conservateur.full_name),
+         from: email_address_with_name(@commune.support_email(role: :conservateur), "#{@commune} via Collectif Objets")
   end
 
   def activite_email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,7 +7,8 @@ class UserMailer < ApplicationMailer
   def session_code_email
     @session_code = params[:session_code]
     @user = @session_code.user
-    set_login_url
+    @commune = @user.commune
+    @login_url = new_user_session_code_url(code_insee: @commune&.code_insee)
     mail subject: "Collectif Objets - Code de connexion - envoyé à #{I18n.l(Time.zone.now, format: :time_first)} " \
   end
 
@@ -39,7 +40,6 @@ class UserMailer < ApplicationMailer
     @user = params[:user]
     @commune = params[:commune]
     @cta_url = commune_completion_url(@commune)
-    set_login_url
     mail subject: "Vos recensements d'objets ont été transmis aux conservateurs"
   end
 
@@ -47,7 +47,6 @@ class UserMailer < ApplicationMailer
     @user = params[:user]
     @commune = params[:commune]
     @cta_url = commune_objets_url(@commune)
-    set_login_url
     mail subject: "Plus que 3 mois pour pour finaliser votre recensement"
   end
 
@@ -55,7 +54,6 @@ class UserMailer < ApplicationMailer
     @user = params[:user]
     @commune = params[:commune]
     @cta_url = commune_objets_url(@commune)
-    set_login_url
     mail subject: "Plus qu'un mois pour pour finaliser votre recensement"
   end
 
@@ -70,8 +68,4 @@ class UserMailer < ApplicationMailer
   end
 
   protected
-
-  def set_login_url
-    @login_url = new_user_session_code_url
-  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,7 +2,7 @@
 
 class UserMailer < ApplicationMailer
   helper :messages
-  default to: -> { @user.email }
+  default to: -> { email_address_with_name(@user.email, (@commune || @user.commune)&.nom) }
 
   def session_code_email
     @session_code = params[:session_code]

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,7 +9,7 @@ class UserMailer < ApplicationMailer
     @user = @session_code.user
     @commune = @user.commune
     @login_url = new_user_session_code_url(code_insee: @commune&.code_insee)
-    mail subject: "Collectif Objets - Code de connexion - envoyé à #{I18n.l(Time.zone.now, format: :time_first)} " \
+    mail subject: "Code de connexion Collectif Objets - envoyé à #{I18n.l(Time.zone.now, format: :time_first)} "
   end
 
   def commune_completed_email

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,6 +2,9 @@
 
 class UserMailer < ApplicationMailer
   helper :messages
+
+  before_action :set_commune_and_user, except: [:session_code_email, :dossier_accepted_email, :message_received_email]
+
   default to: -> { email_address_with_name(@user.email, (@commune || @user.commune)&.nom) },
           from: -> { email_address_with_name(@commune.support_email(role: :user), "Messagerie Collectif Objets") }
 
@@ -15,13 +18,11 @@ class UserMailer < ApplicationMailer
   end
 
   def commune_completed_email
-    @user, @commune = params.values_at(:user, :commune)
     @cta_url = commune_completion_url(@commune)
     mail subject: "#{@commune.nom}, merci dʼavoir contribué à Collectif Objets"
   end
 
   def commune_avec_objets_verts_email
-    @user, @commune = params.values_at(:user, :commune)
     mail subject: "Suite à votre participation à la campagne de recensement " \
                   "des objets monuments historique #{@commune.departement.dans_nom}"
   end
@@ -38,22 +39,16 @@ class UserMailer < ApplicationMailer
   end
 
   def dossier_auto_submitted_email
-    @user = params[:user]
-    @commune = params[:commune]
     @cta_url = commune_completion_url(@commune)
     mail subject: "Vos recensements d'objets ont été transmis aux conservateurs"
   end
 
   def relance_dossier_incomplet
-    @user = params[:user]
-    @commune = params[:commune]
     @cta_url = commune_objets_url(@commune)
     mail subject: "Plus que 3 mois pour pour finaliser votre recensement"
   end
 
   def derniere_relance_dossier_incomplet
-    @user = params[:user]
-    @commune = params[:commune]
     @cta_url = commune_objets_url(@commune)
     mail subject: "Plus qu'un mois pour pour finaliser votre recensement"
   end
@@ -68,4 +63,9 @@ class UserMailer < ApplicationMailer
   end
 
   protected
+
+  def set_commune_and_user
+    @user = params[:user]
+    @commune = params[:commune]
+  end
 end

--- a/lib/mailer_previews/conservateur_mailer_preview.rb
+++ b/lib/mailer_previews/conservateur_mailer_preview.rb
@@ -3,7 +3,7 @@
 class ConservateurMailerPreview < ApplicationMailerPreview
   def message_received_email
     message = Message.from_commune.first
-    conservateur = message.author
+    conservateur = Message.from_conservateur.first.author
 
     ConservateurMailer.with(message:, conservateur:).message_received_email
   end

--- a/spec/mailers/conservateur_mailer_spec.rb
+++ b/spec/mailers/conservateur_mailer_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe ConservateurMailer, type: :mailer do
 
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille vous a envoyé un message"
-      expect(mail.to).to eq(["nadia.riza@drac.gouv.fr"])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.to).to eq([conservateur.email])
+      expect(mail.from).to eq([commune.support_email(role: :conservateur)])
     end
   end
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,8 +4,11 @@ require "rails_helper"
 require_relative "shared_examples"
 
 RSpec.describe UserMailer, type: :mailer do
+  let(:commune) { create(:commune, nom: "Marseille") }
+  let(:user) { create(:user, commune:) }
+  let(:commune_support_address) { user.commune.support_email(role: :user) }
+
   describe "session_code_email" do
-    let(:user) { build(:user, email: "jean@user.fr") }
     let(:session_code) { build(:session_code, user:, code: "123456") }
     let(:mail) { UserMailer.with(session_code:).session_code_email }
 
@@ -16,15 +19,13 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "behaves as expected" do
       expect(mail.subject).to include "Code de connexion"
-      expect(mail.to).to eq(["jean@user.fr"])
+      expect(mail.to).to eq([user.email])
       expect(mail.from).to eq([CONTACT_EMAIL])
     end
   end
 
   describe "commune_completed_email" do
-    let(:dossier) { create(:dossier, :submitted) }
-    let(:commune) { create(:commune, nom: "Marseille", dossier:) }
-    let(:user) { create(:user, email: "jean@user.fr", commune:) }
+    let(:dossier) { create(:dossier, :submitted, commune:) }
     let(:mail) { UserMailer.with(user:, commune:).commune_completed_email }
 
     include_examples(
@@ -34,14 +35,12 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "behaves as expected" do
       expect(mail.subject).to include "Marseille, merci dʼavoir contribué à Collectif Objets"
-      expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 
   describe "dossier_accepted" do
-    let(:commune) { create(:commune, nom: "Marseille") }
-    let(:user) { build(:user, email: "jean@user.fr", commune:) }
     let(:conservateur) { build(:conservateur, email: "marc@conservateur.fr") }
     let(:dossier) { build(:dossier, commune:, conservateur:) }
     let(:mail) { UserMailer.with(dossier:).dossier_accepted_email }
@@ -55,14 +54,12 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "behaves as expected" do
       expect(mail.subject).to include "Examen du recensement des objets protégés de Marseille"
-      expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 
   describe "dossier_auto_submitted_email" do
-    let(:commune) { create(:commune, nom: "Marseille") }
-    let(:user) { create(:user, email: "jean@user.fr", commune:) }
     let(:mail) { UserMailer.with(user:, commune:).dossier_auto_submitted_email }
 
     include_examples(
@@ -72,14 +69,12 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "behaves as expected" do
       expect(mail.subject).to include "Vos recensements d'objets ont été transmis aux conservateurs"
-      expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 
   describe "relance_dossier_incomplet" do
-    let(:commune) { create(:commune, nom: "Marseille") }
-    let(:user) { create(:user, email: "jean@user.fr", commune:) }
     let(:mail) { UserMailer.with(user:, commune:).relance_dossier_incomplet }
 
     include_examples(
@@ -90,13 +85,11 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Plus que 3 mois pour pour finaliser votre recensement"
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 
   describe "derniere_relance_dossier_incomplet" do
-    let(:commune) { create(:commune, nom: "Marseille") }
-    let(:user) { create(:user, email: "jean@user.fr", commune:) }
     let(:mail) { UserMailer.with(user:, commune:).derniere_relance_dossier_incomplet }
 
     include_examples(
@@ -107,14 +100,12 @@ RSpec.describe UserMailer, type: :mailer do
     it "behaves as expected" do
       expect(mail.subject).to include "Plus qu'un mois pour pour finaliser votre recensement"
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 
   describe "message_received_email" do
-    let!(:commune) { create(:commune, id: 10, nom: "Marseille") }
-    let(:user) { build(:user, email: "jean@user.fr", commune:) }
-    let(:conservateur) { build(:conservateur, first_name: "Nadia", last_name: "Riza") }
+    let(:conservateur) { build(:conservateur) }
     let(:message) { build(:message, text: "quel est l'objet ?", author: conservateur, created_at: 1.day.ago, commune:) }
     let(:mail) { UserMailer.with(user:, message:).message_received_email }
 
@@ -124,9 +115,9 @@ RSpec.describe UserMailer, type: :mailer do
     )
 
     it "behaves as expected" do
-      expect(mail.subject).to include "Nadia Riza vous a envoyé un message sur Collectif Objets"
-      expect(mail.to).to eq(["jean@user.fr"])
-      expect(mail.from).to eq([CONTACT_EMAIL])
+      expect(mail.subject).to include "#{conservateur.full_name} vous a envoyé un message sur Collectif Objets"
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq([commune_support_address])
     end
   end
 end


### PR DESCRIPTION
- [x] Envoie le maximum de mails avec l'adresse de la messagerie
- [x] Remplace le `reply-to` par un `from`, comme dans #1381.
- [x] Améliore les sujets de mails
- [x] Utilise le nom et l'email du destinataire pour améliorer le score antispam
- [x] Refactorise les mailers et les tests pour clarifier et éviter de la duplication