### PR TITLE
Refactor: improve impersonation and fix N+1

### DIFF
--- a/app/components/communes/objet_card_component.rb
+++ b/app/components/communes/objet_card_component.rb
@@ -49,7 +49,7 @@ module Communes
     end
 
     def readonly?
-      objet.commune && commune&.status == "completed"
+      commune&.status == "completed"
     end
 
     def header_badges

--- a/app/components/impersonate_callout_component.rb
+++ b/app/components/impersonate_callout_component.rb
@@ -3,16 +3,17 @@
 class ImpersonateCalloutComponent < ApplicationComponent
   include ApplicationHelper
 
-  def initialize(mode:, name:, toggle_path:)
+  def initialize(mode:, name:, toggle_path:, stop_path:)
     @mode = mode
     @name = name
     @toggle_path = toggle_path
+    @stop_path = stop_path
     super
   end
 
   private
 
-  attr_reader :mode, :name, :toggle_path
+  attr_reader :mode, :name, :toggle_path, :stop_path
 
   def write?
     mode == :write

--- a/app/components/impersonate_callout_component/impersonate_callout_component.haml
+++ b/app/components/impersonate_callout_component/impersonate_callout_component.haml
@@ -13,5 +13,5 @@
           Mode lecture-seule
         - else
           Mode écriture
-      = link_to admin_communes_path, class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-right fr-icon-logout-box-r-line" do
+      = button_to stop_path, method: :delete, class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-right fr-icon-logout-box-r-line" do
         Arrêter

--- a/app/controllers/admin/communes_controller.rb
+++ b/app/controllers/admin/communes_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class CommunesController < BaseController
     def index
