### PR TITLE
feat: Récupère la configuration email depuis l'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,28 @@ message) qui permettent d'authentifier l'auteur du message :
   `inbound_email_token` secret est `a1b2c3d4h5`.
 - `mairie-30001-conservateur-a1b2c3d4h5@reponse.collectifobjets.org` : réponse du conservateur pour la même commune
 
+Le domaine `reponse.collectifobjets.org` peut être modifié grâce à la variable d'environnement `INBOUND_EMAILS_DOMAIN`.
+
 Voir la partie sur les tunnels plus bas pour itérer en local sur ces webhooks.
+
+## Adresse de contact
+
+L'adresse de contact est affichée dans différentes pages de l'application.
+Pour éviter des redites, elle est stockée dans une constante dans le fichier `config/initializers/contact_email.rb`.
+Pour simplifier le déploiement, elle est récupérée en priorité de l'environnement, dans la clé `ENV["CONTACT_EMAIL"]`, avec une valeur de fallback.
+
+## SMTP
+
+Pour l'envoi des mails, le SMTP est configuré par les variables d'environnement suivantes :
+```
+SMTP_USERNAME
+SMTP_ADDRESS
+SMTP_USERNAME
+SMTP_PASSWORD
+SMTP_PORT
+# Et, indispensable pour pouvoir générer les URLs complètes :
+HOST
+```
 
 ## Accessibilité, Plan du site et Pages démos
 

--- a/app/mailer_views/campaign_v1_mailer/_objet_photo.mjml
+++ b/app/mailer_views/campaign_v1_mailer/_objet_photo.mjml
@@ -1,6 +1,6 @@
 <% return unless objet %>
 <% photo_presenter = objet.palissy_photos_presenters&.first %>
-<mj-image width="300px" alt="" src="<%= photo_presenter&.url || "https://collectif-objets.beta.gouv.fr/image-non-renseignee.jpeg" %>" />
+<mj-image width="300px" alt="" src="<%= photo_presenter&.url || asset_url("/image-non-renseignee.jpeg") %>" />
 <mj-text align="center">
   <%= objet.palissy_TICO %>
   <br />

--- a/app/mailer_views/shared/_footer.mjml
+++ b/app/mailer_views/shared/_footer.mjml
@@ -5,7 +5,7 @@
 </mj-section>
 <mj-section>
   <mj-column width="40%" vertical-align="top">
-    <mj-image align="left" width="100px" alt="Ministère de la Culture" src="https://collectif-objets.beta.gouv.fr/ministere-culture.png"></mj-image>
+    <mj-image align="left" width="100px" alt="Ministère de la Culture" src="<%= asset_url("/ministere-culture.png") %>"></mj-image>
   </mj-column>
   <mj-column width="60%" vertical-align="top">
     <% if local_assigns.key?(:signature) %>

--- a/app/mailer_views/shared/_header.mjml
+++ b/app/mailer_views/shared/_header.mjml
@@ -1,6 +1,6 @@
 <mj-section>
   <mj-column width="25%" vertical-align="middle">
-    <mj-image align="left" width="100px" alt="Ministère de la Culture" src="https://collectif-objets.beta.gouv.fr/ministere-culture.png"></mj-image>
+    <mj-image align="left" width="100px" alt="Ministère de la Culture" src="<%= asset_url("/ministere-culture.png") %>"></mj-image>
   </mj-column>
   <mj-column width="75%" vertical-align="middle">
     <mj-text font-size="20px"><%= local_assigns.fetch(:header_name, t("application_mailer_layout.project_name")) %></mj-text>

--- a/app/views/conservateurs/departements/index.html.haml
+++ b/app/views/conservateurs/departements/index.html.haml
@@ -14,4 +14,4 @@
           %span.fr-text--sm
             = "#{number_with_delimiter departement.objets_count} objets protégés dans #{departement.communes_count} communes"
   .fr-my-4w
-    = link_to t("conservateurs.departements.index.contact"), "mailto:support@collectif-objets.beta.gouv.fr"
+    = link_to t("conservateurs.departements.index.contact"), "mailto:#{CONTACT_EMAIL}"

--- a/app/views/conservateurs/passwords/new.haml
+++ b/app/views/conservateurs/passwords/new.haml
@@ -22,8 +22,8 @@
               Impossible de trouver un compte conservateur ou conservatrice pour l'email #{resource.email}. Êtes-vous sûr·e que c'est l'email que vous utilisez pour votre activité de conservation ?
 
             %p
-              Si vous n'arrivez pas à vous connecter, écrivez nous à
-              = link_to("support@collectif-objets.beta.gouv.fr", "mailto:support@collectif-objets.beta.gouv.fr")
+              Si vous n'arrivez pas à vous connecter, écrivez-nous à
+              = link_to(CONTACT_EMAIL, "mailto:#{CONTACT_EMAIL}")
 
           - else
             %ul

--- a/app/views/conservateurs/sessions/new.html.haml
+++ b/app/views/conservateurs/sessions/new.html.haml
@@ -33,8 +33,7 @@
                 = link_to "Réinitialiser mon mot de passe", new_conservateur_password_path
                 .fr-mt-2w
                   Si votre email n'est pas reconnu, veuillez nous contacter par mail à
-                  = link_to "mailto:support@collectif-objets.beta.gouv.fr" do
-                    support@collectif-objets.beta.gouv.fr
+                  = link_to CONTACT_EMAIL, "mailto:#{CONTACT_EMAIL}"
           %li
             %section.fr-accordion
               %h2.fr-accordion__title

--- a/app/views/devise/mailer/define_password_instructions.mjml
+++ b/app/views/devise/mailer/define_password_instructions.mjml
@@ -8,7 +8,7 @@
   <mj-body>
     <mj-section>
       <mj-column vertical-align="middle">
-        <mj-image width="100px" src="https://collectif-objets.beta.gouv.fr/ministere-culture.png" align="left"></mj-image>
+        <mj-image width="100px" src="<%= asset_url("/ministere-culture.png") %>" align="left"></mj-image>
       </mj-column>
       <mj-column vertical-align="middle">
         <mj-text align="left" font-size="20px">Collectif Objets</mj-text>

--- a/app/views/devise/mailer/reset_password_instructions.mjml
+++ b/app/views/devise/mailer/reset_password_instructions.mjml
@@ -8,7 +8,7 @@
   <mj-body>
     <mj-section>
       <mj-column vertical-align="middle">
-        <mj-image width="100px" src="https://collectif-objets.beta.gouv.fr/ministere-culture.png" align="left"></mj-image>
+        <mj-image width="100px" src="<%= asset_url("/ministere-culture.png") %>" align="left"></mj-image>
       </mj-column>
       <mj-column vertical-align="middle">
         <mj-text align="left" font-size="20px">Collectif Objets</mj-text>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { hsts: { preload: true } }
   config.x.environment_specific_name = ENV["HOST"] =~ /staging/ ? "staging" : "production"
-  config.x.inbound_emails_domain = "reponse.collectifobjets.org"
+  config.x.inbound_emails_domain = ENV.fetch("INBOUND_EMAILS_DOMAIN", "reponse.collectifobjets.org")
 
   if config.x.environment_specific_name == "staging"
     config.action_mailer.show_previews = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 
-Rails.application.default_url_options = { host: ENV["HOST"]&.sub(/https:\/\//, ""), protocol: "https" }
+Rails.application.default_url_options = { host: ENV.fetch("HOST").sub(/https:\/\//, ""), protocol: "https" }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -55,14 +55,14 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: ENV["HOST"] }
+  config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     authentication: :login,
-    address: ENV["SMTP_ADDRESS"],
-    user_name: ENV["SMTP_USERNAME"],
-    password: ENV["SMTP_PASSWORD"],
-    port: ENV["SMTP_PORT"],
+    address: ENV.fetch("SMTP_ADDRESS"),
+    user_name: ENV.fetch("SMTP_USERNAME"),
+    password: ENV.fetch("SMTP_PASSWORD"),
+    port: ENV.fetch("SMTP_PORT"),
     enable_starttls_auto: true,
     return_response: true
   }
@@ -92,7 +92,7 @@ Rails.application.configure do
 
   config.force_ssl = true
   config.ssl_options = { hsts: { preload: true } }
-  config.x.environment_specific_name = ENV["HOST"] =~ /staging/ ? "staging" : "production"
+  config.x.environment_specific_name = ENV.fetch("HOST") =~ /staging/ ? "staging" : "production"
   config.x.inbound_emails_domain = ENV.fetch("INBOUND_EMAILS_DOMAIN", "reponse.collectifobjets.org")
 
   if config.x.environment_specific_name == "staging"

--- a/config/initializers/contact_email.rb
+++ b/config/initializers/contact_email.rb
@@ -1,1 +1,3 @@
-CONTACT_EMAIL="contact@collectif-objets.beta.gouv.fr"
+# frozen_string_literal: true
+
+CONTACT_EMAIL = ENV.fetch("CONTACT_EMAIL", "contact@collectif-objets.beta.gouv.fr")

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'contact@collectif-objets.beta.gouv.fr'
+  config.mailer_sender = CONTACT_EMAIL
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'CustomDeviseMailer'

--- a/public/404.html
+++ b/public/404.html
@@ -81,7 +81,7 @@
       <div class="fr-footer__bottom">
         <ul class="fr-footer__bottom-list">
           <li class="fr-footer__bottom-item">
-            <a class="fr-footer__bottom-link fr-link--icon-left " href="mailto:support@collectif-objets.beta.gouv.fr">
+            <a class="fr-footer__bottom-link fr-link--icon-left " href="mailto:contact@collectif-objets.beta.gouv.fr">
               Contact
             </a>
           </li>

--- a/public/500.html
+++ b/public/500.html
@@ -60,7 +60,7 @@
       </p>
 
       <p>
-        <a href="mailto:support@collectif-objets.beta.gouv.fr" class="fr-btn fr-btn--secondary">
+        <a href="mailto:contact@collectif-objets.beta.gouv.fr" class="fr-btn fr-btn--secondary">
           Contactez-nous
         </a>
       </p>
@@ -85,7 +85,7 @@
       <div class="fr-footer__bottom">
         <ul class="fr-footer__bottom-list">
           <li class="fr-footer__bottom-item">
-            <a class="fr-footer__bottom-link fr-link--icon-left " href="mailto:support@collectif-objets.beta.gouv.fr">
+            <a class="fr-footer__bottom-link fr-link--icon-left " href="mailto:contact@collectif-objets.beta.gouv.fr">
               Contact
             </a>
           </li>


### PR DESCRIPTION
- [x] Récupère l'adresse de contact depuis l'environnement
- [x] Récupère le domaine de réception des emails depuis l'environnement
- [x] Rend les variables d'environnement SMTP obligatoires en production
- [x] Documente l'utilisation des variables d'environnement pour les mails entrant et sortants
- [x] Utilise l'adresse de contact dans les vues conservateurs
- [x] Utilise l'adresse de contact dans les mails de Devise
- [x] Utilise l'hôte courant pour charger les images dans les mails