-      @ransack = Commune.include_statut_global.ransack(params[:q])
+      @ransack = Commune.preload(:users).include_statut_global.ransack(params[:q])
       @query_present = params[:q].present?
       @pagy, @communes = pagy(
         @ransack.result, items: 20

--- a/app/controllers/admin/communes_controller.rb
+++ b/app/controllers/admin/communes_controller.rb
@@ -11,8 +11,14 @@ module Admin
     end
 
     def show
-      @commune = Commune.find(params[:id])
-      @messages = Message.where(commune: @commune).order(created_at: :asc)
+      @commune = Commune.includes(
+        edifices: :objets,
+        archived_dossiers: { recensements: { objet: [], photos_attachments: :blob } }
+      ).find(params[:id])
+      @messages = Message
+        .includes(:author, :inbound_email, files_attachments: :blob)
+        .where(commune: @commune)
+        .order(created_at: :asc)
     end
 
     def session_code

--- a/app/controllers/admin/conservateurs_controller.rb
+++ b/app/controllers/admin/conservateurs_controller.rb
@@ -2,8 +2,8 @@
 
 module Admin
   class ConservateursController < BaseController
-    before_action :set_conservateur, only: [:edit, :update, :impersonate]
-    skip_before_action :disconnect_impersonating_conservateur, only: [:toggle_impersonate_mode]
+    before_action :set_conservateur, only: [:edit, :update, :impersonate, :stop_impersonating]
+    skip_before_action :disconnect_impersonating_conservateur, only: [:toggle_impersonate_mode, :stop_impersonating]
 
     def index
       @ransack = Conservateur.order(:last_name).includes(:departements).ransack(params[:q])
@@ -38,6 +38,12 @@ module Admin
     def impersonate
       impersonate_conservateur(@conservateur)
       redirect_to after_sign_in_path_for_conservateur(@conservateur)
+    end
+
+    def stop_impersonating
+      session.delete(:conservateur_impersonate_write)
+      stop_impersonating_conservateur
+      redirect_to admin_conservateurs_path, notice: "Vous n'incarnez plus de conservateur"
     end
 
     def toggle_impersonate_mode

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,12 +2,19 @@
 
 module Admin
   class UsersController < BaseController
-    skip_before_action :disconnect_impersonating_user, only: [:toggle_impersonate_mode]
+    before_action :set_user, only: [:impersonate, :stop_impersonating]
+    skip_before_action :disconnect_impersonating_user, only: [:toggle_impersonate_mode, :stop_impersonating]
 
     def impersonate
-      @user = User.find(params[:id])
       impersonate_user(@user)
       redirect_to commune_objets_path(@user.commune)
+    end
+
+    def stop_impersonating
+      commune = current_user&.commune
+      session.delete(:user_impersonate_write)
+      stop_impersonating_user
+      redirect_to admin_commune_path(commune), notice: "Vous n'incarnez plus d'usager"
     end
 
     def toggle_impersonate_mode
@@ -20,6 +27,10 @@ module Admin
     end
 
     private
+
+    def set_user
+      @user = User.find(params[:id])
+    end
 
     def active_nav_links = %w[Communes]
   end

--- a/app/controllers/conservateurs/communes_controller.rb
+++ b/app/controllers/conservateurs/communes_controller.rb
@@ -23,19 +23,20 @@ module Conservateurs
     def show_analyse_saved
       @objets = @commune
         .objets
-        .includes(:edifice, recensement: %i[photos_attachments photos_blobs])
+        .includes(:edifice, recensement: { photos_attachments: :blob })
         .a_examiner
         .order_by_recensement_priorite
       render "show_analyse_saved"
     end
 
     def set_commune
-      @commune = Commune.find(params[:id])
+      @commune = Commune.includes(:departement).find(params[:id])
       authorize(@commune)
     end
 
     def set_dossier
       @dossier = @commune.dossier
+      @dossier&.recensements&.load
     end
 
     def set_departement

--- a/app/lib/co/communes/objets_list.rb
+++ b/app/lib/co/communes/objets_list.rb
@@ -19,7 +19,7 @@ module Co
         @edifices ||= commune
           .edifices
           .with_objets
-          .includes(objets: { recensement: %i[photos_attachments photos_blobs] })
+          .includes(objets: { recensement: [:dossier, { photos_attachments: :blob }] })
           .ordered_by_nom
       end
 
@@ -27,7 +27,7 @@ module Co
         @objets ||= begin
           objets = scoped_objets
             .where(commune: @commune)
-            .includes(:commune, recensement: %i[photos_attachments photos_blobs])
+            .includes(:commune, recensement: [:dossier, { photos_attachments: :blob }])
           objets = objets.without_completed_recensements if @exclude_recensed
           objets = objets.where.not(id: @exclude_ids) if @exclude_ids.any?
           objets = objets.where(edifice: @edifice) if @edifice.present?

--- a/app/models/conservateur.rb
+++ b/app/models/conservateur.rb
@@ -9,6 +9,11 @@ class Conservateur < ApplicationRecord
 
   scope :send_recap, -> { where(send_recap: true) }
   scope :with_departement, ->(d) { where("departement_codes @> ARRAY[?]::varchar[]", d) }
+  scope :with_dossiers_count, lambda {
+    left_joins(:dossiers)
+      .select("conservateurs.*", "COUNT(dossiers.id) > 0 AS has_dossiers")
+      .group("conservateurs.id")
+  }
 
   attr_accessor :impersonating
 

--- a/app/models/edifice.rb
+++ b/app/models/edifice.rb
@@ -19,9 +19,10 @@ class Edifice < ApplicationRecord
   scope :ordered_by_nom, -> { order(Arel.sql("LOWER(UNACCENT(edifices.nom))")) }
 
   scope :preloaded, lambda {
-    with_objets.ordered_by_nom.includes(
-      objets: [:commune, { recensement: [:photos_attachments, :photos_blobs] }]
-    )
+    joins(:objets)
+      .group("edifices.id")
+      .ordered_by_nom
+      .includes(objets: [:commune, { recensement: [:dossier, { photos_attachments: :blob }] }])
   }
 
   delegate :normalize_nom, to: :class

--- a/app/models/objet.rb
+++ b/app/models/objet.rb
@@ -92,6 +92,17 @@ class Objet < ApplicationRecord
     !recensement.nil? && recensement.completed?
   end
 
+  def self.sort_by_recensement_priorite(objets)
+    objets.sort_by do |objet|
+      recensement = objet.recensement
+      [
+        (recensement&.en_peril? ? 0 : recensement&.absent? ? 1 : 2),
+        (recensement&.analysed_at ? 1 : 0),
+        recensement&.analysed_at || Time.at(0)
+      ]
+    end
+  end
+
   def self.select_best_objet_in_list(objets_arr)
     current_arr = objets_arr
     [

--- a/app/models/recensement.rb
+++ b/app/models/recensement.rb
@@ -159,6 +159,17 @@ class Recensement < ApplicationRecord
     end
   end
 
+  def absent? = localisation == LOCALISATION_ABSENT
+
+  def en_peril?
+    (etat_sanitaire == ETAT_PERIL && analyse_etat_sanitaire.nil?) ||
+      analyse_etat_sanitaire == ETAT_PERIL
+  end
+
+  def prioritaire?
+    absent? || en_peril?
+  end
+
   def nom_commune_localisation_objet
     nouvelle_commune || commune
   end

--- a/app/views/admin/communes/index.html.haml
+++ b/app/views/admin/communes/index.html.haml
@@ -26,6 +26,7 @@
                 %th Objets
                 %th Statut
                 %th Envoi dossier
+                %th
             %tbody
               - @communes.each do |commune|
                 %tr
@@ -35,6 +36,11 @@
                   %td= commune.objets_count
                   %td= commune_statut_global_badge(commune, small: true)
                   %td= l(commune.completed_at.to_date) if commune.completed_at.present?
+                  %td.co-white-space-nowrap
+                    = button_to impersonate_admin_user_path(commune.users.first),
+                    class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-eye-line w-100",
+                    title: "Incarner #{commune.nom}" do
+                      Incarner
         - if @pagy.pages > 1
           = render partial: 'shared/pagy_nav', locals: {pagy: @pagy}
 

--- a/app/views/admin/communes/show.html.haml
+++ b/app/views/admin/communes/show.html.haml
@@ -41,13 +41,15 @@
                 session_code_admin_commune_path,
                 id: dom_id(@commune, :session_code),
                 form_class: "co-width-md-40", class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-refresh-line w-100"
-            = link_to "Incarner la commune",
+            = button_to "Incarner la commune",
               impersonate_admin_user_path(user),
-              class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-warning-line co-width-md-40"
+              form_class: "co-width-md-40",
+              class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-warning-line w-100"
           - @commune.departement.conservateurs.each do |conservateur|
-            = link_to "Incarner #{conservateur.full_name}",
+            = button_to "Incarner #{conservateur.full_name}",
               impersonate_admin_conservateur_path(conservateur),
-              class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-user-star-line co-width-md-40"
+              form_class: "co-width-md-40",
+              class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-user-star-line w-100"
 
     .fr-col-md-4
       %h2.h4 Commentaires admin

--- a/app/views/admin/conservateurs/index.html.haml
+++ b/app/views/admin/conservateurs/index.html.haml
@@ -37,16 +37,16 @@
                     %div
                       = conservateur.full_name
                       .co-word-break-all= link_to conservateur.email, "mailto:#{conservateur.email}", target: "_blank"
-                  %td= conservateur.departements.sorted.map { _1.to_s }.to_sentence
+                  %td= conservateur.departements.sort_by(&:code).map { _1.to_s }.to_sentence
                   %td.co-white-space-nowrap= conservateur.phone_number
                   %td.co-white-space-nowrap
                     %div
-                      = link_to impersonate_admin_conservateur_path(conservateur) do
-                        = icon_span("eye")
+                      = link_to impersonate_admin_conservateur_path(conservateur),
+                      class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-eye-line w-100" do
                         Incarner
                     .fr-mt-1w
-                      = link_to edit_admin_conservateur_path(conservateur) do
-                        = icon_span("pencil")
+                      = link_to edit_admin_conservateur_path(conservateur),
+                        class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-pencil-line w-100" do
                         Modifier
 
         - if @pagy.pages > 1

--- a/app/views/admin/conservateurs/index.html.haml
+++ b/app/views/admin/conservateurs/index.html.haml
@@ -41,7 +41,7 @@
                   %td.co-white-space-nowrap= conservateur.phone_number
                   %td.co-white-space-nowrap
                     %div
-                      = link_to impersonate_admin_conservateur_path(conservateur),
+                      = button_to impersonate_admin_conservateur_path(conservateur),
                       class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-eye-line w-100" do
                         Incarner
                     .fr-mt-1w

--- a/app/views/admin/conservateurs/index.html.haml
+++ b/app/views/admin/conservateurs/index.html.haml
@@ -50,6 +50,13 @@
                         class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-pencil-line w-100",
                         title: "Modifier #{conservateur.full_name}" do
                         Modifier
+                    .fr-mt-1w
+                      = button_to admin_conservateur_path(conservateur), method: :delete,
+                      disabled: conservateur.has_dossiers,
+                      class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-delete-line w-100",
+                      title: "Supprimer #{conservateur.full_name}",
+                      data: { turbo_confirm: "Êtes-vous sûr de vouloir supprimer ce conservateur ?" } do
+                        Supprimer
 
         - if @pagy.pages > 1
           = render partial: 'shared/pagy_nav', locals: {pagy: @pagy}

--- a/app/views/admin/conservateurs/index.html.haml
+++ b/app/views/admin/conservateurs/index.html.haml
@@ -42,11 +42,13 @@
                   %td.co-white-space-nowrap
                     %div
                       = button_to impersonate_admin_conservateur_path(conservateur),
-                      class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-eye-line w-100" do
+                      class: "fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-eye-line w-100",
+                      title: "Incarner #{conservateur.full_name}" do
                         Incarner
                     .fr-mt-1w
                       = link_to edit_admin_conservateur_path(conservateur),
-                        class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-pencil-line w-100" do
+                        class: "fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-pencil-line w-100",
+                        title: "Modifier #{conservateur.full_name}" do
                         Modifier
 
         - if @pagy.pages > 1

--- a/app/views/conservateurs/communes/show.html.haml
+++ b/app/views/conservateurs/communes/show.html.haml
@@ -34,10 +34,12 @@
   - @edifices.each do |edifice|
     = render "edifices/title", edifice:
     = render layout: "shared/grid_layout" do
-      - reordered = @dossier ? edifice.objets.order_by_recensement_priorite : edifice.objets
-      - reordered.each do |objet|
+      - objets_to_display = @dossier ? Objet.sort_by_recensement_priorite(edifice.objets.to_a) : edifice.objets.to_a
+      - objets_to_display.each do |objet|
+        - recensement = objet.recensement
+        - can_analyse = recensement&.completed? && @commune.completed? && @dossier&.submitted? && current_conservateur.departements.include?(@commune.departement)
         .fr-col-md-4
-          = render Conservateurs::ObjetCardComponent.new objet, recensement: objet.recensement, can_analyse: objet.recensement&.completed? && conservateurs_policy(Analyse.new(recensement: objet.recensement)).edit?, commune: @commune
+          = render Conservateurs::ObjetCardComponent.new objet, recensement:, can_analyse:, commune: @commune
 
   - deleted_recensements = @dossier&.recensements&.only_deleted
   - if deleted_recensements&.any?

--- a/app/views/edifices/_list.html.haml
+++ b/app/views/edifices/_list.html.haml
@@ -1,5 +1,5 @@
-- unless edifices.count <= 3 || edifices.count <= 3 && edifices.all? { _1.objets.count <= 6 }
-  %p.fr-h4 Liste des #{edifices.count} édifices
+- unless edifices.length <= 3 || edifices.length <= 3 && edifices.all? { _1.objets.length <= 6 }
+  %p.fr-h4 Liste des #{edifices.length} édifices
 
   %ul.fr-mb-8w
     - edifices.each do |edifice|

--- a/app/views/shared/_banners.html.haml
+++ b/app/views/shared/_banners.html.haml
@@ -13,12 +13,14 @@
         - if banners.include?(:conservateur_impersonate)
           = render ImpersonateCalloutComponent.new name: "le conservateur #{current_conservateur}",
             mode: session[:conservateur_impersonate_write].present? ? :write : :read,
-            toggle_path: toggle_impersonate_mode_admin_conservateurs_path
+            toggle_path: toggle_impersonate_mode_admin_conservateurs_path,
+            stop_path: stop_impersonating_admin_conservateur_path(current_conservateur)
 
         - if banners.include?(:user_impersonate)
           = render ImpersonateCalloutComponent.new name: "l'usager #{current_user} de la commune #{current_user.commune}",
             mode: session[:user_impersonate_write].present? ? :write : :read,
-            toggle_path: toggle_impersonate_mode_admin_users_path
+            toggle_path: toggle_impersonate_mode_admin_users_path,
+            stop_path: stop_impersonating_admin_user_path(current_user)
 
       .co-text--right
         %button{type: :button,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,7 +145,7 @@ Rails.application.routes.draw do
     resources :communes, only: %i[index show] do
       post :session_code, on: :member
     end
-    resources :conservateurs, except: [:destroy] do
+    resources :conservateurs do
       post :impersonate, on: :member
       delete :stop_impersonating, on: :member
       post :toggle_impersonate_mode, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,12 +146,14 @@ Rails.application.routes.draw do
       post :session_code, on: :member
     end
     resources :conservateurs, except: [:destroy] do
-      get :impersonate, on: :member
+      post :impersonate, on: :member
+      delete :stop_impersonating, on: :member
       post :toggle_impersonate_mode, on: :collection
     end
     resources :dossiers, only: [:show]
     resources :users, only: %i[] do
-      get :impersonate, on: :member
+      post :impersonate, on: :member
+      delete :stop_impersonating, on: :member
       post :toggle_impersonate_mode, on: :collection
     end
     get "/session_codes(/:offset)", to: "session_codes#index", as: :session_codes


### PR DESCRIPTION
- Replace GET impersonate requests with POST
- Replace GET stop_impersonate with DELETE
- Add button to impersonate a commune from admin/communes
- Add button styles to action links in admin/conservateurs
- Add a button to remove conservateurs without associated dossiers
- Fix N+1 on admin/conservateurs
- Fix N+1 on communes/objets
- Fix N+1 on conservateurs/communes/:id